### PR TITLE
feat(smart-ad-targets): add CRUD tools for smartadtargets CLI group

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -34,6 +34,7 @@ import server.tools.reports  # noqa: E402, F401
 import server.tools.research  # noqa: E402, F401
 import server.tools.retargeting  # noqa: E402, F401
 import server.tools.sitelinks  # noqa: E402, F401
+import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.smart_targets  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
 import server.tools.vcards  # noqa: E402, F401

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -1,0 +1,67 @@
+"""MCP tools for smart ad target management."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool()
+@handle_cli_errors
+def smart_ad_targets_list(ad_group_ids: str) -> list[dict] | dict:
+    """List smart ad targets.
+
+    Args:
+        ad_group_ids: Comma-separated ad group IDs.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["smartadtargets", "get", "--adgroup-ids", ad_group_ids, "--format", "json"]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def smart_ad_targets_add(ad_group_id: str, target_type: str, extra_json: str | None = None) -> dict:
+    """Add a smart ad target.
+
+    Args:
+        ad_group_id: Ad group ID.
+        target_type: Target type.
+        extra_json: Optional JSON string with additional parameters.
+    """
+    args = ["smartadtargets", "add", "--adgroup-id", ad_group_id, "--type", target_type]
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def smart_ad_targets_update(id: str, extra_json: str | None = None) -> dict:
+    """Update a smart ad target.
+
+    Args:
+        id: Target ID.
+        extra_json: JSON string with fields to update.
+    """
+    args = ["smartadtargets", "update", "--id", id]
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def smart_ad_targets_delete(id: str) -> dict:
+    """Delete a smart ad target.
+
+    Args:
+        id: Target ID.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["smartadtargets", "delete", "--id", id, "--format", "json"]
+    )

--- a/tests/test_smart_ad_targets.py
+++ b/tests/test_smart_ad_targets.py
@@ -1,0 +1,62 @@
+"""Tests for smart_ad_targets MCP tools."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import server.tools
+from server.tools.smart_ad_targets import (
+    smart_ad_targets_list,
+    smart_ad_targets_add,
+    smart_ad_targets_update,
+    smart_ad_targets_delete,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+SAMPLE_TARGETS = [
+    {"Id": 100, "CampaignId": 300, "AdGroupId": 200, "Status": "ACCEPTED", "ServingStatus": "ELIGIBLE"},
+]
+
+
+def _mock_runner(return_value):
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_smart_ad_targets_list():
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(SAMPLE_TARGETS)):
+        result = smart_ad_targets_list(ad_group_ids="200")
+        assert len(result) == 1
+
+
+def test_smart_ad_targets_list_empty():
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner([])):
+        result = smart_ad_targets_list(ad_group_ids="200")
+        assert result == []
+
+
+def test_smart_ad_targets_add():
+    mock_result = {"Id": 400}
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
+        result = smart_ad_targets_add(ad_group_id="200", target_type="RETARGETING")
+        assert result["Id"] == 400
+
+
+def test_smart_ad_targets_update():
+    mock_result = {"success": True}
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
+        result = smart_ad_targets_update(id="100", extra_json='{"Type": "RETARGETING"}')
+        assert result["success"] is True
+
+
+def test_smart_ad_targets_delete():
+    mock_result = {"success": True}
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
+        result = smart_ad_targets_delete(id="100")
+        assert result["success"] is True


### PR DESCRIPTION
## Summary
- Add `server/tools/smart_ad_targets.py` with 4 MCP tools: `smart_ad_targets_list`, `smart_ad_targets_add`, `smart_ad_targets_update`, `smart_ad_targets_delete`
- These wrap the `smartadtargets` CLI group (distinct from existing `smart_targets` which wraps `smarttargets`)
- Add corresponding test file with 5 passing tests
- Register module import in `server/main.py`

## Test plan
- [x] All 5 unit tests pass (`pytest tests/test_smart_ad_targets.py`)
- [x] Existing `test_smart_targets.py` tests still pass (no regression)
- [ ] Manual verification with live CLI (requires token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)