### PR TITLE
feat(keywords): add archive and unarchive tools

### DIFF
--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -144,3 +144,41 @@ def keywords_resume(ids: str) -> dict:
     runner = get_runner()
     result = runner.run_json(["keywords", "resume", "--ids", ids, "--format", "json"])
     return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def keywords_archive(ids: str) -> dict:
+    """Archive keywords.
+
+    Args:
+        ids: Comma-separated keyword IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["keywords", "archive", "--ids", ids, "--format", "json"])
+    return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def keywords_unarchive(ids: str) -> dict:
+    """Unarchive keywords.
+
+    Args:
+        ids: Comma-separated keyword IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["keywords", "unarchive", "--ids", ids, "--format", "json"])
+    return result

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -12,6 +12,8 @@ from server.tools.keywords import (
     keywords_delete,
     keywords_suspend,
     keywords_resume,
+    keywords_archive,
+    keywords_unarchive,
 )
 
 
@@ -122,3 +124,31 @@ class TestKeywordsCrudOperations:
         result = keywords_resume(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
+
+
+def test_keywords_archive_success():
+    mock_result = {"success": True}
+    with patch("server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)):
+        result = keywords_archive(ids="111,222")
+        assert result["success"] is True
+
+
+def test_keywords_archive_batch_limit():
+    ids = ",".join(str(i) for i in range(1, 12))
+    result = keywords_archive(ids=ids)
+    assert "error" in result
+    assert result["error"] == "batch_limit"
+
+
+def test_keywords_unarchive_success():
+    mock_result = {"success": True}
+    with patch("server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)):
+        result = keywords_unarchive(ids="111,222")
+        assert result["success"] is True
+
+
+def test_keywords_unarchive_batch_limit():
+    ids = ",".join(str(i) for i in range(1, 12))
+    result = keywords_unarchive(ids=ids)
+    assert "error" in result
+    assert result["error"] == "batch_limit"


### PR DESCRIPTION
## Summary
- Add `keywords_archive` and `keywords_unarchive` MCP tools to `server/tools/keywords.py`
- Both tools validate batch limit (max 10 IDs) and delegate to the `direct` CLI
- Add 4 tests: success and batch-limit cases for each tool

## Test plan
- [x] All 14 tests in `tests/test_keywords.py` pass (`pytest tests/test_keywords.py -x -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)