### PR TITLE
docs: update tool tables and counts for issue #43

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ server/main.py (MCP)        — FastMCP server (stdio transport)
        ↑
 server/auth/                — OAuth 2.0 module (httpx)
 server/cli/runner.py        — subprocess wrapper over `direct`
-server/tools/               — 75 MCP tools across 26 modules
+server/tools/               — 105 MCP tools across 31 modules
        ↑
 skills/                     — domain knowledge (SKILL.md files)
        ↑
@@ -145,27 +145,32 @@ yandex-direct-mcp-plugin/
 │       ├── helpers.py           # Shared validation (parse_ids, check_batch_limit)
 │       ├── adextensions.py      # adextensions_list/add/delete
 │       ├── adgroups.py          # adgroups_list/add/update/delete
-│       ├── ads.py               # ads_list/add/update/delete/moderate/suspend/resume
+│       ├── ads.py               # ads_list/add/update/delete/moderate/suspend/resume/archive/unarchive
 │       ├── images.py            # adimages_list/add/delete
 │       ├── agency.py            # agency_clients_list/add/delete
 │       ├── audience.py          # audience_targets_list/add/delete/suspend/resume
 │       ├── auth_tools.py        # auth_status, auth_setup, auth_login
 │       ├── bids.py              # bids_list/set
 │       ├── bidmodifiers.py      # bidmodifiers_list/set/toggle/delete
-│       ├── campaigns.py         # campaigns_list/update/add/delete/archive/unarchive
-│       ├── changes.py           # changes_check/checkcamp/checkdict
+│       ├── campaigns.py         # campaigns_list/update/add/delete/archive/unarchive/suspend/resume
+│       ├── businesses.py        # businesses_list
+changes.py           # changes_check/checkcamp/checkdict
 │       ├── clients.py           # clients_get/update
 │       ├── creatives.py         # creatives_list
 │       ├── dictionaries.py      # dictionaries_get
 │       ├── dynamic_targets.py   # dynamic_targets_list/add/update/delete
+│       ├── dynamic_ads.py       # dynamic_ads_list/add/update/delete
 │       ├── feeds.py             # feeds_list/add/update/delete
-│       ├── keywords.py          # keywords_list/update/add/delete/suspend/resume
+│       ├── keywords.py          # keyword_bids.py      # keyword_bids_list/set
+keywords_list/update/add/delete/suspend/resume/archive/unarchive
 │       ├── leads.py             # leads_list
+│       ├── negative_keyword_shared_sets.py # negative_keyword_shared_sets_list/add/update/delete
 │       ├── negative_keywords.py # negative_keywords_list/add/update/delete
-│       ├── reports.py           # reports_get
+│       ├── reports.py           # reports_get/list_types
 │       ├── research.py          # keywords_has_volume/deduplicate
 │       ├── retargeting.py       # retargeting_list/add/delete
 │       ├── sitelinks.py         # sitelinks_list/add/delete
+│       ├── smart_ad_targets.py  # smart_ad_targets_list/add/update/delete
 │       ├── smart_targets.py     # smart_targets_list/add/update/delete
 │       ├── turbo_pages.py       # turbo_pages_list
 │       └── vcards.py            # vcards_list/add/delete
@@ -184,7 +189,7 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (75 total) + 1 Prompt
+## MCP Tools (105 total) + 1 Prompt
 
 | Tool | Purpose |
 |---|---|
@@ -194,6 +199,8 @@ yandex-direct-mcp-plugin/
 | `campaigns_delete` | Delete campaigns |
 | `campaigns_archive` | Archive campaigns |
 | `campaigns_unarchive` | Unarchive campaigns |
+| `campaigns_suspend` | Suspend campaigns |
+| `campaigns_resume` | Resume suspended campaigns |
 | `adgroups_list` | List ad groups |
 | `adgroups_add` | Create ad group |
 | `adgroups_update` | Update ad group |
@@ -205,14 +212,20 @@ yandex-direct-mcp-plugin/
 | `ads_moderate` | Submit ads for moderation |
 | `ads_suspend` | Suspend ads |
 | `ads_resume` | Resume suspended ads |
+| `ads_archive` | Archive ads |
+| `ads_unarchive` | Unarchive ads |
 | `keywords_list` | List keywords by campaign IDs |
 | `keywords_update` | Update keyword bid (micro-units) |
 | `keywords_add` | Add keywords |
 | `keywords_delete` | Delete keywords |
 | `keywords_suspend` | Suspend keywords |
 | `keywords_resume` | Resume keywords |
+| `keywords_archive` | Archive keywords |
+| `keywords_unarchive` | Unarchive keywords |
 | `bids_list` | List bids |
 | `bids_set` | Set bid for campaign |
+| `keyword_bids_list` | List keyword bids |
+| `keyword_bids_set` | Set keyword bids |
 | `bidmodifiers_list` | List bid modifiers |
 | `bidmodifiers_set` | Set bid modifier |
 | `bidmodifiers_toggle` | Toggle modifier on/off |
@@ -241,14 +254,26 @@ yandex-direct-mcp-plugin/
 | `dynamic_targets_add` | Add dynamic target |
 | `dynamic_targets_update` | Update dynamic target |
 | `dynamic_targets_delete` | Delete dynamic targets |
+| `dynamic_ads_list` | List dynamic ad targets (webpages) |
+| `dynamic_ads_add` | Add dynamic ad target |
+| `dynamic_ads_update` | Update dynamic ad target |
+| `dynamic_ads_delete` | Delete dynamic ad target |
 | `negative_keywords_list` | List negative keywords |
 | `negative_keywords_add` | Add negative keywords |
 | `negative_keywords_update` | Update negative keywords |
 | `negative_keywords_delete` | Delete negative keywords |
+| `negative_keyword_shared_sets_list` | List negative keyword shared sets |
+| `negative_keyword_shared_sets_add` | Add negative keyword shared set |
+| `negative_keyword_shared_sets_update` | Update negative keyword shared set |
+| `negative_keyword_shared_sets_delete` | Delete negative keyword shared set |
 | `smart_targets_list` | List smart targets |
 | `smart_targets_add` | Add smart target |
 | `smart_targets_update` | Update smart target |
 | `smart_targets_delete` | Delete smart targets |
+| `smart_ad_targets_list` | List smart ad targets |
+| `smart_ad_targets_add` | Add smart ad target |
+| `smart_ad_targets_update` | Update smart ad target |
+| `smart_ad_targets_delete` | Delete smart ad target |
 | `dictionaries_get` | Get dictionary data |
 | `changes_check` | Check changes since timestamp |
 | `changes_checkcamp` | Check campaign changes |
@@ -258,6 +283,7 @@ yandex-direct-mcp-plugin/
 | `agency_clients_list` | List agency clients |
 | `agency_clients_add` | Add client to agency |
 | `agency_clients_delete` | Remove client from agency |
+| `businesses_list` | List businesses |
 | `keywords_has_volume` | Check keyword search volume |
 | `keywords_deduplicate` | Deduplicate keywords |
 | `leads_list` | List leads |
@@ -268,6 +294,7 @@ yandex-direct-mcp-plugin/
 | `creatives_list` | List creatives |
 | `turbo_pages_list` | List turbo pages |
 | `reports_get` | Campaign statistics for date range |
+| `reports_list_types` | List available report types |
 | `auth_status` | Check OAuth token validity |
 | `auth_setup` | Submit authorization code or direct token |
 | `auth_login` | Interactive OAuth flow with elicitation |

--- a/README.md
+++ b/README.md
@@ -138,20 +138,115 @@ OAuth-приложение само по себе не даёт доступ к 
 
 Или через переменные окружения `CLAUDE_PLUGIN_OPTION_client_id` / `CLAUDE_PLUGIN_OPTION_client_secret`.
 
-## MCP Tools
+## MCP Tools (105 total)
 
 | Tool | Description |
 |---|---|
 | `campaigns_list` | List campaigns (filter by state) |
 | `campaigns_update` | Enable/disable campaigns |
+| `campaigns_add` | Create campaign |
+| `campaigns_delete` | Delete campaigns |
+| `campaigns_archive` | Archive campaigns |
+| `campaigns_unarchive` | Unarchive campaigns |
+| `campaigns_suspend` | Suspend campaigns |
+| `campaigns_resume` | Resume suspended campaigns |
+| `adgroups_list` | List ad groups |
+| `adgroups_add` | Create ad group |
+| `adgroups_update` | Update ad group |
+| `adgroups_delete` | Delete ad groups |
 | `ads_list` | List ads in a campaign |
+| `ads_add` | Create ad |
+| `ads_update` | Update ad |
+| `ads_delete` | Delete ads |
+| `ads_moderate` | Submit ads for moderation |
+| `ads_suspend` | Suspend ads |
+| `ads_resume` | Resume suspended ads |
+| `ads_archive` | Archive ads |
+| `ads_unarchive` | Unarchive ads |
 | `keywords_list` | List keywords in a campaign |
 | `keywords_update` | Update keyword bids |
+| `keywords_add` | Add keywords |
+| `keywords_delete` | Delete keywords |
+| `keywords_suspend` | Suspend keywords |
+| `keywords_resume` | Resume keywords |
+| `keywords_archive` | Archive keywords |
+| `keywords_unarchive` | Unarchive keywords |
+| `bids_list` | List bids |
+| `bids_set` | Set bid for campaign |
+| `keyword_bids_list` | List keyword bids |
+| `keyword_bids_set` | Set keyword bids |
+| `bidmodifiers_list` | List bid modifiers |
+| `bidmodifiers_set` | Set bid modifier |
+| `bidmodifiers_toggle` | Toggle modifier on/off |
+| `bidmodifiers_delete` | Delete bid modifiers |
+| `sitelinks_list` | List sitelinks sets |
+| `sitelinks_add` | Add sitelinks set |
+| `sitelinks_delete` | Delete sitelinks |
+| `vcards_list` | List vCards |
+| `vcards_add` | Add vCard |
+| `vcards_delete` | Delete vCards |
+| `adimages_list` | List ad images |
+| `adimages_add` | Add ad image |
+| `adimages_delete` | Delete images |
+| `adextensions_list` | List ad extensions |
+| `adextensions_add` | Add extension |
+| `adextensions_delete` | Delete extensions |
+| `audience_targets_list` | List audience targets |
+| `audience_targets_add` | Add audience target |
+| `audience_targets_delete` | Delete targets |
+| `audience_targets_suspend` | Suspend targets |
+| `audience_targets_resume` | Resume targets |
+| `retargeting_list` | List retargeting lists |
+| `retargeting_add` | Add retargeting list |
+| `retargeting_delete` | Delete retargeting lists |
+| `dynamic_targets_list` | List dynamic targets |
+| `dynamic_targets_add` | Add dynamic target |
+| `dynamic_targets_update` | Update dynamic target |
+| `dynamic_targets_delete` | Delete dynamic targets |
+| `dynamic_ads_list` | List dynamic ad targets (webpages) |
+| `dynamic_ads_add` | Add dynamic ad target |
+| `dynamic_ads_update` | Update dynamic ad target |
+| `dynamic_ads_delete` | Delete dynamic ad target |
+| `negative_keywords_list` | List negative keywords |
+| `negative_keywords_add` | Add negative keywords |
+| `negative_keywords_update` | Update negative keywords |
+| `negative_keywords_delete` | Delete negative keywords |
+| `negative_keyword_shared_sets_list` | List negative keyword shared sets |
+| `negative_keyword_shared_sets_add` | Add shared set |
+| `negative_keyword_shared_sets_update` | Update shared set |
+| `negative_keyword_shared_sets_delete` | Delete shared set |
+| `smart_targets_list` | List smart targets |
+| `smart_targets_add` | Add smart target |
+| `smart_targets_update` | Update smart target |
+| `smart_targets_delete` | Delete smart targets |
+| `smart_ad_targets_list` | List smart ad targets |
+| `smart_ad_targets_add` | Add smart ad target |
+| `smart_ad_targets_update` | Update smart ad target |
+| `smart_ad_targets_delete` | Delete smart ad target |
+| `dictionaries_get` | Get dictionary data |
+| `changes_check` | Check changes since timestamp |
+| `changes_checkcamp` | Check campaign changes |
+| `changes_checkdict` | Check dictionary changes |
+| `clients_get` | Get client info |
+| `clients_update` | Update client |
+| `agency_clients_list` | List agency clients |
+| `agency_clients_add` | Add client to agency |
+| `agency_clients_delete` | Remove client from agency |
+| `businesses_list` | List businesses |
+| `keywords_has_volume` | Check keyword search volume |
+| `keywords_deduplicate` | Deduplicate keywords |
+| `leads_list` | List leads |
+| `feeds_list` | List feeds |
+| `feeds_add` | Add feed |
+| `feeds_update` | Update feed |
+| `feeds_delete` | Delete feeds |
+| `creatives_list` | List creatives |
+| `turbo_pages_list` | List turbo pages |
 | `reports_get` | Get campaign statistics |
+| `reports_list_types` | List available report types |
 | `auth_status` | Check OAuth token status |
 | `auth_setup` | Submit authorization code or direct token |
 | `auth_login` | Interactive OAuth flow (browser + code input via elicitation) |
-
 ## Skills
 
 - `/yandex-direct:yandex-direct` — campaign management guidance

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 
 Не пытайся вызывать другие tools пока авторизация не пройдена — они вернут ошибку.
 
-## Доступные MCP Tools (83)
+## Доступные MCP Tools (105)
 
 ### Кампании
 | Tool | Описание | Параметры |
@@ -29,6 +29,8 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `campaigns_delete` | Удалить кампании | `ids` (max 10) |
 | `campaigns_archive` | Архивировать кампании | `ids` (max 10) |
 | `campaigns_unarchive` | Разархивировать кампании | `ids` (max 10) |
+| `campaigns_suspend` | Приостановить кампании | `ids` (max 10) |
+| `campaigns_resume` | Возобновить кампании | `ids` (max 10) |
 
 ### Группы объявлений
 | Tool | Описание | Параметры |
@@ -48,6 +50,8 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `ads_moderate` | Отправить на модерацию | `ids` (max 10) |
 | `ads_suspend` | Приостановить объявления | `ids` (max 10) |
 | `ads_resume` | Возобновить объявления | `ids` (max 10) |
+| `ads_archive` | Архивировать объявления | `ids` (max 10) |
+| `ads_unarchive` | Разархивировать объявления | `ids` (max 10) |
 
 ### Ключевые слова
 | Tool | Описание | Параметры |
@@ -58,12 +62,20 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `keywords_delete` | Удалить ключевые слова | `ids` (max 10) |
 | `keywords_suspend` | Приостановить ключевые слова | `ids` (max 10) |
 | `keywords_resume` | Возобновить ключевые слова | `ids` (max 10) |
+| `keywords_archive` | Архивировать ключевые слова | `ids` (max 10) |
+| `keywords_unarchive` | Разархивировать ключевые слова | `ids` (max 10) |
 
 ### Ставки
 | Tool | Описание | Параметры |
 |---|---|---|
 | `bids_list` | Список ставок | `campaign_ids` (max 10) |
 | `bids_set` | Установить ставку | `campaign_id`, `bid`, `context_bid?` |
+
+### Ставки ключевых слов
+| Tool | Описание | Параметры |
+|---|---|---|
+| `keyword_bids_list` | Список ставок ключевых слов | `campaign_ids?`, `ad_group_ids?`, `keyword_ids?` |
+| `keyword_bids_set` | Установить ставку ключевого слова | `keyword_id`, `search_bid?`, `network_bid?` |
 
 ### Корректировки ставок
 | Tool | Описание | Параметры |
@@ -104,14 +116,26 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `dynamic_targets_add` | Добавить динамический таргет | `ad_group_id`, `conditions` (JSON) |
 | `dynamic_targets_update` | Обновить динамический таргет | `id`, `conditions` (JSON) |
 | `dynamic_targets_delete` | Удалить динамические таргеты | `ids` (max 10) |
+| `dynamic_ads_list` | Список динамических объявлений (webpages) | `ad_group_ids` |
+| `dynamic_ads_add` | Добавить динамическое объявление | `ad_group_id`, `target_data` (JSON) |
+| `dynamic_ads_update` | Обновить динамическое объявление | `id`, `extra_json` |
+| `dynamic_ads_delete` | Удалить динамическое объявление | `id` |
 | `negative_keywords_list` | Список минус-слов | `campaign_ids` (max 10) |
 | `negative_keywords_add` | Добавить минус-слова | `campaign_id`, `keywords` |
 | `negative_keywords_update` | Обновить минус-слова | `id`, `keywords` |
 | `negative_keywords_delete` | Удалить минус-слова | `ids` (max 10) |
+| `negative_keyword_shared_sets_list` | Список общих наборов минус-слов | `ids?` |
+| `negative_keyword_shared_sets_add` | Добавить набор минус-слов | `name`, `keywords` |
+| `negative_keyword_shared_sets_update` | Обновить набор минус-слов | `id`, `name?`, `keywords?` |
+| `negative_keyword_shared_sets_delete` | Удалить набор минус-слов | `id` |
 | `smart_targets_list` | Список смарт-таргетов | `ad_group_ids` (max 10) |
 | `smart_targets_add` | Добавить смарт-таргет | `ad_group_id`, `conditions` (JSON) |
 | `smart_targets_update` | Обновить смарт-таргет | `id`, `conditions` (JSON) |
 | `smart_targets_delete` | Удалить смарт-таргеты | `ids` (max 10) |
+| `smart_ad_targets_list` | Список смарт-таргетов объявлений | `ad_group_ids` |
+| `smart_ad_targets_add` | Добавить смарт-таргет объявления | `ad_group_id`, `target_type`, `extra_json?` |
+| `smart_ad_targets_update` | Обновить смарт-таргет объявления | `id`, `extra_json?` |
+| `smart_ad_targets_delete` | Удалить смарт-таргет объявления | `id` |
 
 ### Справочники и изменения
 | Tool | Описание | Параметры |
@@ -130,6 +154,11 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `agency_clients_add` | Добавить клиента агентству | `login`, `client_info` (JSON) |
 | `agency_clients_delete` | Удалить клиента из агентства | `login`, `client_login` |
 
+### Бизнесы
+| Tool | Описание | Параметры |
+|---|---|---|
+| `businesses_list` | Список бизнесов | `ids?` |
+
 ### Исследования и отчёты
 | Tool | Описание | Параметры |
 |---|---|---|
@@ -137,6 +166,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `keywords_deduplicate` | Дедупликация ключевых слов | `keywords` |
 | `leads_list` | Список лидов | `campaign_ids`, `date_from?`, `date_to?` |
 | `reports_get` | Статистика кампаний | `date_from?`, `date_to?` |
+| `reports_list_types` | Список типов отчётов | — |
 
 ### Фиды, креативы, Турбо-страницы
 | Tool | Описание | Параметры |


### PR DESCRIPTION
## Summary
- Update CLAUDE.md, SKILL.md, and README.md with 22 new tools from issue #43 feature branches
- Tool count updated from 83 to 105 across 31 modules
- New tools documented: campaigns_suspend/resume, ads_archive/unarchive, keywords_archive/unarchive, reports_list_types, keyword_bids_list/set, dynamic_ads_*, negative_keyword_shared_sets_*, smart_ad_targets_*, businesses_list

Closes #43 (Unit 12 — documentation)

## Test plan
- [x] All three files have consistent 105 tool count
- [x] New tools match signatures verified from feature branches
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)