### PR TITLE
feat: use built-in OAuth app as default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,10 +6,10 @@
   "keywords": ["yandex", "direct", "advertising", "oauth"],
   "userConfig": {
     "client_id": {
-      "description": "Client ID приложения Яндекс OAuth"
+      "description": "Client ID приложения Яндекс OAuth (по умолчанию используется встроенное приложение)"
     },
     "client_secret": {
-      "description": "Client Secret приложения Яндекс OAuth",
+      "description": "Client Secret приложения Яндекс OAuth (по умолчанию используется встроенное приложение)",
       "sensitive": true
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,10 @@ cd docs && make html
 
 MCP server reads these at runtime:
 - `CLAUDE_PLUGIN_DATA` — directory for `tokens.json` storage (default: plugin data dir)
-- `CLAUDE_PLUGIN_OPTION_client_id` — Yandex OAuth app client ID
-- `CLAUDE_PLUGIN_OPTION_client_secret` — Yandex OAuth app client secret
+- `CLAUDE_PLUGIN_OPTION_client_id` — Yandex OAuth app client ID (optional, built-in app used by default)
+- `CLAUDE_PLUGIN_OPTION_client_secret` — Yandex OAuth app client secret (optional, built-in app used by default)
+
+The plugin ships with a built-in OAuth application — most users don't need to configure anything. To use your own Yandex OAuth app: create one at https://oauth.yandex.ru/, set `client_id` and `client_secret` in plugin settings.
 
 Integration tests: copy `.env.test.example` → `.env.test` and fill `YANDEX_OAUTH_TOKEN`, `YANDEX_CLIENT_ID`, `YANDEX_CLIENT_SECRET`, `YANDEX_LOGIN`.
 

--- a/server/auth/oauth.py
+++ b/server/auth/oauth.py
@@ -42,8 +42,12 @@ class OAuthManager:
 
     def __init__(self, storage: FileTokenStorage | None = None) -> None:
         self._storage = storage or FileTokenStorage()
-        self._client_id = os.environ.get("CLAUDE_PLUGIN_OPTION_client_id", "")
-        self._client_secret = os.environ.get("CLAUDE_PLUGIN_OPTION_client_secret", "")
+        self._client_id = os.environ.get(
+            "CLAUDE_PLUGIN_OPTION_client_id", "dcf15d9625f6471d94d6d054d52017ba"
+        )
+        self._client_secret = os.environ.get(
+            "CLAUDE_PLUGIN_OPTION_client_secret", "c168aacc471f47a09222a4c4affc10d5"
+        )
 
     @property
     def authorize_url(self) -> str:


### PR DESCRIPTION
## Summary
- Plugin now ships with a built-in Yandex OAuth app — users don't need to create their own
- `client_id` and `client_secret` can still be overridden via plugin settings for advanced users
- Updated `plugin.json` descriptions and `CLAUDE.md` docs to reflect the change

## Test plan
- [x] All 61 existing tests pass (`python3 -m pytest`)
- [ ] Manual: install plugin without configuring OAuth — auth_setup should work with built-in app
- [ ] Manual: set custom `client_id`/`client_secret` in plugin settings — should override defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)