### PR TITLE
feat(dynamic-ads): add dynamic_ads tools for webpage targets

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -24,6 +24,7 @@ import server.tools.changes  # noqa: E402, F401
 import server.tools.clients  # noqa: E402, F401
 import server.tools.creatives  # noqa: E402, F401
 import server.tools.dictionaries  # noqa: E402, F401
+import server.tools.dynamic_ads  # noqa: E402, F401
 import server.tools.dynamic_targets  # noqa: E402, F401
 import server.tools.feeds  # noqa: E402, F401
 import server.tools.images  # noqa: E402, F401

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -1,0 +1,71 @@
+"""MCP tools for dynamic ad (webpage) management."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool()
+@handle_cli_errors
+def dynamic_ads_list(ad_group_ids: str) -> list[dict] | dict:
+    """List dynamic ad targets (webpages).
+
+    Args:
+        ad_group_ids: Comma-separated ad group IDs.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["dynamicads", "get", "--adgroup-ids", ad_group_ids, "--format", "json"]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def dynamic_ads_add(ad_group_id: str, target_data: str) -> dict:
+    """Add a dynamic ad target (webpage).
+
+    Args:
+        ad_group_id: Ad group ID.
+        target_data: JSON string with target data (must include Name and Conditions).
+    """
+    runner = get_runner()
+    return runner.run_json(
+        [
+            "dynamicads",
+            "add",
+            "--adgroup-id",
+            ad_group_id,
+            "--json",
+            target_data,
+            "--format",
+            "json",
+        ]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def dynamic_ads_update(id: str, extra_json: str) -> dict:
+    """Update a dynamic ad target (webpage).
+
+    Args:
+        id: Target ID.
+        extra_json: JSON string with fields to update.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["dynamicads", "update", "--id", id, "--json", extra_json, "--format", "json"]
+    )
+
+
+@mcp.tool()
+@handle_cli_errors
+def dynamic_ads_delete(id: str) -> dict:
+    """Delete a dynamic ad target (webpage).
+
+    Args:
+        id: Target ID.
+    """
+    runner = get_runner()
+    return runner.run_json(
+        ["dynamicads", "delete", "--id", id, "--format", "json"]
+    )

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -1,0 +1,72 @@
+"""Tests for dynamic_ads MCP tools."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import server.tools
+from server.tools.dynamic_ads import (
+    dynamic_ads_list,
+    dynamic_ads_add,
+    dynamic_ads_update,
+    dynamic_ads_delete,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+SAMPLE_TARGETS = [
+    {
+        "Id": 100,
+        "AdGroupId": 200,
+        "Conditions": [
+            {"Operand": "URL", "Operator": "CONTAINS", "Arguments": ["sale"]}
+        ],
+    },
+]
+
+
+def _mock_runner(return_value):
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_dynamic_ads_list():
+    with patch(
+        "server.tools.dynamic_ads.get_runner", return_value=_mock_runner(SAMPLE_TARGETS)
+    ):
+        result = dynamic_ads_list(ad_group_ids="200")
+        assert len(result) == 1
+
+
+def test_dynamic_ads_list_empty():
+    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner([])):
+        result = dynamic_ads_list(ad_group_ids="200")
+        assert result == []
+
+
+def test_dynamic_ads_add():
+    mock_result = {"Id": 300}
+    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+        result = dynamic_ads_add(
+            ad_group_id="200", target_data='{"Name": "Test", "Conditions": []}'
+        )
+        assert result["Id"] == 300
+
+
+def test_dynamic_ads_update():
+    mock_result = {"success": True}
+    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+        result = dynamic_ads_update(id="100", extra_json='{"Conditions": []}')
+        assert result["success"] is True
+
+
+def test_dynamic_ads_delete():
+    mock_result = {"success": True}
+    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+        result = dynamic_ads_delete(id="100")
+        assert result["success"] is True


### PR DESCRIPTION
## Summary
- Add `dynamic_ads_list`, `dynamic_ads_add`, `dynamic_ads_update`, `dynamic_ads_delete` MCP tools
- Wraps the `dynamicads` CLI group (Webpages/Dynamic Text Ad targets)
- Note: separate from existing `dynamic_targets` which wraps `dynamictargets`

Part of #43 CLI parity cleanup.

## Test plan
- [x] `pytest tests/test_dynamic_ads.py` — 5 tests pass
- [ ] Verify against live CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)