### PR TITLE
fix(ads): align parameters with direct-cli + add archive/unarchive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ server/main.py (MCP)        — FastMCP server (stdio transport)
        ↑
 server/auth/                — OAuth 2.0 module (httpx)
 server/cli/runner.py        — subprocess wrapper over `direct`
-server/tools/               — 75 MCP tools across 26 modules
+server/tools/               — 79 MCP tools across 27 modules
        ↑
 skills/                     — domain knowledge (SKILL.md files)
        ↑
@@ -161,6 +161,7 @@ yandex-direct-mcp-plugin/
 │       ├── feeds.py             # feeds_list/add/update/delete
 │       ├── keywords.py          # keywords_list/update/add/delete/suspend/resume
 │       ├── leads.py             # leads_list
+│       ├── negative_keyword_shared_sets.py # negative_keyword_shared_sets_list/add/update/delete
 │       ├── negative_keywords.py # negative_keywords_list/add/update/delete
 │       ├── reports.py           # reports_get
 │       ├── research.py          # keywords_has_volume/deduplicate
@@ -184,7 +185,7 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (75 total) + 1 Prompt
+## MCP Tools (79 total) + 1 Prompt
 
 | Tool | Purpose |
 |---|---|
@@ -245,6 +246,10 @@ yandex-direct-mcp-plugin/
 | `negative_keywords_add` | Add negative keywords |
 | `negative_keywords_update` | Update negative keywords |
 | `negative_keywords_delete` | Delete negative keywords |
+| `negative_keyword_shared_sets_list` | List negative keyword shared sets |
+| `negative_keyword_shared_sets_add` | Add negative keyword shared set |
+| `negative_keyword_shared_sets_update` | Update negative keyword shared set |
+| `negative_keyword_shared_sets_delete` | Delete negative keyword shared set |
 | `smart_targets_list` | List smart targets |
 | `smart_targets_add` | Add smart target |
 | `smart_targets_update` | Update smart target |

--- a/server/main.py
+++ b/server/main.py
@@ -29,6 +29,7 @@ import server.tools.feeds  # noqa: E402, F401
 import server.tools.images  # noqa: E402, F401
 import server.tools.keywords  # noqa: E402, F401
 import server.tools.leads  # noqa: E402, F401
+import server.tools.negative_keyword_shared_sets  # noqa: E402, F401
 import server.tools.negative_keywords  # noqa: E402, F401
 import server.tools.reports  # noqa: E402, F401
 import server.tools.research  # noqa: E402, F401

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -63,47 +63,42 @@ def ads_list(campaign_ids: str) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def ads_add(campaign_id: str, ad_group_id: str, text: str) -> dict:
+def ads_add(ad_group_id: str, title: str | None = None, text: str | None = None, href: str | None = None) -> dict:
     """Create a new ad.
 
     Args:
-        campaign_id: Campaign ID to add the ad to.
         ad_group_id: Ad group ID to add the ad to.
-        text: Ad text content.
+        title: Ad title (optional).
+        text: Ad text content (optional).
+        href: Ad URL (optional).
     """
+    args = ["ads", "add", "--adgroup-id", ad_group_id]
+    if title:
+        args.extend(["--title", title])
+    if text:
+        args.extend(["--text", text])
+    if href:
+        args.extend(["--href", href])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "ads",
-            "add",
-            "--campaign-id",
-            campaign_id,
-            "--ad-group-id",
-            ad_group_id,
-            "--text",
-            text,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def ads_update(id: str, text: str) -> dict:
+def ads_update(id: str, extra_json: str | None = None) -> dict:
     """Update an ad.
 
     Args:
         id: Ad ID to update.
-        text: New ad text.
+        extra_json: JSON string with fields to update (e.g. '{"TextAd": {"Title": "New"}}').
     """
-
+    args = ["ads", "update", "--id", id]
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        ["ads", "update", "--id", id, "--text", text, "--format", "json"]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
@@ -179,4 +174,42 @@ def ads_resume(ids: str) -> dict:
 
     runner = get_runner()
     result = runner.run_json(["ads", "resume", "--ids", ids, "--format", "json"])
+    return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def ads_archive(ids: str) -> dict:
+    """Archive ads.
+
+    Args:
+        ids: Comma-separated ad IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["ads", "archive", "--ids", ids, "--format", "json"])
+    return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def ads_unarchive(ids: str) -> dict:
+    """Unarchive ads.
+
+    Args:
+        ids: Comma-separated ad IDs (max 10).
+    """
+    from server.tools.helpers import check_batch_limit
+
+    batch_error = check_batch_limit(ids)
+    if batch_error:
+        return batch_error.__dict__
+
+    runner = get_runner()
+    result = runner.run_json(["ads", "unarchive", "--ids", ids, "--format", "json"])
     return result

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -1,0 +1,72 @@
+"""MCP tools for negative keyword shared sets management."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_list(ids: str | None = None) -> list[dict] | dict:
+    """List negative keyword shared sets.
+
+    Args:
+        ids: Comma-separated set IDs (optional).
+    """
+    args = ["negativekeywordsharedsets", "get", "--format", "json"]
+    if ids:
+        args.extend(["--ids", ids])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_add(name: str, keywords: str) -> dict:
+    """Add a negative keyword shared set.
+
+    Args:
+        name: Set name.
+        keywords: Comma-separated negative keywords.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["negativekeywordsharedsets", "add", "--name", name, "--keywords", keywords, "--format", "json"]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_update(
+    id: str,
+    name: str | None = None,
+    keywords: str | None = None,
+) -> dict:
+    """Update a negative keyword shared set.
+
+    Args:
+        id: Set ID.
+        name: New set name (optional).
+        keywords: New comma-separated negative keywords (optional).
+    """
+    args = ["negativekeywordsharedsets", "update", "--id", id]
+    if name:
+        args.extend(["--name", name])
+    if keywords:
+        args.extend(["--keywords", keywords])
+    args.extend(["--format", "json"])
+    runner = get_runner()
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def negative_keyword_shared_sets_delete(id: str) -> dict:
+    """Delete a negative keyword shared set.
+
+    Args:
+        id: Set ID.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["negativekeywordsharedsets", "delete", "--id", id, "--format", "json"]
+    )

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -13,6 +13,8 @@ from server.tools.ads import (
     ads_moderate,
     ads_suspend,
     ads_resume,
+    ads_archive,
+    ads_unarchive,
 )
 
 
@@ -77,31 +79,31 @@ class TestAdsCrudOperations:
         with patch(
             "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
         ):
-            result = ads_add(campaign_id="12345", ad_group_id="1", text="New ad text")
+            result = ads_add(ad_group_id="1", text="New ad text")
             assert result["Id"] == 999
 
     def test_ads_update(self):
         """Test updating an ad."""
-        mock_result = {"Id": 111, "Text": "Updated ad text"}
+        mock_result = {"Id": 111, "Status": "SUSPENDED"}
         with patch(
             "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
         ):
-            result = ads_update(id="111", text="Updated ad text")
+            result = ads_update(id="111", extra_json='{"Status": "SUSPENDED"}')
             assert result["Id"] == 111
 
     def test_ads_update_argv_composition(self):
         """Test that update passes correct argv to CLI."""
         runner = _mock_runner({"Id": 111})
         with patch("server.tools.ads.get_runner", return_value=runner):
-            ads_update(id="111", text="New text")
+            ads_update(id="111", extra_json='{"TextAd": {"Title": "New"}}')
             runner.run_json.assert_called_once_with(
                 [
                     "ads",
                     "update",
                     "--id",
                     "111",
-                    "--text",
-                    "New text",
+                    "--json",
+                    '{"TextAd": {"Title": "New"}}',
                     "--format",
                     "json",
                 ]
@@ -168,5 +170,37 @@ class TestAdsCrudOperations:
         """Test batch limit validation for resume."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
         result = ads_resume(ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
+    def test_ads_archive_success(self):
+        """Test archiving ads."""
+        mock_result = {"success": True}
+        with patch(
+            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
+        ):
+            result = ads_archive(ids="111,222")
+            assert result["success"] is True
+
+    def test_ads_archive_batch_limit(self):
+        """Test batch limit validation for archive."""
+        ids = ",".join(str(i) for i in range(1, 12))
+        result = ads_archive(ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
+    def test_ads_unarchive_success(self):
+        """Test unarchiving ads."""
+        mock_result = {"success": True}
+        with patch(
+            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
+        ):
+            result = ads_unarchive(ids="111,222")
+            assert result["success"] is True
+
+    def test_ads_unarchive_batch_limit(self):
+        """Test batch limit validation for unarchive."""
+        ids = ",".join(str(i) for i in range(1, 12))
+        result = ads_unarchive(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -1,0 +1,68 @@
+"""Tests for negative_keyword_shared_sets MCP tools."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import server.tools
+from server.tools.negative_keyword_shared_sets import (
+    negative_keyword_shared_sets_list,
+    negative_keyword_shared_sets_add,
+    negative_keyword_shared_sets_update,
+    negative_keyword_shared_sets_delete,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+SAMPLE_SETS = [
+    {"Id": 100, "Name": "Block list", "NegativeKeywords": ["free", "cheap"]},
+]
+
+
+def _mock_runner(return_value):
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_nkss_list():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+        result = negative_keyword_shared_sets_list()
+        assert len(result) == 1
+
+
+def test_nkss_list_with_ids():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+        result = negative_keyword_shared_sets_list(ids="100")
+        assert len(result) == 1
+
+
+def test_nkss_list_empty():
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner([])):
+        result = negative_keyword_shared_sets_list()
+        assert result == []
+
+
+def test_nkss_add():
+    mock_result = {"Id": 200}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_add(name="New list", keywords="bad,word")
+        assert result["Id"] == 200
+
+
+def test_nkss_update():
+    mock_result = {"success": True}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_update(id="100", name="Updated")
+        assert result["success"] is True
+
+
+def test_nkss_delete():
+    mock_result = {"success": True}
+    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+        result = negative_keyword_shared_sets_delete(id="100")
+        assert result["success"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -79,6 +79,11 @@ EXPECTED_TOOLS = {
     "negative_keywords_add",
     "negative_keywords_update",
     "negative_keywords_delete",
+    # Negative Keyword Shared Sets (4 tools)
+    "negative_keyword_shared_sets_list",
+    "negative_keyword_shared_sets_add",
+    "negative_keyword_shared_sets_update",
+    "negative_keyword_shared_sets_delete",
     # Smart Targets (4 tools)
     "smart_targets_list",
     "smart_targets_add",


### PR DESCRIPTION
## Summary
- Fix `ads_add`: align with CLI — use `--adgroup-id` instead of `--campaign-id`, add `--title`/`--href` options
- Fix `ads_update`: use `--json` for flexible updates instead of `--text`
- Add `ads_archive` and `ads_unarchive` tools (previously missing)

Part of #43 CLI parity cleanup.

## Test plan
- [x] `pytest tests/test_ads.py` — 19 tests pass
- [ ] Verify against live CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)