### PR TITLE
feat(businesses): add businesses_list tool

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -17,6 +17,7 @@ import server.tools.ads  # noqa: E402, F401
 import server.tools.agency  # noqa: E402, F401
 import server.tools.audience  # noqa: E402, F401
 import server.tools.auth_tools  # noqa: E402, F401
+import server.tools.businesses  # noqa: E402, F401
 import server.tools.bidmodifiers  # noqa: E402, F401
 import server.tools.bids  # noqa: E402, F401
 import server.tools.campaigns  # noqa: E402, F401

--- a/server/tools/businesses.py
+++ b/server/tools/businesses.py
@@ -1,0 +1,19 @@
+"""MCP tools for business management."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool()
+@handle_cli_errors
+def businesses_list(ids: str | None = None) -> list[dict] | dict:
+    """List businesses.
+
+    Args:
+        ids: Comma-separated business IDs (optional).
+    """
+    args = ["businesses", "get", "--format", "json"]
+    if ids:
+        args.extend(["--ids", ids])
+    runner = get_runner()
+    return runner.run_json(args)

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -1,0 +1,53 @@
+"""Tests for businesses MCP tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.tools
+from server.tools.businesses import businesses_list
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+SAMPLE_BUSINESSES = [
+    {"Id": 100, "Name": "Test Business", "Url": "https://example.com"},
+]
+
+
+def _mock_runner(return_value):
+    """Create a mock get_runner that returns a runner with the given run_json result."""
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_businesses_list_success():
+    with patch(
+        "server.tools.businesses.get_runner",
+        return_value=_mock_runner(SAMPLE_BUSINESSES),
+    ):
+        result = businesses_list()
+        assert len(result) == 1
+        assert result[0]["Id"] == 100
+
+
+def test_businesses_list_with_ids():
+    with patch(
+        "server.tools.businesses.get_runner",
+        return_value=_mock_runner(SAMPLE_BUSINESSES),
+    ):
+        result = businesses_list(ids="100")
+        assert len(result) == 1
+
+
+def test_businesses_list_empty():
+    with patch(
+        "server.tools.businesses.get_runner",
+        return_value=_mock_runner([]),
+    ):
+        result = businesses_list()
+        assert result == []


### PR DESCRIPTION
## Summary
- Add `server/tools/businesses.py` with `businesses_list` MCP tool (supports optional `ids` filter)
- Add `tests/test_businesses.py` with 3 unit tests (success, with-ids, empty)
- Register new module import in `server/main.py`

## Test plan
- [x] `python3 -m pytest tests/test_businesses.py -x -q` — 3 passed
- [x] Full suite passes (248 passed, 1 pre-existing server test failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)