### PR TITLE
feat(campaigns): add suspend and resume tools

### DIFF
--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -141,3 +141,41 @@ def campaigns_unarchive(ids: str) -> dict:
         ["campaigns", "unarchive", "--ids", ids, "--format", "json"]
     )
     return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def campaigns_suspend(ids: str) -> dict:
+    """Suspend campaigns.
+
+    Args:
+        ids: Comma-separated campaign IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["campaigns", "suspend", "--ids", ids, "--format", "json"])
+    return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def campaigns_resume(ids: str) -> dict:
+    """Resume suspended campaigns.
+
+    Args:
+        ids: Comma-separated campaign IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["campaigns", "resume", "--ids", ids, "--format", "json"])
+    return result

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -12,6 +12,8 @@ from server.tools.campaigns import (
     campaigns_delete,
     campaigns_archive,
     campaigns_unarchive,
+    campaigns_suspend,
+    campaigns_resume,
 )
 from server.cli.runner import CliAuthError
 
@@ -190,5 +192,37 @@ class TestCampaignsCrudOperations:
         """Test batch limit validation for unarchive."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
         result = campaigns_unarchive(ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
+    def test_campaigns_suspend_success(self):
+        """Test suspending campaigns successfully."""
+        mock_result = {"success": True}
+        with patch(
+            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
+        ):
+            result = campaigns_suspend(ids="12345")
+            assert result["success"] is True
+
+    def test_campaigns_suspend_batch_limit(self):
+        """Test batch limit validation for suspend."""
+        ids = ",".join(str(i) for i in range(1, 12))
+        result = campaigns_suspend(ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
+    def test_campaigns_resume_success(self):
+        """Test resuming campaigns successfully."""
+        mock_result = {"success": True}
+        with patch(
+            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
+        ):
+            result = campaigns_resume(ids="12345")
+            assert result["success"] is True
+
+    def test_campaigns_resume_batch_limit(self):
+        """Test batch limit validation for resume."""
+        ids = ",".join(str(i) for i in range(1, 12))
+        result = campaigns_resume(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"


### PR DESCRIPTION
## Summary
- Add `campaigns_suspend` and `campaigns_resume` MCP tools to `server/tools/campaigns.py`
- Both tools accept comma-separated campaign IDs (max 10) with batch limit validation
- Add 4 test cases: success and batch-limit scenarios for each tool

## Test plan
- [x] All 20 campaign tests pass (`pytest tests/test_campaigns.py -x -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)