### PR TITLE
fix(keywords): align keywords_add parameters with direct-cli

### DIFF
--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -63,30 +63,20 @@ def keywords_update(id: str, bid: str) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def keywords_add(campaign_id: str, ad_group_id: str, keywords: str) -> dict:
-    """Add keywords to an ad group.
+def keywords_add(ad_group_id: str, keyword: str, bid: str | None = None) -> dict:
+    """Add a keyword to an ad group.
 
     Args:
-        campaign_id: Campaign ID.
-        ad_group_id: Ad group ID to add keywords to.
-        keywords: Comma-separated keyword list.
+        ad_group_id: Ad group ID to add the keyword to.
+        keyword: Keyword text.
+        bid: Optional bid (will be converted to micro-units if numeric, e.g. 15 → 15000000).
     """
+    args = ["keywords", "add", "--adgroup-id", ad_group_id, "--keyword", keyword]
+    if bid:
+        args.extend(["--bid", bid])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "keywords",
-            "add",
-            "--campaign-id",
-            campaign_id,
-            "--ad-group-id",
-            ad_group_id,
-            "--keywords",
-            keywords,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -65,14 +65,12 @@ class TestKeywordsCrudOperations:
     """Tests for keyword CRUD operations (add, delete, suspend, resume)."""
 
     def test_keywords_add(self):
-        """Test adding keywords to an ad group."""
-        mock_result = {"success": True, "keywords": ["keyword1", "keyword2"]}
+        """Test adding a keyword to an ad group."""
+        mock_result = {"success": True}
         with patch(
             "server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)
         ):
-            result = keywords_add(
-                campaign_id="12345", ad_group_id="1", keywords="keyword1,keyword2"
-            )
+            result = keywords_add(ad_group_id="1", keyword="buy shoes")
             assert result["success"] is True
 
     def test_keywords_delete_success(self):


### PR DESCRIPTION
## Summary
- Fixed `keywords_add` MCP tool to match the actual `direct-cli` CLI interface: `--adgroup-id`, `--keyword` (singular), and optional `--bid` instead of the incorrect `--campaign-id`, `--ad-group-id`, `--keywords`
- Updated the corresponding test to use the new signature

## Test plan
- [x] All 10 keyword tests pass (`pytest tests/test_keywords.py -x -q`)
- [ ] Verify with live CLI that `direct keywords add --adgroup-id 1 --keyword "buy shoes"` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)