### PR TITLE
feat(reports): add list_types tool

### DIFF
--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -64,3 +64,11 @@ def reports_get(
         "json",
     ]
     return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def reports_list_types() -> list[str]:
+    """List available report types."""
+    runner = get_runner()
+    return runner.run_json(["reports", "list-types", "--format", "json"])

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -11,6 +11,7 @@ from server.tools.reports import (
     DEFAULT_REPORT_NAME,
     DEFAULT_REPORT_TYPE,
     reports_get,
+    reports_list_types,
 )
 
 
@@ -141,3 +142,19 @@ def test_reports_only_date_from():
                 "json",
             ]
         )
+
+
+def test_reports_list_types():
+    expected_types = [
+        "CAMPAIGN_PERFORMANCE_REPORT",
+        "ADGROUP_PERFORMANCE_REPORT",
+        "AD_PERFORMANCE_REPORT",
+        "CRITERIA_PERFORMANCE_REPORT",
+        "CUSTOM_REPORT",
+        "REACH_AND_FREQUENCY_CAMPAIGN_REPORT",
+        "SEARCH_QUERY_PERFORMANCE_REPORT",
+    ]
+    with patch("server.tools.reports.get_runner", return_value=_mock_runner(expected_types)):
+        result = reports_list_types()
+        assert len(result) == 7
+        assert "CAMPAIGN_PERFORMANCE_REPORT" in result


### PR DESCRIPTION
## Summary
- Adds `reports_list_types` MCP tool to `server/tools/reports.py` that lists available report types via `direct reports list-types --format json`
- Adds corresponding test `test_reports_list_types` in `tests/test_reports.py`

## Test plan
- [x] All 5 tests in `tests/test_reports.py` pass (`pytest tests/test_reports.py -x -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)