### PR TITLE
feat(negative-keyword-shared-sets): add CRUD tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ server/main.py (MCP)        — FastMCP server (stdio transport)
        ↑
 server/auth/                — OAuth 2.0 module (httpx)
 server/cli/runner.py        — subprocess wrapper over `direct`
-server/tools/               — 75 MCP tools across 26 modules
+server/tools/               — 79 MCP tools across 27 modules
        ↑
 skills/                     — domain knowledge (SKILL.md files)
        ↑
@@ -161,6 +161,7 @@ yandex-direct-mcp-plugin/
 │       ├── feeds.py             # feeds_list/add/update/delete
 │       ├── keywords.py          # keywords_list/update/add/delete/suspend/resume
 │       ├── leads.py             # leads_list
+│       ├── negative_keyword_shared_sets.py # negative_keyword_shared_sets_list/add/update/delete
 │       ├── negative_keywords.py # negative_keywords_list/add/update/delete
 │       ├── reports.py           # reports_get
 │       ├── research.py          # keywords_has_volume/deduplicate
@@ -184,7 +185,7 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (75 total) + 1 Prompt
+## MCP Tools (79 total) + 1 Prompt
 
 | Tool | Purpose |
 |---|---|
@@ -245,6 +246,10 @@ yandex-direct-mcp-plugin/
 | `negative_keywords_add` | Add negative keywords |
 | `negative_keywords_update` | Update negative keywords |
 | `negative_keywords_delete` | Delete negative keywords |
+| `negative_keyword_shared_sets_list` | List negative keyword shared sets |
+| `negative_keyword_shared_sets_add` | Add negative keyword shared set |
+| `negative_keyword_shared_sets_update` | Update negative keyword shared set |
+| `negative_keyword_shared_sets_delete` | Delete negative keyword shared set |
 | `smart_targets_list` | List smart targets |
 | `smart_targets_add` | Add smart target |
 | `smart_targets_update` | Update smart target |

--- a/server/main.py
+++ b/server/main.py
@@ -29,6 +29,7 @@ import server.tools.feeds  # noqa: E402, F401
 import server.tools.images  # noqa: E402, F401
 import server.tools.keywords  # noqa: E402, F401
 import server.tools.leads  # noqa: E402, F401
+import server.tools.negative_keyword_shared_sets  # noqa: E402, F401
 import server.tools.negative_keywords  # noqa: E402, F401
 import server.tools.reports  # noqa: E402, F401
 import server.tools.research  # noqa: E402, F401

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -1,0 +1,72 @@
+"""MCP tools for negative keyword shared sets management."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_list(ids: str | None = None) -> list[dict] | dict:
+    """List negative keyword shared sets.
+
+    Args:
+        ids: Comma-separated set IDs (optional).
+    """
+    args = ["negativekeywordsharedsets", "get", "--format", "json"]
+    if ids:
+        args.extend(["--ids", ids])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_add(name: str, keywords: str) -> dict:
+    """Add a negative keyword shared set.
+
+    Args:
+        name: Set name.
+        keywords: Comma-separated negative keywords.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["negativekeywordsharedsets", "add", "--name", name, "--keywords", keywords, "--format", "json"]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_update(
+    id: str,
+    name: str | None = None,
+    keywords: str | None = None,
+) -> dict:
+    """Update a negative keyword shared set.
+
+    Args:
+        id: Set ID.
+        name: New set name (optional).
+        keywords: New comma-separated negative keywords (optional).
+    """
+    args = ["negativekeywordsharedsets", "update", "--id", id]
+    if name:
+        args.extend(["--name", name])
+    if keywords:
+        args.extend(["--keywords", keywords])
+    args.extend(["--format", "json"])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_delete(id: str) -> dict:
+    """Delete a negative keyword shared set.
+
+    Args:
+        id: Set ID.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["negativekeywordsharedsets", "delete", "--id", id, "--format", "json"]
+    )

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -1,0 +1,68 @@
+"""Tests for negative_keyword_shared_sets MCP tools."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import server.tools
+from server.tools.negative_keyword_shared_sets import (
+    negative_keyword_shared_sets_list,
+    negative_keyword_shared_sets_add,
+    negative_keyword_shared_sets_update,
+    negative_keyword_shared_sets_delete,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+SAMPLE_SETS = [
+    {"Id": 100, "Name": "Block list", "NegativeKeywords": ["free", "cheap"]},
+]
+
+
+def _mock_runner(return_value):
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_nkss_list():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+        result = negative_keyword_shared_sets_list()
+        assert len(result) == 1
+
+
+def test_nkss_list_with_ids():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+        result = negative_keyword_shared_sets_list(ids="100")
+        assert len(result) == 1
+
+
+def test_nkss_list_empty():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner([])):
+        result = negative_keyword_shared_sets_list()
+        assert result == []
+
+
+def test_nkss_add():
+    mock_result = {"Id": 200}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_add(name="New list", keywords="bad,word")
+        assert result["Id"] == 200
+
+
+def test_nkss_update():
+    mock_result = {"success": True}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_update(id="100", name="Updated")
+        assert result["success"] is True
+
+
+def test_nkss_delete():
+    mock_result = {"success": True}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_delete(id="100")
+        assert result["success"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -79,6 +79,11 @@ EXPECTED_TOOLS = {
     "negative_keywords_add",
     "negative_keywords_update",
     "negative_keywords_delete",
+    # Negative Keyword Shared Sets (4 tools)
+    "negative_keyword_shared_sets_list",
+    "negative_keyword_shared_sets_add",
+    "negative_keyword_shared_sets_update",
+    "negative_keyword_shared_sets_delete",
     # Smart Targets (4 tools)
     "smart_targets_list",
     "smart_targets_add",


### PR DESCRIPTION
## Summary
- Adds 4 MCP tools for negative keyword shared sets: `negative_keyword_shared_sets_list`, `negative_keyword_shared_sets_add`, `negative_keyword_shared_sets_update`, `negative_keyword_shared_sets_delete`
- Wraps the `direct-cli negativekeywordsharedsets` command group (get/add/update/delete)
- Unit 10 of Issue #43

## Test plan
- [x] 6 unit tests pass (`tests/test_negative_keyword_shared_sets.py`)
- [x] Server registration test updated and passing (`tests/test_server.py`)
- [x] Full test suite passes (291 passed, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)