### PR TITLE
fix: PKCE verifier rotation and test isolation

### DIFF
--- a/server/auth/oauth.py
+++ b/server/auth/oauth.py
@@ -91,7 +91,7 @@ class OAuthManager:
             "client_id": self._client_id,
         }
         if self._use_pkce:
-            verifier = generate_code_verifier()
+            verifier = self._load_verifier() or generate_code_verifier()
             self._save_verifier(verifier)
             params["code_challenge"] = generate_code_challenge(verifier)
             params["code_challenge_method"] = "S256"
@@ -118,8 +118,12 @@ class OAuthManager:
         }
         if self._use_pkce:
             verifier = self._load_verifier()
-            if verifier:
-                data["code_verifier"] = verifier
+            if not verifier:
+                raise OAuthError(
+                    "invalid_request",
+                    "PKCE code_verifier отсутствует. Сначала получите ссылку через authorize_url.",
+                )
+            data["code_verifier"] = verifier
         else:
             data["client_secret"] = self._client_secret
         resp = self._token_request(data)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -162,6 +162,7 @@ class TestOAuthManager:
             },
         )
         manager = OAuthManager(storage=self._storage(tmp_path))
+        _ = manager.authorize_url  # generate PKCE verifier
 
         with pytest.raises(OAuthError) as exc_info:
             manager.exchange_code("bad-code")
@@ -375,8 +376,8 @@ class TestPKCE:
         expected = urlsafe_b64encode(expected_digest).rstrip(b"=").decode("ascii")
         assert generate_code_challenge(verifier) == expected
 
-    def test_authorize_url_contains_pkce_params(self) -> None:
-        storage = FileTokenStorage(path=Path("/tmp/test-pkce-tokens.json"))
+    def test_authorize_url_contains_pkce_params(self, tmp_path: Path) -> None:
+        storage = FileTokenStorage(path=tmp_path / "tokens.json")
         manager = OAuthManager(storage=storage)
         url = manager.authorize_url
         parsed = urlparse(url)
@@ -387,7 +388,7 @@ class TestPKCE:
         assert params["response_type"] == ["code"]
 
     @patch("server.auth.oauth.httpx.post")
-    def test_exchange_sends_verifier_not_secret(self, mock_post) -> None:
+    def test_exchange_sends_verifier_not_secret(self, mock_post, tmp_path: Path) -> None:
         mock_post.return_value = _make_httpx_response(
             200,
             {
@@ -396,7 +397,7 @@ class TestPKCE:
                 "expires_in": 3600,
             },
         )
-        storage = FileTokenStorage(path=Path("/tmp/test-pkce-tokens.json"))
+        storage = FileTokenStorage(path=tmp_path / "tokens.json")
         manager = OAuthManager(storage=storage)
         _ = manager.authorize_url  # generates code_verifier
         manager.exchange_code("1234567")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -146,7 +146,9 @@ class TestOAuthManager:
         assert result["expires_at"] > time.time()
 
         # Verify PKCE: code_verifier sent, client_secret NOT sent
-        call_data = mock_post.call_args[1].get("data", mock_post.call_args[0][1] if len(mock_post.call_args[0]) > 1 else {})
+        call_data = mock_post.call_args[1].get(
+            "data", mock_post.call_args[0][1] if len(mock_post.call_args[0]) > 1 else {}
+        )
         assert "code_verifier" in call_data
         assert "client_secret" not in call_data
 
@@ -388,7 +390,9 @@ class TestPKCE:
         assert params["response_type"] == ["code"]
 
     @patch("server.auth.oauth.httpx.post")
-    def test_exchange_sends_verifier_not_secret(self, mock_post, tmp_path: Path) -> None:
+    def test_exchange_sends_verifier_not_secret(
+        self, mock_post, tmp_path: Path
+    ) -> None:
         mock_post.return_value = _make_httpx_response(
             200,
             {
@@ -417,9 +421,12 @@ class TestPKCE:
         assert loaded["access_token"] == "y0_direct_token_value"
 
     @patch("server.auth.oauth.httpx.post")
-    def test_exchange_with_client_secret_no_pkce(self, mock_post, tmp_path: Path) -> None:
+    def test_exchange_with_client_secret_no_pkce(
+        self, mock_post, tmp_path: Path
+    ) -> None:
         mock_post.return_value = _make_httpx_response(
-            200, {"access_token": "tok", "expires_in": 3600},
+            200,
+            {"access_token": "tok", "expires_in": 3600},
         )
         storage = FileTokenStorage(path=tmp_path / "tokens.json")
         manager = OAuthManager(storage=storage)
@@ -436,7 +443,9 @@ class TestPKCE:
         manager._static_token = "y0_from_env"
         assert manager.get_valid_token() == "y0_from_env"
 
-    def test_yandex_direct_token_env_priority(self, tmp_path: Path, monkeypatch) -> None:
+    def test_yandex_direct_token_env_priority(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "y0_from_env_var")
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_token", "y0_from_plugin")
         storage = FileTokenStorage(path=tmp_path / "tokens.json")


### PR DESCRIPTION
Closes #32

## Summary
- Fix PKCE verifier rotation: `authorize_url` now reuses stored verifier instead of generating a new one on every access (prevented silent auth breakage in error paths)
- Fail fast when `code_verifier` is missing in PKCE mode instead of silently sending request without it
- Replace hardcoded `/tmp` paths in tests with `tmp_path` fixture for test isolation
- Format `test_auth.py` to pass `ruff format --check`

## Test plan
- [x] `pytest -v` — 72 passed
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — 32 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)