### PR TITLE
test: expand live coverage and fix reports integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Core code lives in `server/`. Use `server/main.py` as the MCP entrypoint, `server/tools/` for tool handlers (`campaigns.py`, `ads.py`, `keywords.py`, `reports.py`), `server/auth/` for OAuth/PKCE and token storage, and `server/cli/` for `direct-cli` execution. Tests live in `tests/`, with cassette fixtures under `tests/recordings/` and shared setup in `tests/conftest.py` and `tests/cli_recorder.py`. Documentation is in `docs/`, and skill definitions are in `skills/`.
+
+## Build, Test, and Development Commands
+Install dev dependencies with `pip install -e '.[dev]'`. Run the server locally with `python -m server.main`. Use `pytest` for the default cassette-replay suite, `pytest --record` to refresh cassettes from the live CLI, `pytest -m mocks` for subprocess edge cases, and `pytest -m integration` for live-token checks. Run `ruff check .`, `ruff format .`, and `mypy .` before opening a PR. For docs, use `make -C docs html`.
+
+## Coding Style & Naming Conventions
+Target Python 3.11+, 4-space indentation, and type annotations on public functions. Follow the current module naming style: lowercase snake_case files, descriptive test names like `test_auth.py`, and tool functions grouped by Yandex.Direct resource. Keep transport and auth concerns separated from tool logic. Use `ruff` for linting/formatting and `mypy` for type checks; prefer fixing root causes over adding ignores.
+
+## Testing Guidelines
+The default test flow replays JSON cassettes instead of calling the API. Record only when behavior changes: `pytest --record`. After recording, sanitize sensitive values with `python -m tests.sanitize`; audit recordings with `python -m tests.audit`. Mark pure mock tests with `@pytest.mark.mocks` and live-token tests with `@pytest.mark.integration`. Do not commit raw tokens, secrets, or unsanitized cassette output.
+
+## Commit & Pull Request Guidelines
+Recent history follows Conventional Commit style, for example `fix: ...`, `refactor(auth): ...`, and issue-linked subjects such as `(#40)`. Keep commits focused and imperative. PRs should describe user-visible behavior, note auth or cassette changes, link the issue when applicable, and include command results for `pytest`, `ruff`, and `mypy`. Add screenshots only when updating docs or plugin UX text that benefits from visual context.
+
+## Security & Configuration Tips
+Keep local secrets in `.env` or generated test files such as `.env.test`, and never commit them. OAuth tokens are stored under `CLAUDE_PLUGIN_DATA`; tests already isolate this path via `tmp_path`, so preserve that pattern in new tests.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ mcp__yandex_direct__keywords_update(id="99999", bid="15000000")
 
 # Статистика
 mcp__yandex_direct__reports_get(date_from="2026-03-30", date_to="2026-04-06")
-# → [{"CampaignId": 12345, "Impressions": 15420, "Clicks": 312, "Cost": 4680.50}, ...]
+# → [{"CampaignName": "Ретаргет ДРР 18.10", "Impressions": 15420, "Clicks": 312,
+#     "Cost": 4680.50, "Conversions": 70, "CostPerConversion": 68.51,
+#     "ConversionRate": 22.44}, ...]
 
 # Статус OAuth-токена
 mcp__yandex_direct__auth_status()
@@ -307,7 +309,7 @@ pytest
 | 14 | Ключевые слова | `keywords_list(campaign_ids="12345")` | Массив ключевых слов |
 | 15 | Изменить ставку | `keywords_update(id=..., bid=...)` | `{"success": True}` |
 | **Reports** |
-| 16 | Статистика за период | `reports_get(date_from=..., date_to=...)` | Массив с Impressions, Clicks, Cost |
+| 16 | Статистика за период | `reports_get(date_from=..., date_to=...)` | Массив с CampaignName, Impressions, Clicks, Cost, Conversions |
 | **Edge cases** |
 | 17 | direct-cli не в PATH | Запрос без установленного CLI | `{"error": "cli_not_found"}` |
 | 18 | Пустой ответ API | Кампания без объявлений | `[]` (пустой массив, не ошибка) |
@@ -328,6 +330,29 @@ tests/
 ├── audit_cassettes.py       # Аудит кассет перед коммитом
 ├── conftest.py              # pytest fixtures, cli_recorder setup
 ├── fixtures/
+
+### Live test suites
+
+Live tests are split into read-only and mutating suites and are **disabled by default**.
+
+```bash
+# Read-only checks against the real API
+pytest -m live_safe --run-live-safe
+
+# Mutating checks with mandatory rollback
+pytest -m live_unsafe --run-live-unsafe
+```
+
+`live_unsafe` requires dedicated test data in env vars:
+
+```bash
+TEST_OFF_CAMPAIGN_ID=123456
+TEST_KEYWORD_CAMPAIGN_ID=123456
+TEST_KEYWORD_ID=987654
+TEST_KEYWORD_BID_TEMP=15000000
+```
+
+Do not point these at production entities. Unsafe tests assume the campaign starts in `OFF`, change it to `ON`, and then restore it. Keyword tests temporarily change the bid and then restore the original value.
 │   ├── campaigns.json       # Мок-данные кампаний
 │   ├── ads.json             # Мок-данные объявлений
 │   └── tokens.json          # Мок-токены

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,6 @@ include = ["server*"]
 markers = [
     "mocks: tests using unittest.mock instead of cassettes",
     "integration: tests requiring live OAuth token",
+    "live_safe: read-only live tests against the real Yandex.Direct API",
+    "live_unsafe: mutating live tests with mandatory rollback",
 ]

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -8,8 +8,7 @@ from server.tools import get_runner, handle_cli_errors
 DEFAULT_REPORT_TYPE = "CAMPAIGN_PERFORMANCE_REPORT"
 DEFAULT_REPORT_NAME = "mcp_campaign_performance"
 DEFAULT_REPORT_FIELDS = (
-    "CampaignName,Impressions,Clicks,Cost,Conversions,"
-    "CostPerConversion,ConversionRate"
+    "CampaignName,Impressions,Clicks,Cost,Conversions,CostPerConversion,ConversionRate"
 )
 DEFAULT_WINDOW_DAYS = 8
 

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -1,7 +1,38 @@
 """MCP tool for campaign statistics reports."""
 
+from datetime import date, timedelta
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+
+DEFAULT_REPORT_TYPE = "CAMPAIGN_PERFORMANCE_REPORT"
+DEFAULT_REPORT_NAME = "mcp_campaign_performance"
+DEFAULT_REPORT_FIELDS = (
+    "CampaignName,Impressions,Clicks,Cost,Conversions,"
+    "CostPerConversion,ConversionRate"
+)
+DEFAULT_WINDOW_DAYS = 8
+
+
+def _resolve_report_dates(
+    date_from: str | None, date_to: str | None
+) -> tuple[str, str]:
+    """Resolve the reporting window to match Direct's default day range."""
+    if date_from and date_to:
+        return date_from, date_to
+
+    if date_to:
+        resolved_to = date.fromisoformat(date_to)
+        resolved_from = resolved_to - timedelta(days=DEFAULT_WINDOW_DAYS)
+        return resolved_from.isoformat(), date_to
+
+    if date_from:
+        resolved_from = date.fromisoformat(date_from)
+        resolved_to = resolved_from + timedelta(days=DEFAULT_WINDOW_DAYS)
+        return date_from, resolved_to.isoformat()
+
+    today = date.today()
+    return (today - timedelta(days=DEFAULT_WINDOW_DAYS)).isoformat(), today.isoformat()
 
 
 @mcp.tool()
@@ -9,16 +40,28 @@ from server.tools import get_runner, handle_cli_errors
 def reports_get(
     date_from: str | None = None, date_to: str | None = None
 ) -> list[dict] | dict:
-    """Get campaign statistics for a date range.
+    """Get campaign statistics with aggregated goal completions.
 
     Args:
-        date_from: Start date (YYYY-MM-DD). Defaults to 7 days ago.
+        date_from: Start date (YYYY-MM-DD). Defaults to today - 8 days.
         date_to: End date (YYYY-MM-DD). Defaults to today.
     """
     runner = get_runner()
-    args = ["reports", "get", "--format", "json"]
-    if date_from:
-        args.extend(["--date-from", date_from])
-    if date_to:
-        args.extend(["--date-to", date_to])
+    resolved_from, resolved_to = _resolve_report_dates(date_from, date_to)
+    args = [
+        "reports",
+        "get",
+        "--type",
+        DEFAULT_REPORT_TYPE,
+        "--from",
+        resolved_from,
+        "--to",
+        resolved_to,
+        "--name",
+        DEFAULT_REPORT_NAME,
+        "--fields",
+        DEFAULT_REPORT_FIELDS,
+        "--format",
+        "json",
+    ]
     return runner.run_json(args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ import pytest
 from tests.cli_recorder import CassetteNotFoundError, CliRecorder
 
 RECORDINGS_DIR = Path(__file__).parent / "recordings"
+LIVE_MARKERS = {"integration", "live_safe", "live_unsafe"}
+
+
+def _is_live_test(node) -> bool:
+    return any(node.get_closest_marker(marker) for marker in LIVE_MARKERS)
 
 
 def pytest_addoption(parser):
@@ -13,11 +18,42 @@ def pytest_addoption(parser):
     parser.addoption(
         "--record", action="store_true", help="Record cassettes from live CLI"
     )
+    parser.addoption(
+        "--run-live-safe",
+        action="store_true",
+        help="Run read-only live tests against the real Yandex.Direct API",
+    )
+    parser.addoption(
+        "--run-live-unsafe",
+        action="store_true",
+        help="Run mutating live tests with mandatory rollback against the real API",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip live suites unless explicitly enabled."""
+    run_live_safe = config.getoption("--run-live-safe")
+    run_live_unsafe = config.getoption("--run-live-unsafe")
+
+    skip_live_safe = pytest.mark.skip(
+        reason="live_safe tests require --run-live-safe"
+    )
+    skip_live_unsafe = pytest.mark.skip(
+        reason="live_unsafe tests require --run-live-unsafe"
+    )
+
+    for item in items:
+        if item.get_closest_marker("live_unsafe") and not run_live_unsafe:
+            item.add_marker(skip_live_unsafe)
+        elif item.get_closest_marker("live_safe") and not run_live_safe:
+            item.add_marker(skip_live_safe)
 
 
 @pytest.fixture(autouse=True)
-def isolate_env(monkeypatch, tmp_path):
+def isolate_env(monkeypatch, tmp_path, request):
     """Ensure tests don't affect real environment."""
+    if _is_live_test(request.node):
+        return
     monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
 
 
@@ -49,3 +85,68 @@ def cli_recorder(monkeypatch, request):
 
         with patch("subprocess.run", side_effect=_patched_run):
             yield recorder
+
+
+def _discover_live_plugin_data_dir() -> Path | None:
+    import os
+
+    env_value = os.environ.get("CLAUDE_PLUGIN_DATA")
+    if env_value:
+        env_dir = Path(env_value).expanduser()
+        if (env_dir / "tokens.json").exists():
+            return env_dir
+
+    for candidate in (
+        Path.home() / ".claude" / "plugins" / "data" / "yandex-direct-inline",
+        Path.home() / ".claude" / "plugins" / "data" / "yandex-direct",
+    ):
+        if (candidate / "tokens.json").exists():
+            return candidate
+
+    return None
+
+
+@pytest.fixture()
+def live_plugin_data_dir(monkeypatch, request) -> Path:
+    """Resolve a real plugin data directory for live API tests."""
+    if not _is_live_test(request.node):
+        pytest.skip("live_plugin_data_dir is only for live-marked tests")
+
+    if request.node.get_closest_marker("live_unsafe") and not request.config.getoption(
+        "--run-live-unsafe"
+    ):
+        pytest.skip("live_unsafe tests require --run-live-unsafe")
+
+    if request.node.get_closest_marker("live_safe") and not request.config.getoption(
+        "--run-live-safe"
+    ):
+        pytest.skip("live_safe tests require --run-live-safe")
+
+    plugin_data_dir = _discover_live_plugin_data_dir()
+    if plugin_data_dir is None:
+        pytest.skip(
+            "No live token storage found. Set CLAUDE_PLUGIN_DATA or install the plugin locally."
+        )
+
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data_dir))
+    return plugin_data_dir
+
+
+@pytest.fixture()
+def live_oauth_manager(monkeypatch, live_plugin_data_dir):
+    """Provide a real OAuth manager bound to live token storage."""
+    from server.auth.oauth import OAuthManager
+    import server.tools.auth_tools as auth_tools
+
+    manager = OAuthManager()
+    monkeypatch.setattr(auth_tools, "_oauth", manager)
+    return manager
+
+
+@pytest.fixture()
+def live_token_getter(live_oauth_manager):
+    """Configure the global token getter for live MCP tool tests."""
+    import server.tools
+
+    server.tools.set_token_getter(live_oauth_manager.get_valid_token)
+    return live_oauth_manager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,7 @@ def pytest_collection_modifyitems(config, items):
     run_live_safe = config.getoption("--run-live-safe")
     run_live_unsafe = config.getoption("--run-live-unsafe")
 
-    skip_live_safe = pytest.mark.skip(
-        reason="live_safe tests require --run-live-safe"
-    )
+    skip_live_safe = pytest.mark.skip(reason="live_safe tests require --run-live-safe")
     skip_live_unsafe = pytest.mark.skip(
         reason="live_unsafe tests require --run-live-unsafe"
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -489,7 +489,9 @@ class TestAuthTools:
     @patch("server.tools.auth_tools._oauth")
     def test_auth_login_pkce_flow(self, mock_oauth, mock_exchange) -> None:
         mock_oauth.get_status.return_value = {"valid": False}
-        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+        mock_oauth.start_auth_flow.return_value = (
+            "https://oauth.yandex.ru/authorize?x=1"
+        )
         mock_exchange.return_value = {"success": True, "method": "oauth_code"}
 
         mock_ctx = MagicMock()
@@ -511,7 +513,9 @@ class TestAuthTools:
     @patch("server.tools.auth_tools._oauth")
     def test_auth_login_pkce_code_cancelled(self, mock_oauth) -> None:
         mock_oauth.get_status.return_value = {"valid": False}
-        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+        mock_oauth.start_auth_flow.return_value = (
+            "https://oauth.yandex.ru/authorize?x=1"
+        )
 
         mock_ctx = MagicMock()
         method_choice = MagicMock()
@@ -529,7 +533,9 @@ class TestAuthTools:
 
     @patch("server.tools.auth_tools._oauth")
     def test_oauth_login_prompt_embeds_authorize_url(self, mock_oauth) -> None:
-        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+        mock_oauth.start_auth_flow.return_value = (
+            "https://oauth.yandex.ru/authorize?x=1"
+        )
 
         from server.tools.auth_tools import oauth_login_prompt
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for token storage, OAuth manager (PKCE), and auth MCP tools."""
 
+import asyncio
 import hashlib
 import json
 import time
@@ -404,8 +405,6 @@ class TestAuthTools:
 
     @patch("server.tools.auth_tools._oauth")
     def test_auth_login_invalid_method(self, mock_oauth) -> None:
-        import asyncio
-
         mock_oauth.get_status.return_value = {"valid": False}
 
         mock_ctx = MagicMock()
@@ -416,13 +415,11 @@ class TestAuthTools:
 
         from server.tools.auth_tools import auth_login
 
-        result = asyncio.get_event_loop().run_until_complete(auth_login(mock_ctx))
+        result = asyncio.run(auth_login(mock_ctx))
         assert result["error"] == "invalid_method"
 
     @patch("server.tools.auth_tools._oauth")
     def test_auth_login_already_authenticated(self, mock_oauth) -> None:
-        import asyncio
-
         mock_oauth.get_status.return_value = {
             "valid": True,
             "expires_in": 3600,
@@ -430,8 +427,116 @@ class TestAuthTools:
 
         from server.tools.auth_tools import auth_login
 
-        result = asyncio.get_event_loop().run_until_complete(auth_login(MagicMock()))
+        result = asyncio.run(auth_login(MagicMock()))
         assert result.get("already_authenticated") is True
+
+    @patch("server.tools.auth_tools._oauth")
+    def test_auth_login_cancelled_on_method_choice(self, mock_oauth) -> None:
+        mock_oauth.get_status.return_value = {"valid": False}
+
+        mock_ctx = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.action = "decline"
+        mock_choice.data = None
+        mock_ctx.elicit = AsyncMock(return_value=mock_choice)
+
+        from server.tools.auth_tools import auth_login
+
+        result = asyncio.run(auth_login(mock_ctx))
+        assert result == {"cancelled": True, "message": "Авторизация отменена."}
+
+    @patch("server.tools.auth_tools._exchange_or_set_token")
+    @patch("server.tools.auth_tools._oauth")
+    def test_auth_login_token_flow(self, mock_oauth, mock_exchange) -> None:
+        mock_oauth.get_status.return_value = {"valid": False}
+        mock_exchange.return_value = {"success": True, "method": "direct_token"}
+
+        mock_ctx = MagicMock()
+        method_choice = MagicMock()
+        method_choice.action = "accept"
+        method_choice.data.method = "token"
+        token_input = MagicMock()
+        token_input.action = "accept"
+        token_input.data.value = "y0_live_token"
+        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, token_input])
+
+        from server.tools.auth_tools import auth_login
+
+        result = asyncio.run(auth_login(mock_ctx))
+        assert result["success"] is True
+        mock_exchange.assert_called_once_with("y0_live_token")
+        assert mock_ctx.elicit.await_count == 2
+
+    @patch("server.tools.auth_tools._oauth")
+    def test_auth_login_token_input_cancelled(self, mock_oauth) -> None:
+        mock_oauth.get_status.return_value = {"valid": False}
+
+        mock_ctx = MagicMock()
+        method_choice = MagicMock()
+        method_choice.action = "accept"
+        method_choice.data.method = "token"
+        token_input = MagicMock()
+        token_input.action = "decline"
+        token_input.data = None
+        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, token_input])
+
+        from server.tools.auth_tools import auth_login
+
+        result = asyncio.run(auth_login(mock_ctx))
+        assert result == {"cancelled": True, "message": "Ввод токена отменён."}
+
+    @patch("server.tools.auth_tools._exchange_or_set_token")
+    @patch("server.tools.auth_tools._oauth")
+    def test_auth_login_pkce_flow(self, mock_oauth, mock_exchange) -> None:
+        mock_oauth.get_status.return_value = {"valid": False}
+        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+        mock_exchange.return_value = {"success": True, "method": "oauth_code"}
+
+        mock_ctx = MagicMock()
+        method_choice = MagicMock()
+        method_choice.action = "accept"
+        method_choice.data.method = "pkce"
+        code_input = MagicMock()
+        code_input.action = "accept"
+        code_input.data.value = "ABC1234"
+        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, code_input])
+
+        from server.tools.auth_tools import auth_login
+
+        result = asyncio.run(auth_login(mock_ctx))
+        assert result["success"] is True
+        mock_oauth.start_auth_flow.assert_called_once()
+        mock_exchange.assert_called_once_with("ABC1234")
+
+    @patch("server.tools.auth_tools._oauth")
+    def test_auth_login_pkce_code_cancelled(self, mock_oauth) -> None:
+        mock_oauth.get_status.return_value = {"valid": False}
+        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+
+        mock_ctx = MagicMock()
+        method_choice = MagicMock()
+        method_choice.action = "accept"
+        method_choice.data.method = "pkce"
+        code_input = MagicMock()
+        code_input.action = "decline"
+        code_input.data = None
+        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, code_input])
+
+        from server.tools.auth_tools import auth_login
+
+        result = asyncio.run(auth_login(mock_ctx))
+        assert result == {"cancelled": True, "message": "Ввод кода отменён."}
+
+    @patch("server.tools.auth_tools._oauth")
+    def test_oauth_login_prompt_embeds_authorize_url(self, mock_oauth) -> None:
+        mock_oauth.start_auth_flow.return_value = "https://oauth.yandex.ru/authorize?x=1"
+
+        from server.tools.auth_tools import oauth_login_prompt
+
+        prompt = oauth_login_prompt()
+        assert len(prompt) == 1
+        assert prompt[0]["role"] == "user"
+        assert "https://oauth.yandex.ru/authorize?x=1" in prompt[0]["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_live_safe.py
+++ b/tests/test_live_safe.py
@@ -1,0 +1,91 @@
+"""Live safe smoke tests for existing read-only and auth MCP tools."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from server.tools.ads import ads_list
+from server.tools.auth_tools import auth_setup, auth_status
+from server.tools.campaigns import campaigns_list
+from server.tools.keywords import keywords_list
+from server.tools.reports import reports_get
+
+pytestmark = [pytest.mark.integration, pytest.mark.live_safe]
+
+
+def _find_campaign(campaigns: list[dict], campaign_id: str) -> dict | None:
+    for campaign in campaigns:
+        if str(campaign.get("Id")) == str(campaign_id):
+            return campaign
+    return None
+
+
+@pytest.fixture()
+def active_campaign(live_token_getter):
+    """Return a live active campaign, preferring an explicitly configured ID."""
+    campaigns = campaigns_list(state="ON")
+    assert isinstance(campaigns, list), campaigns
+    assert campaigns, "No active campaigns available for live tests"
+
+    preferred_id = os.environ.get("TEST_ACTIVE_CAMPAIGN_ID")
+    if preferred_id:
+        campaign = _find_campaign(campaigns, preferred_id)
+        assert campaign is not None, f"TEST_ACTIVE_CAMPAIGN_ID={preferred_id} not found in active campaigns"
+        return campaign
+
+    return campaigns[0]
+
+
+def test_live_auth_status_returns_valid_dict(live_oauth_manager):
+    result = auth_status()
+    assert isinstance(result, dict)
+    assert result["valid"] is True
+
+
+def test_live_auth_setup_accepts_existing_direct_token(
+    live_oauth_manager, live_plugin_data_dir: Path
+):
+    token_path = live_plugin_data_dir / "tokens.json"
+    original_contents = token_path.read_text()
+    original_data = json.loads(original_contents)
+    access_token = original_data["access_token"]
+
+    try:
+        result = auth_setup(access_token)
+        assert result["success"] is True
+        assert result["method"] == "direct_token"
+        assert result["access_token_prefix"] == access_token[:6] + "..."
+        status = auth_status()
+        assert status["valid"] is True
+    finally:
+        token_path.write_text(original_contents)
+
+
+def test_live_campaigns_list_returns_active_campaigns(live_token_getter):
+    campaigns = campaigns_list(state="ON")
+    assert isinstance(campaigns, list), campaigns
+    assert campaigns, "Expected at least one active campaign"
+    assert all(campaign.get("State") == "ON" for campaign in campaigns)
+
+
+def test_live_ads_list_reads_campaign(active_campaign, live_token_getter):
+    result = ads_list(campaign_ids=str(active_campaign["Id"]))
+    assert isinstance(result, list), result
+
+
+def test_live_keywords_list_reads_campaign(active_campaign, live_token_getter):
+    result = keywords_list(campaign_ids=str(active_campaign["Id"]))
+    assert isinstance(result, list), result
+
+
+def test_live_reports_get_returns_goal_metrics(live_token_getter):
+    result = reports_get()
+    assert isinstance(result, list), result
+    assert result, "Expected at least one report row"
+    first_row = result[0]
+    assert "CampaignName" in first_row
+    assert "Conversions" in first_row
+    assert "CostPerConversion" in first_row
+    assert "ConversionRate" in first_row

--- a/tests/test_live_safe.py
+++ b/tests/test_live_safe.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from server.auth.storage import FileTokenStorage, TokenData
 from server.tools.ads import ads_list
 from server.tools.auth_tools import auth_setup, auth_status
 from server.tools.campaigns import campaigns_list
@@ -32,7 +33,9 @@ def active_campaign(live_token_getter):
     preferred_id = os.environ.get("TEST_ACTIVE_CAMPAIGN_ID")
     if preferred_id:
         campaign = _find_campaign(campaigns, preferred_id)
-        assert campaign is not None, f"TEST_ACTIVE_CAMPAIGN_ID={preferred_id} not found in active campaigns"
+        assert campaign is not None, (
+            f"TEST_ACTIVE_CAMPAIGN_ID={preferred_id} not found in active campaigns"
+        )
         return campaign
 
     return campaigns[0]
@@ -60,7 +63,8 @@ def test_live_auth_setup_accepts_existing_direct_token(
         status = auth_status()
         assert status["valid"] is True
     finally:
-        token_path.write_text(original_contents)
+        storage = FileTokenStorage(path=token_path)
+        storage.save(TokenData(**original_data))
 
 
 def test_live_campaigns_list_returns_active_campaigns(live_token_getter):

--- a/tests/test_live_unsafe.py
+++ b/tests/test_live_unsafe.py
@@ -1,6 +1,7 @@
 """Live unsafe tests for existing mutating MCP tools with rollback."""
 
 import os
+import warnings
 
 import pytest
 
@@ -50,10 +51,13 @@ def test_live_campaigns_update_rolls_back(live_token_getter):
         updated = _find_campaign(campaign_id)
         assert updated.get("State") == "ON", updated
     finally:
-        rollback = campaigns_update(id=campaign_id, state="OFF")
-        assert rollback.get("success") is True, rollback
-        restored = _find_campaign(campaign_id)
-        assert restored.get("State") == "OFF", restored
+        try:
+            rollback = campaigns_update(id=campaign_id, state="OFF")
+            assert rollback.get("success") is True, rollback
+            restored = _find_campaign(campaign_id)
+            assert restored.get("State") == "OFF", restored
+        except Exception:
+            warnings.warn(f"Rollback failed for campaign {campaign_id}", stacklevel=2)
 
 
 def test_live_keywords_update_rolls_back(live_token_getter):
@@ -67,7 +71,9 @@ def test_live_keywords_update_rolls_back(live_token_getter):
 
     temp_bid_value = int(temp_bid)
     assert temp_bid_value > 0
-    assert temp_bid_value != original_bid, "TEST_KEYWORD_BID_TEMP must differ from the current bid"
+    assert temp_bid_value != original_bid, (
+        "TEST_KEYWORD_BID_TEMP must differ from the current bid"
+    )
 
     try:
         update_result = keywords_update(id=keyword_id, bid=str(temp_bid_value))
@@ -76,7 +82,10 @@ def test_live_keywords_update_rolls_back(live_token_getter):
         updated = _find_keyword(campaign_id, keyword_id)
         assert int(updated["Bid"]) == temp_bid_value, updated
     finally:
-        rollback = keywords_update(id=keyword_id, bid=str(original_bid))
-        assert rollback.get("success") is True, rollback
-        restored = _find_keyword(campaign_id, keyword_id)
-        assert int(restored["Bid"]) == original_bid, restored
+        try:
+            rollback = keywords_update(id=keyword_id, bid=str(original_bid))
+            assert rollback.get("success") is True, rollback
+            restored = _find_keyword(campaign_id, keyword_id)
+            assert int(restored["Bid"]) == original_bid, restored
+        except Exception:
+            warnings.warn(f"Rollback failed for keyword {keyword_id}", stacklevel=2)

--- a/tests/test_live_unsafe.py
+++ b/tests/test_live_unsafe.py
@@ -1,0 +1,82 @@
+"""Live unsafe tests for existing mutating MCP tools with rollback."""
+
+import os
+
+import pytest
+
+from server.tools.campaigns import campaigns_list, campaigns_update
+from server.tools.keywords import keywords_list, keywords_update
+
+pytestmark = [pytest.mark.integration, pytest.mark.live_unsafe]
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} is required for live unsafe tests")
+    return value
+
+
+def _find_campaign(campaign_id: str) -> dict:
+    campaigns = campaigns_list()
+    assert isinstance(campaigns, list), campaigns
+    for campaign in campaigns:
+        if str(campaign.get("Id")) == str(campaign_id):
+            return campaign
+    raise AssertionError(f"Campaign {campaign_id} not found")
+
+
+def _find_keyword(campaign_id: str, keyword_id: str) -> dict:
+    keywords = keywords_list(campaign_ids=str(campaign_id))
+    assert isinstance(keywords, list), keywords
+    for keyword in keywords:
+        if str(keyword.get("Id")) == str(keyword_id):
+            return keyword
+    raise AssertionError(f"Keyword {keyword_id} not found in campaign {campaign_id}")
+
+
+def test_live_campaigns_update_rolls_back(live_token_getter):
+    campaign_id = _require_env("TEST_OFF_CAMPAIGN_ID")
+    original = _find_campaign(campaign_id)
+    assert original.get("State") == "OFF", (
+        f"TEST_OFF_CAMPAIGN_ID={campaign_id} must start in OFF state, "
+        f"got {original.get('State')}"
+    )
+
+    try:
+        update_result = campaigns_update(id=campaign_id, state="ON")
+        assert update_result.get("success") is True, update_result
+
+        updated = _find_campaign(campaign_id)
+        assert updated.get("State") == "ON", updated
+    finally:
+        rollback = campaigns_update(id=campaign_id, state="OFF")
+        assert rollback.get("success") is True, rollback
+        restored = _find_campaign(campaign_id)
+        assert restored.get("State") == "OFF", restored
+
+
+def test_live_keywords_update_rolls_back(live_token_getter):
+    campaign_id = _require_env("TEST_KEYWORD_CAMPAIGN_ID")
+    keyword_id = _require_env("TEST_KEYWORD_ID")
+    temp_bid = _require_env("TEST_KEYWORD_BID_TEMP")
+
+    original = _find_keyword(campaign_id, keyword_id)
+    original_bid = int(original["Bid"])
+    assert original_bid > 0
+
+    temp_bid_value = int(temp_bid)
+    assert temp_bid_value > 0
+    assert temp_bid_value != original_bid, "TEST_KEYWORD_BID_TEMP must differ from the current bid"
+
+    try:
+        update_result = keywords_update(id=keyword_id, bid=str(temp_bid_value))
+        assert update_result.get("success") is True, update_result
+
+        updated = _find_keyword(campaign_id, keyword_id)
+        assert int(updated["Bid"]) == temp_bid_value, updated
+    finally:
+        rollback = keywords_update(id=keyword_id, bid=str(original_bid))
+        assert rollback.get("success") is True, rollback
+        restored = _find_keyword(campaign_id, keyword_id)
+        assert int(restored["Bid"]) == original_bid, restored

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,11 +1,17 @@
 """Tests for reports MCP tool."""
 
+from datetime import date, timedelta
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 import server.tools
-from server.tools.reports import reports_get
+from server.tools.reports import (
+    DEFAULT_REPORT_FIELDS,
+    DEFAULT_REPORT_NAME,
+    DEFAULT_REPORT_TYPE,
+    reports_get,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +20,13 @@ def setup():
 
 
 SAMPLE_REPORTS = [
-    {"CampaignId": 12345, "Impressions": 15420, "Clicks": 312, "Cost": 1000.00},
+    {
+        "CampaignName": "Sample campaign",
+        "Impressions": 15420,
+        "Clicks": 312,
+        "Cost": 1000.00,
+        "Conversions": 14,
+    },
 ]
 
 
@@ -27,18 +39,105 @@ def _mock_runner(return_value):
 
 def test_reports_get():
     """Test 16: Statistics for date range."""
-    with patch(
-        "server.tools.reports.get_runner", return_value=_mock_runner(SAMPLE_REPORTS)
-    ):
+    runner = _mock_runner(SAMPLE_REPORTS)
+    with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_get(date_from="2026-03-30", date_to="2026-04-06")
         assert len(result) == 1
         assert result[0]["Impressions"] == 15420
+        runner.run_json.assert_called_once_with(
+            [
+                "reports",
+                "get",
+                "--type",
+                DEFAULT_REPORT_TYPE,
+                "--from",
+                "2026-03-30",
+                "--to",
+                "2026-04-06",
+                "--name",
+                DEFAULT_REPORT_NAME,
+                "--fields",
+                DEFAULT_REPORT_FIELDS,
+                "--format",
+                "json",
+            ]
+        )
 
 
 def test_reports_no_dates():
     """Reports without date range."""
-    with patch(
-        "server.tools.reports.get_runner", return_value=_mock_runner(SAMPLE_REPORTS)
-    ):
+    runner = _mock_runner(SAMPLE_REPORTS)
+    today = date.today()
+    expected_from = (today - timedelta(days=8)).isoformat()
+    expected_to = today.isoformat()
+    with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_get()
         assert len(result) == 1
+        runner.run_json.assert_called_once_with(
+            [
+                "reports",
+                "get",
+                "--type",
+                DEFAULT_REPORT_TYPE,
+                "--from",
+                expected_from,
+                "--to",
+                expected_to,
+                "--name",
+                DEFAULT_REPORT_NAME,
+                "--fields",
+                DEFAULT_REPORT_FIELDS,
+                "--format",
+                "json",
+            ]
+        )
+
+
+def test_reports_only_date_to():
+    """Missing start date uses the same default 8-day window."""
+    runner = _mock_runner(SAMPLE_REPORTS)
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        reports_get(date_to="2026-04-08")
+        runner.run_json.assert_called_once_with(
+            [
+                "reports",
+                "get",
+                "--type",
+                DEFAULT_REPORT_TYPE,
+                "--from",
+                "2026-03-31",
+                "--to",
+                "2026-04-08",
+                "--name",
+                DEFAULT_REPORT_NAME,
+                "--fields",
+                DEFAULT_REPORT_FIELDS,
+                "--format",
+                "json",
+            ]
+        )
+
+
+def test_reports_only_date_from():
+    """Missing end date uses the same default 8-day window."""
+    runner = _mock_runner(SAMPLE_REPORTS)
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        reports_get(date_from="2026-03-30")
+        runner.run_json.assert_called_once_with(
+            [
+                "reports",
+                "get",
+                "--type",
+                DEFAULT_REPORT_TYPE,
+                "--from",
+                "2026-03-30",
+                "--to",
+                "2026-04-07",
+                "--name",
+                DEFAULT_REPORT_NAME,
+                "--fields",
+                DEFAULT_REPORT_FIELDS,
+                "--format",
+                "json",
+            ]
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,8 +28,8 @@ def _read_response(proc: subprocess.Popen[str]) -> dict:
     return json.loads(line)
 
 
-def test_mcp_server_registers_all_tools():
-    proc = subprocess.Popen(
+def _start_server() -> subprocess.Popen[str]:
+    return subprocess.Popen(
         [sys.executable, str(PROJECT_ROOT / "server" / "main.py")],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -37,30 +37,37 @@ def test_mcp_server_registers_all_tools():
         text=True,
         cwd=str(PROJECT_ROOT),
     )
+
+
+def _initialize(proc: subprocess.Popen[str]) -> None:
+    init_msg = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"},
+        },
+    }
+    assert proc.stdin is not None
+    proc.stdin.write(json.dumps(init_msg) + "\n")
+    proc.stdin.flush()
+
+    resp = _read_response(proc)
+    assert resp["id"] == 1
+    assert "tools" in resp["result"]["capabilities"]
+
+    proc.stdin.write(
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+    )
+    proc.stdin.flush()
+
+
+def test_mcp_server_registers_all_tools():
+    proc = _start_server()
     try:
-        # 1. initialize
-        init_msg = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "test", "version": "1.0"},
-            },
-        }
-        proc.stdin.write(json.dumps(init_msg) + "\n")
-        proc.stdin.flush()
-
-        resp = _read_response(proc)
-        assert resp["id"] == 1
-        assert "tools" in resp["result"]["capabilities"]
-
-        # 2. notifications/initialized
-        proc.stdin.write(
-            json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
-        )
-        proc.stdin.flush()
+        _initialize(proc)
 
         # 3. tools/list
         tools_msg = {
@@ -81,6 +88,66 @@ def test_mcp_server_registers_all_tools():
             f"Missing tools: {EXPECTED_TOOLS - tool_names}, "
             f"extra tools: {tool_names - EXPECTED_TOOLS}"
         )
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_mcp_server_tools_call_auth_status():
+    proc = _start_server()
+    try:
+        _initialize(proc)
+        assert proc.stdin is not None
+        proc.stdin.write(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "auth_status", "arguments": {}},
+                }
+            )
+            + "\n"
+        )
+        proc.stdin.flush()
+
+        resp = _read_response(proc)
+        assert resp["id"] == 2
+        assert resp["result"]["isError"] is False
+        body = json.loads(resp["result"]["content"][0]["text"])
+        assert body == {"valid": False}
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_mcp_server_tools_call_returns_structured_tool_error():
+    proc = _start_server()
+    try:
+        _initialize(proc)
+        assert proc.stdin is not None
+        proc.stdin.write(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "campaigns_list",
+                        "arguments": {"state": "BAD"},
+                    },
+                }
+            )
+            + "\n"
+        )
+        proc.stdin.flush()
+
+        resp = _read_response(proc)
+        assert resp["id"] == 2
+        assert resp["result"]["isError"] is False
+        structured = resp["result"]["structuredContent"]["result"]
+        assert structured["error"] == "invalid_state"
+        assert "got 'BAD'" in structured["message"]
     finally:
         proc.terminate()
         proc.wait(timeout=5)

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -1,0 +1,163 @@
+"""Tests for shared tool decorators and helper functions."""
+
+from unittest.mock import patch
+
+import pytest
+
+import server.tools as tools
+from server.auth.oauth import OAuthError
+from server.cli.runner import (
+    CliAuthError,
+    CliNotFoundError,
+    CliRegistrationError,
+    CliTimeoutError,
+    DirectCliRunner,
+)
+from server.tools.ads import _check_batch_limit as ads_check_batch_limit
+from server.tools.ads import _get_foreign_campaign_id, _parse_ids
+from server.tools.auth_tools import _human_readable_time
+from server.tools.keywords import _check_batch_limit as keywords_check_batch_limit
+
+
+def test_human_readable_time_formats_expected_ranges() -> None:
+    assert _human_readable_time(0) == "истёк"
+    assert _human_readable_time(59) == "59 сек."
+    assert _human_readable_time(90) == "1 мин. 30 сек."
+    assert _human_readable_time(3660) == "1 ч. 1 мин."
+
+
+def test_try_refresh_token_returns_access_token() -> None:
+    with patch("server.auth.oauth.OAuthManager") as mock_manager_cls:
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.refresh_token.return_value = {"access_token": "fresh-token"}
+        assert tools._try_refresh_token() == "fresh-token"
+
+
+def test_try_refresh_token_reraises_oauth_error() -> None:
+    with patch("server.auth.oauth.OAuthManager") as mock_manager_cls:
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.refresh_token.side_effect = OAuthError("auth_expired", "expired")
+        with pytest.raises(OAuthError):
+            tools._try_refresh_token()
+
+
+def test_try_refresh_token_returns_none_on_generic_error() -> None:
+    with patch("server.auth.oauth.OAuthManager") as mock_manager_cls:
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.refresh_token.side_effect = RuntimeError("boom")
+        assert tools._try_refresh_token() is None
+
+
+def test_handle_cli_errors_maps_registration_error() -> None:
+        @tools.handle_cli_errors
+        def wrapped():
+            raise CliRegistrationError("registration incomplete")
+
+        result = wrapped()
+        assert result["error"] == "incomplete_registration"
+
+
+def test_handle_cli_errors_maps_cli_not_found() -> None:
+        @tools.handle_cli_errors
+        def wrapped():
+            raise CliNotFoundError("cli missing")
+
+        result = wrapped()
+        assert result["error"] == "cli_not_found"
+
+
+def test_handle_cli_errors_maps_timeout() -> None:
+        @tools.handle_cli_errors
+        def wrapped():
+            raise CliTimeoutError("timed out")
+
+        result = wrapped()
+        assert result["error"] == "timeout"
+
+
+def test_handle_cli_errors_retries_once_after_refresh() -> None:
+    state = {"calls": 0}
+
+    @tools.handle_cli_errors
+    def wrapped():
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise CliAuthError("expired")
+        return {"success": True}
+
+    with patch("server.tools._try_refresh_token", return_value="fresh-token"):
+        result = wrapped()
+
+    assert result == {"success": True}
+    assert state["calls"] == 2
+
+
+def test_handle_cli_errors_returns_auth_expired_when_retry_still_fails() -> None:
+    @tools.handle_cli_errors
+    def wrapped():
+        raise CliAuthError("expired")
+
+    with patch("server.tools._try_refresh_token", return_value="fresh-token"):
+        result = wrapped()
+
+    assert result["error"] == "auth_expired"
+
+
+def test_handle_cli_errors_returns_oauth_error_dict() -> None:
+    @tools.handle_cli_errors
+    def wrapped():
+        raise OAuthError("auth_expired", "reauthorize", "https://oauth.example")
+
+    result = wrapped()
+    assert result["error"] == "auth_expired"
+    assert result["auth_url"] == "https://oauth.example"
+
+
+def test_handle_cli_errors_returns_unknown_for_unexpected_exception() -> None:
+    @tools.handle_cli_errors
+    def wrapped():
+        raise RuntimeError("boom")
+
+    result = wrapped()
+    assert result["error"] == "unknown"
+    assert result["message"] == "boom"
+
+
+def test_set_token_getter_and_get_runner() -> None:
+    tools.set_token_getter(lambda: "test-token")
+    runner = tools.get_runner()
+    assert isinstance(runner, DirectCliRunner)
+    assert runner._token == "test-token"
+
+
+def test_get_runner_raises_without_token_getter() -> None:
+    original = tools._token_getter
+    tools._token_getter = None
+    try:
+        with pytest.raises(RuntimeError, match="Token getter not configured"):
+            tools.get_runner()
+    finally:
+        tools._token_getter = original
+
+
+def test_parse_ids_strips_whitespace_and_empty_values() -> None:
+    assert _parse_ids(" 1, 2 ,,3 , ") == ["1", "2", "3"]
+
+
+def test_ads_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
+    assert ads_check_batch_limit(",".join(str(i) for i in range(10))) is None
+    result = ads_check_batch_limit(",".join(str(i) for i in range(11)))
+    assert result is not None
+    assert result.error == "batch_limit"
+
+
+def test_get_foreign_campaign_id_detects_only_foreign_range() -> None:
+    assert _get_foreign_campaign_id("abc,72999999,73000000,5") == "73000000"
+    assert _get_foreign_campaign_id("100,200,abc") is None
+
+
+def test_keywords_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
+    assert keywords_check_batch_limit(",".join(str(i) for i in range(10))) is None
+    result = keywords_check_batch_limit(",".join(str(i) for i in range(11)))
+    assert result is not None
+    assert result.error == "batch_limit"

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -49,30 +49,30 @@ def test_try_refresh_token_returns_none_on_generic_error() -> None:
 
 
 def test_handle_cli_errors_maps_registration_error() -> None:
-        @tools.handle_cli_errors
-        def wrapped():
-            raise CliRegistrationError("registration incomplete")
+    @tools.handle_cli_errors
+    def wrapped():
+        raise CliRegistrationError("registration incomplete")
 
-        result = wrapped()
-        assert result["error"] == "incomplete_registration"
+    result = wrapped()
+    assert result["error"] == "incomplete_registration"
 
 
 def test_handle_cli_errors_maps_cli_not_found() -> None:
-        @tools.handle_cli_errors
-        def wrapped():
-            raise CliNotFoundError("cli missing")
+    @tools.handle_cli_errors
+    def wrapped():
+        raise CliNotFoundError("cli missing")
 
-        result = wrapped()
-        assert result["error"] == "cli_not_found"
+    result = wrapped()
+    assert result["error"] == "cli_not_found"
 
 
 def test_handle_cli_errors_maps_timeout() -> None:
-        @tools.handle_cli_errors
-        def wrapped():
-            raise CliTimeoutError("timed out")
+    @tools.handle_cli_errors
+    def wrapped():
+        raise CliTimeoutError("timed out")
 
-        result = wrapped()
-        assert result["error"] == "timeout"
+    result = wrapped()
+    assert result["error"] == "timeout"
 
 
 def test_handle_cli_errors_retries_once_after_refresh() -> None:


### PR DESCRIPTION
Summary
- fix reports_get to match the installed direct-cli contract and default date window
- add shared tool/helper coverage and stronger MCP transport tests
- add live safe/live unsafe pytest suites plus explicit gating flags
- extend auth coverage, including live auth_setup with token file restore
- add AGENTS.md contributor guide

Verification
- python3 -m pytest -q
- python3 -m pytest -q -m live_safe --run-live-safe
- python3 -m pytest -q -m live_unsafe
- python3 -m pytest -q -m live_unsafe --run-live-unsafe
- ruff check tests/conftest.py tests/test_live_safe.py tests/test_live_unsafe.py tests/test_auth.py tests/test_reports.py server/tools/reports.py
