### PR TITLE
fix(issue-43): restore CLI parity for update tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Just ask in natural language — the plugin handles the rest:
   → ads_list(campaign_ids="12345") → count
 
 > отключи кампанию 67890
-  → campaigns_update(id="67890", state="OFF")
+  → campaigns_update(id="67890", status="OFF")
 
 > покажи ключевые слова кампании 12345
   → keywords_list(campaign_ids="12345")
@@ -297,8 +297,8 @@ mcp__yandex_direct__ads_list(campaign_ids="12345")
 # → [{"Id": 111, "Title": "Доставка пиццы", "Title2": "За 30 минут", "State": "ON"}, ...]
 
 # Включить/отключить кампанию
-mcp__yandex_direct__campaigns_update(id="67890", state="OFF")
-# → {"success": True, "id": 67890, "state": "OFF"}
+mcp__yandex_direct__campaigns_update(id="67890", status="OFF")
+# → {"success": True, "id": 67890, "status": "OFF"}
 
 # Ключевые слова
 mcp__yandex_direct__keywords_list(campaign_ids="12345")
@@ -341,7 +341,7 @@ mcp__yandex_direct__auth_setup(code="0000000")
 # → {"error": "invalid_grant", "message": "Неверный или просроченный код. Код действует 10 минут."}
 
 # Кампания не найдена
-mcp__yandex_direct__campaigns_update(id="999", state="ON")
+mcp__yandex_direct__campaigns_update(id="999", status="ON")
 # → {"error": "not_found", "message": "Кампания 999 не найдена в аккаунте ksamatadirect"}
 
 # Кампания принадлежит второму аккаунту (ID ~73-77М)
@@ -395,7 +395,7 @@ pytest
 | **Campaigns** |
 | 7 | Список всех кампаний | `campaigns_list()` | Массив кампаний с Id, Name, State |
 | 8 | Фильтр по статусу | `campaigns_list(state="ON")` | Только кампании с State=ON |
-| 9 | Включить кампанию | `campaigns_update(id=..., state="ON")` | `{"success": True}` |
+| 9 | Включить кампанию | `campaigns_update(id=..., status="ON")` | `{"success": True}` |
 | 10 | Несуществующая кампания | `campaigns_update(id="999")` | `{"error": "not_found"}` |
 | **Ads** |
 | 11 | Объявления в кампании | `ads_list(campaign_ids="12345")` | Массив объявлений |

--- a/docs/api/issue-43-parity.rst
+++ b/docs/api/issue-43-parity.rst
@@ -1,0 +1,103 @@
+Issue #43 CLI Parity
+====================
+
+This page captures the current CLI parity scope for issue ``#43``.
+
+In-scope groups
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - CLI group
+     - CLI command
+     - MCP tool
+     - Status
+     - Notes
+   * - ``ads``
+     - ``get``
+     - ``ads_list``
+     - implemented
+     - Campaign-scoped list wrapper with existing batch/foreign-account guards.
+   * - ``ads``
+     - ``add``
+     - ``ads_add``
+     - implemented
+     - CLI-backed wrapper.
+   * - ``ads``
+     - ``update``
+     - ``ads_update``
+     - implemented
+     - Supports ``status`` and ``extra_json``; empty updates are rejected.
+   * - ``ads``
+     - ``delete`` / ``moderate`` / ``suspend`` / ``resume`` / ``archive`` / ``unarchive``
+     - ``ads_delete`` / ``ads_moderate`` / ``ads_suspend`` / ``ads_resume`` / ``ads_archive`` / ``ads_unarchive``
+     - implemented
+     - Batch-limited wrappers.
+   * - ``campaigns``
+     - ``get``
+     - ``campaigns_list``
+     - implemented
+     - State filtering remains MCP-side.
+   * - ``campaigns``
+     - ``update``
+     - ``campaigns_update``
+     - implemented
+     - Supports ``name``, ``status``, ``budget``, and ``extra_json``; empty updates are rejected.
+   * - ``campaigns``
+     - ``add`` / ``delete`` / ``archive`` / ``unarchive`` / ``suspend`` / ``resume``
+     - matching MCP tools
+     - implemented
+     - CLI-backed wrappers.
+   * - ``keywords``
+     - ``get``
+     - ``keywords_list``
+     - implemented
+     - Campaign-scoped list wrapper.
+   * - ``keywords``
+     - ``update``
+     - ``keywords_update``
+     - implemented
+     - Supports ``bid``, ``context_bid``, ``status``, and ``extra_json``; empty updates are rejected.
+   * - ``keywords``
+     - ``add`` / ``delete`` / ``suspend`` / ``resume`` / ``archive`` / ``unarchive``
+     - matching MCP tools
+     - implemented
+     - CLI-backed wrappers.
+   * - ``reports``
+     - ``get``
+     - ``reports_get``
+     - implemented
+     - Opinionated campaign-performance wrapper retained for MCP convenience.
+   * - ``reports``
+     - ``list-types``
+     - ``reports_list_types``
+     - implemented
+     - Exposes report type discovery directly.
+
+Deferred backlog outside issue #43
+----------------------------------
+
+The following Phase 2 groups are intentionally tracked outside the acceptance scope of issue ``#43``:
+
+- ``adgroups``
+- ``bids``
+- ``bidmodifiers``
+- ``audiencetargets``
+- ``sitelinks``
+- ``vcards``
+- ``adimages``
+- ``adextensions``
+- ``dictionaries``
+- ``changes``
+- ``clients``
+- ``agencyclients``
+- ``feeds``
+- ``retargeting``
+- ``dynamictargets``
+- ``creatives``
+- ``keywordsresearch``
+- ``leads``
+- ``negativekeywords``
+- ``smarttargets``
+- ``turbopages``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,3 +10,4 @@ Claude Code plugin for managing Yandex.Direct advertising campaigns.
    api/auth
    api/cli
    api/tools
+   api/issue-43-parity

--- a/server/main.py
+++ b/server/main.py
@@ -1,9 +1,11 @@
 import sys
+from pathlib import Path
 
 # Prevent dual-import: when run as `python3 server/main.py`, register
 # the __main__ module under its canonical name so that tool modules
 # doing `from server.main import mcp` get the same instance.
 if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     sys.modules.setdefault("server.main", sys.modules["__main__"])
 
 from mcp.server.fastmcp import FastMCP

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -91,14 +91,25 @@ def ads_add(
 
 @mcp.tool()
 @handle_cli_errors
-def ads_update(id: str, extra_json: str | None = None) -> dict:
+def ads_update(
+    id: str, status: str | None = None, extra_json: str | None = None
+) -> dict:
     """Update an ad.
 
     Args:
         id: Ad ID to update.
+        status: Optional new ad status.
         extra_json: JSON string with fields to update (e.g. '{"TextAd": {"Title": "New"}}').
     """
+    if not status and not extra_json:
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: status, extra_json",
+        ).__dict__
+
     args = ["ads", "update", "--id", id]
+    if status:
+        args.extend(["--status", status])
     if extra_json:
         args.extend(["--json", extra_json])
     args.extend(["--format", "json"])

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -65,26 +65,33 @@ def ads_list(campaign_ids: str) -> list[dict] | dict:
 @handle_cli_errors
 def ads_add(
     ad_group_id: str,
+    ad_type: str | None = None,
     title: str | None = None,
     text: str | None = None,
     href: str | None = None,
+    extra_json: str | None = None,
 ) -> dict:
     """Create a new ad.
 
     Args:
         ad_group_id: Ad group ID to add the ad to.
+        ad_type: Ad type (optional).
         title: Ad title (optional).
         text: Ad text content (optional).
         href: Ad URL (optional).
+        extra_json: JSON string with additional parameters (optional).
     """
     args = ["ads", "add", "--adgroup-id", ad_group_id]
+    if ad_type:
+        args.extend(["--type", ad_type])
     if title:
         args.extend(["--title", title])
     if text:
         args.extend(["--text", text])
     if href:
         args.extend(["--href", href])
-    args.extend(["--format", "json"])
+    if extra_json:
+        args.extend(["--json", extra_json])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -112,7 +119,6 @@ def ads_update(
         args.extend(["--status", status])
     if extra_json:
         args.extend(["--json", extra_json])
-    args.extend(["--format", "json"])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -125,15 +131,9 @@ def ads_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "delete", ids)
 
 
 @mcp.tool()
@@ -144,15 +144,9 @@ def ads_moderate(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "moderate", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "moderate", ids)
 
 
 @mcp.tool()
@@ -163,15 +157,9 @@ def ads_suspend(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "suspend", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "suspend", ids)
 
 
 @mcp.tool()
@@ -182,15 +170,9 @@ def ads_resume(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "resume", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "resume", ids)
 
 
 @mcp.tool()
@@ -201,15 +183,9 @@ def ads_archive(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "archive", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "archive", ids)
 
 
 @mcp.tool()
@@ -220,12 +196,6 @@ def ads_unarchive(ids: str) -> dict:
     Args:
         ids: Comma-separated ad IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["ads", "unarchive", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "ads", "unarchive", ids)

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -30,24 +30,53 @@ def campaigns_list(state: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def campaigns_update(id: str, state: str) -> dict:
-    """Update campaign state (enable or disable).
+def campaigns_update(
+    id: str,
+    name: str | None = None,
+    status: str | None = None,
+    budget: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
+    """Update campaign fields.
 
     Args:
         id: Campaign ID to update.
-        state: New state ("ON" to enable, "OFF" to disable).
+        name: Optional new campaign name.
+        status: Optional new campaign status.
+        budget: Optional new daily budget.
+        extra_json: Optional JSON string forwarded to direct-cli --json.
     """
-    if state not in ("ON", "OFF"):
+    if not any((name, status, budget, extra_json)):
         return ToolError(
-            error="invalid_state",
-            message=f"State must be 'ON' or 'OFF', got '{state}'",
+            error="missing_update_fields",
+            message="Provide at least one of: name, status, budget, extra_json",
         ).__dict__
+
+    budget_value: str | None = None
+    if budget is not None:
+        try:
+            if int(budget) <= 0:
+                raise ValueError("Budget must be positive")
+            budget_value = budget
+        except (ValueError, TypeError):
+            return ToolError(
+                error="invalid_budget",
+                message=f"Budget must be a positive integer. Got: '{budget}'",
+            ).__dict__
 
     runner = get_runner()
     try:
-        runner.run_json(
-            ["campaigns", "update", "--id", id, "--state", state, "--format", "json"]
-        )
+        args = ["campaigns", "update", "--id", id]
+        if name:
+            args.extend(["--name", name])
+        if status:
+            args.extend(["--status", status])
+        if budget_value is not None:
+            args.extend(["--budget", budget_value])
+        if extra_json:
+            args.extend(["--json", extra_json])
+        args.extend(["--format", "json"])
+        runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
         raise
     except Exception as exc:
@@ -56,7 +85,16 @@ def campaigns_update(id: str, state: str) -> dict:
                 error="not_found", message=f"Campaign '{id}' not found"
             ).__dict__
         raise
-    return {"success": True, "id": id, "state": state}
+    result: dict[str, object] = {"success": True, "id": id}
+    if name:
+        result["name"] = name
+    if status:
+        result["status"] = status
+    if budget_value is not None:
+        result["budget"] = int(budget_value)
+    if extra_json:
+        result["extra_json"] = extra_json
+    return result
 
 
 @mcp.tool()

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -75,7 +75,6 @@ def campaigns_update(
             args.extend(["--budget", budget_value])
         if extra_json:
             args.extend(["--json", extra_json])
-        args.extend(["--format", "json"])
         runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
         raise
@@ -99,26 +98,47 @@ def campaigns_update(
 
 @mcp.tool()
 @handle_cli_errors
-def campaigns_add(name: str, start_date: str) -> dict:
+def campaigns_add(
+    name: str,
+    start_date: str,
+    campaign_type: str | None = None,
+    budget: str | None = None,
+    end_date: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Create a new campaign.
 
     Args:
         name: Campaign name.
         start_date: Campaign start date in YYYY-MM-DD format.
+        campaign_type: Campaign type (optional).
+        budget: Optional daily budget.
+        end_date: Optional campaign end date in YYYY-MM-DD format.
+        extra_json: Optional JSON string forwarded to direct-cli --json.
     """
+    budget_value: str | None = None
+    if budget is not None:
+        try:
+            if int(budget) <= 0:
+                raise ValueError("Budget must be positive")
+            budget_value = budget
+        except (ValueError, TypeError):
+            return ToolError(
+                error="invalid_budget",
+                message=f"Budget must be a positive integer. Got: '{budget}'",
+            ).__dict__
+
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "campaigns",
-            "add",
-            "--name",
-            name,
-            "--start-date",
-            start_date,
-            "--format",
-            "json",
-        ]
-    )
+    args = ["campaigns", "add", "--name", name, "--start-date", start_date]
+    if campaign_type:
+        args.extend(["--type", campaign_type])
+    if budget_value is not None:
+        args.extend(["--budget", budget_value])
+    if end_date:
+        args.extend(["--end-date", end_date])
+    if extra_json:
+        args.extend(["--json", extra_json])
+    result = runner.run_json(args)
     return result
 
 
@@ -130,15 +150,9 @@ def campaigns_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated campaign IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["campaigns", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "campaigns", "delete", ids)
 
 
 @mcp.tool()
@@ -149,15 +163,9 @@ def campaigns_archive(ids: str) -> dict:
     Args:
         ids: Comma-separated campaign IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["campaigns", "archive", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "campaigns", "archive", ids)
 
 
 @mcp.tool()
@@ -168,17 +176,9 @@ def campaigns_unarchive(ids: str) -> dict:
     Args:
         ids: Comma-separated campaign IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["campaigns", "unarchive", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "campaigns", "unarchive", ids)
 
 
 @mcp.tool()
@@ -189,15 +189,9 @@ def campaigns_suspend(ids: str) -> dict:
     Args:
         ids: Comma-separated campaign IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["campaigns", "suspend", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "campaigns", "suspend", ids)
 
 
 @mcp.tool()
@@ -208,12 +202,6 @@ def campaigns_resume(ids: str) -> dict:
     Args:
         ids: Comma-separated campaign IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["campaigns", "resume", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "campaigns", "resume", ids)

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -36,8 +36,6 @@ def dynamic_ads_add(ad_group_id: str, target_data: str) -> dict:
             ad_group_id,
             "--json",
             target_data,
-            "--format",
-            "json",
         ]
     )
 
@@ -52,9 +50,7 @@ def dynamic_ads_update(id: str, extra_json: str) -> dict:
         extra_json: JSON string with fields to update.
     """
     runner = get_runner()
-    return runner.run_json(
-        ["dynamicads", "update", "--id", id, "--json", extra_json, "--format", "json"]
-    )
+    return runner.run_json(["dynamicads", "update", "--id", id, "--json", extra_json])
 
 
 @mcp.tool()
@@ -66,6 +62,4 @@ def dynamic_ads_delete(id: str) -> dict:
         id: Target ID.
     """
     runner = get_runner()
-    return runner.run_json(
-        ["dynamicads", "delete", "--id", id, "--format", "json"]
-    )
+    return runner.run_json(["dynamicads", "delete", "--id", id])

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -43,3 +43,20 @@ def validate_positive_int(value: str, field_name: str) -> int | ToolError:
             error="invalid_value",
             message=f"{field_name} must be a positive integer. Got: '{value}'",
         )
+
+
+def run_single_id_batch(runner, resource: str, action: str, ids_str: str) -> dict:
+    """Run a single-ID CLI mutation for a comma-separated batch of IDs."""
+    batch_error = check_batch_limit(ids_str)
+    if batch_error:
+        return batch_error.__dict__
+
+    ids = parse_ids(ids_str)
+    results = [runner.run_json([resource, action, "--id", item_id]) for item_id in ids]
+    if len(results) == 1:
+        return results[0]
+    success = all(
+        not isinstance(result, dict) or result.get("success", True) is not False
+        for result in results
+    )
+    return {"success": success, "ids": ids, "results": results}

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -51,11 +51,27 @@ def keyword_bids_set(
             message="Provide at least one of: search_bid, network_bid, extra_json",
         ).__dict__
 
+    from server.tools.helpers import validate_positive_int
+
+    search_bid_value: int | None = None
+    if search_bid is not None:
+        result = validate_positive_int(search_bid, "search_bid")
+        if isinstance(result, ToolError):
+            return result.__dict__
+        search_bid_value = result
+
+    network_bid_value: int | None = None
+    if network_bid is not None:
+        result = validate_positive_int(network_bid, "network_bid")
+        if isinstance(result, ToolError):
+            return result.__dict__
+        network_bid_value = result
+
     args = ["keywordbids", "set", "--keyword-id", keyword_id]
-    if search_bid:
-        args.extend(["--search-bid", search_bid])
-    if network_bid:
-        args.extend(["--network-bid", network_bid])
+    if search_bid_value is not None:
+        args.extend(["--search-bid", str(search_bid_value)])
+    if network_bid_value is not None:
+        args.extend(["--network-bid", str(network_bid_value)])
     if extra_json:
         args.extend(["--json", extra_json])
     runner = get_runner()

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -1,7 +1,7 @@
 """MCP tools for keyword bid management."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 
 @mcp.tool()
@@ -35,6 +35,7 @@ def keyword_bids_set(
     keyword_id: str,
     search_bid: str | None = None,
     network_bid: str | None = None,
+    extra_json: str | None = None,
 ) -> dict:
     """Set keyword bids.
 
@@ -42,12 +43,20 @@ def keyword_bids_set(
         keyword_id: Keyword ID.
         search_bid: Search bid amount (optional).
         network_bid: Network bid amount (optional).
+        extra_json: JSON string with additional parameters (optional).
     """
+    if not any((search_bid, network_bid, extra_json)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: search_bid, network_bid, extra_json",
+        ).__dict__
+
     args = ["keywordbids", "set", "--keyword-id", keyword_id]
     if search_bid:
         args.extend(["--search-bid", search_bid])
     if network_bid:
         args.extend(["--network-bid", network_bid])
-    args.extend(["--format", "json"])
+    if extra_json:
+        args.extend(["--json", extra_json])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -88,7 +88,6 @@ def keywords_update(
         args.extend(["--status", status])
     if extra_json:
         args.extend(["--json", extra_json])
-    args.extend(["--format", "json"])
     runner.run_json(args)
 
     result: dict[str, object] = {"success": True, "id": id}
@@ -105,18 +104,37 @@ def keywords_update(
 
 @mcp.tool()
 @handle_cli_errors
-def keywords_add(ad_group_id: str, keyword: str, bid: str | None = None) -> dict:
+def keywords_add(
+    ad_group_id: str,
+    keyword: str,
+    bid: str | None = None,
+    context_bid: str | None = None,
+    user_param_1: str | None = None,
+    user_param_2: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Add a keyword to an ad group.
 
     Args:
         ad_group_id: Ad group ID to add the keyword to.
         keyword: Keyword text.
-        bid: Optional bid (will be converted to micro-units if numeric, e.g. 15 → 15000000).
+        bid: Optional search bid.
+        context_bid: Optional context bid.
+        user_param_1: Optional user parameter 1.
+        user_param_2: Optional user parameter 2.
+        extra_json: Optional JSON string forwarded to direct-cli --json.
     """
     args = ["keywords", "add", "--adgroup-id", ad_group_id, "--keyword", keyword]
     if bid is not None:
         args.extend(["--bid", bid])
-    args.extend(["--format", "json"])
+    if context_bid is not None:
+        args.extend(["--context-bid", context_bid])
+    if user_param_1 is not None:
+        args.extend(["--user-param-1", user_param_1])
+    if user_param_2 is not None:
+        args.extend(["--user-param-2", user_param_2])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -129,15 +147,9 @@ def keywords_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated keyword IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["keywords", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "keywords", "delete", ids)
 
 
 @mcp.tool()
@@ -148,15 +160,9 @@ def keywords_suspend(ids: str) -> dict:
     Args:
         ids: Comma-separated keyword IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["keywords", "suspend", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "keywords", "suspend", ids)
 
 
 @mcp.tool()
@@ -167,15 +173,9 @@ def keywords_resume(ids: str) -> dict:
     Args:
         ids: Comma-separated keyword IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["keywords", "resume", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "keywords", "resume", ids)
 
 
 @mcp.tool()
@@ -186,15 +186,9 @@ def keywords_archive(ids: str) -> dict:
     Args:
         ids: Comma-separated keyword IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["keywords", "archive", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "keywords", "archive", ids)
 
 
 @mcp.tool()
@@ -205,12 +199,6 @@ def keywords_unarchive(ids: str) -> dict:
     Args:
         ids: Comma-separated keyword IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    from server.tools.helpers import run_single_id_batch
 
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["keywords", "unarchive", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "keywords", "unarchive", ids)

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -37,28 +37,70 @@ def keywords_list(campaign_ids: str) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def keywords_update(id: str, bid: str) -> dict:
-    """Update keyword bid.
+def keywords_update(
+    id: str,
+    bid: str | None = None,
+    context_bid: str | None = None,
+    status: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
+    """Update keyword fields.
 
     Args:
         id: Keyword ID.
-        bid: New bid in micro-units (e.g., 15 RUB = 15000000). Must be a positive integer.
+        bid: Optional new search bid in micro-units. Must be a positive integer.
+        context_bid: Optional new context bid in micro-units. Must be a positive integer.
+        status: Optional new keyword status.
+        extra_json: Optional JSON string forwarded to direct-cli --json.
     """
-    try:
-        bid_value = int(bid)
-        if bid_value <= 0:
-            raise ValueError("Bid must be positive")
-    except (ValueError, TypeError):
+    if not any((bid, context_bid, status, extra_json)):
         return ToolError(
-            error="invalid_bid",
-            message=f"Bid must be a positive integer in micro-units. Got: '{bid}'",
+            error="missing_update_fields",
+            message="Provide at least one of: bid, context_bid, status, extra_json",
         ).__dict__
 
+    def _parse_bid(raw_bid: str | None, field_name: str) -> int | None:
+        if raw_bid is None:
+            return None
+        try:
+            bid_value = int(raw_bid)
+            if bid_value <= 0:
+                raise ValueError("Bid must be positive")
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"{field_name} must be a positive integer in micro-units. Got: '{raw_bid}'"
+            ) from None
+        return bid_value
+
+    try:
+        bid_value = _parse_bid(bid, "bid")
+        context_bid_value = _parse_bid(context_bid, "context_bid")
+    except ValueError as exc:
+        return ToolError(error="invalid_bid", message=str(exc)).__dict__
+
     runner = get_runner()
-    runner.run_json(
-        ["keywords", "update", "--id", id, "--bid", str(bid_value), "--format", "json"]
-    )
-    return {"success": True, "id": id, "bid": bid_value}
+    args = ["keywords", "update", "--id", id]
+    if bid_value is not None:
+        args.extend(["--bid", str(bid_value)])
+    if context_bid_value is not None:
+        args.extend(["--context-bid", str(context_bid_value)])
+    if status:
+        args.extend(["--status", status])
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
+    runner.run_json(args)
+
+    result: dict[str, object] = {"success": True, "id": id}
+    if bid_value is not None:
+        result["bid"] = bid_value
+    if context_bid_value is not None:
+        result["context_bid"] = context_bid_value
+    if status:
+        result["status"] = status
+    if extra_json:
+        result["extra_json"] = extra_json
+    return result
 
 
 @mcp.tool()

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -1,7 +1,7 @@
 """MCP tools for negative keyword shared sets management."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 
 @mcp.tool()
@@ -37,8 +37,6 @@ def negative_keyword_shared_sets_add(name: str, keywords: str) -> dict:
             name,
             "--keywords",
             keywords,
-            "--format",
-            "json",
         ]
     )
 
@@ -49,6 +47,7 @@ def negative_keyword_shared_sets_update(
     id: str,
     name: str | None = None,
     keywords: str | None = None,
+    extra_json: str | None = None,
 ) -> dict:
     """Update a negative keyword shared set.
 
@@ -56,13 +55,21 @@ def negative_keyword_shared_sets_update(
         id: Set ID.
         name: New set name (optional).
         keywords: New comma-separated negative keywords (optional).
+        extra_json: JSON string with additional parameters (optional).
     """
+    if not any((name, keywords, extra_json)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: name, keywords, extra_json",
+        ).__dict__
+
     args = ["negativekeywordsharedsets", "update", "--id", id]
     if name is not None:
         args.extend(["--name", name])
     if keywords is not None:
         args.extend(["--keywords", keywords])
-    args.extend(["--format", "json"])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -76,6 +83,4 @@ def negative_keyword_shared_sets_delete(id: str) -> dict:
         id: Set ID.
     """
     runner = get_runner()
-    return runner.run_json(
-        ["negativekeywordsharedsets", "delete", "--id", id, "--format", "json"]
-    )
+    return runner.run_json(["negativekeywordsharedsets", "delete", "--id", id])

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -71,4 +71,4 @@ def reports_get(
 def reports_list_types() -> list[str] | dict:
     """List available report types."""
     runner = get_runner()
-    return runner.run_json(["reports", "list-types", "--format", "json"])
+    return runner.run_json(["reports", "list-types"])

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -1,7 +1,7 @@
 """MCP tools for smart ad target management."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 
 @mcp.tool()
@@ -20,7 +20,9 @@ def smart_ad_targets_list(ad_group_ids: str) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def smart_ad_targets_add(ad_group_id: str, target_type: str, extra_json: str | None = None) -> dict:
+def smart_ad_targets_add(
+    ad_group_id: str, target_type: str, extra_json: str | None = None
+) -> dict:
     """Add a smart ad target.
 
     Args:
@@ -31,24 +33,33 @@ def smart_ad_targets_add(ad_group_id: str, target_type: str, extra_json: str | N
     args = ["smartadtargets", "add", "--adgroup-id", ad_group_id, "--type", target_type]
     if extra_json:
         args.extend(["--json", extra_json])
-    args.extend(["--format", "json"])
     runner = get_runner()
     return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def smart_ad_targets_update(id: str, extra_json: str | None = None) -> dict:
+def smart_ad_targets_update(
+    id: str, target_type: str | None = None, extra_json: str | None = None
+) -> dict:
     """Update a smart ad target.
 
     Args:
         id: Target ID.
+        target_type: Optional target type.
         extra_json: JSON string with fields to update.
     """
+    if not any((target_type, extra_json)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: target_type, extra_json",
+        ).__dict__
+
     args = ["smartadtargets", "update", "--id", id]
+    if target_type:
+        args.extend(["--type", target_type])
     if extra_json:
         args.extend(["--json", extra_json])
-    args.extend(["--format", "json"])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -62,6 +73,4 @@ def smart_ad_targets_delete(id: str) -> dict:
         id: Target ID.
     """
     runner = get_runner()
-    return runner.run_json(
-        ["smartadtargets", "delete", "--id", id, "--format", "json"]
-    )
+    return runner.run_json(["smartadtargets", "delete", "--id", id])

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -24,7 +24,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Tool | Описание | Параметры |
 |---|---|---|
 | `campaigns_list` | Список кампаний | `state?` (ON/OFF) |
-| `campaigns_update` | Изменить статус кампании | `id`, `state` (ON/OFF) |
+| `campaigns_update` | Обновить кампанию | `id`, `name?`, `status?`, `budget?`, `extra_json?` |
 | `campaigns_add` | Создать кампанию | `name`, `start_date` |
 | `campaigns_delete` | Удалить кампании | `ids` (max 10) |
 | `campaigns_archive` | Архивировать кампании | `ids` (max 10) |
@@ -45,7 +45,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 |---|---|---|
 | `ads_list` | Список объявлений | `campaign_ids` (max 10) |
 | `ads_add` | Создать объявление | `ad_group_id`, `title?`, `text?`, `href?` |
-| `ads_update` | Обновить объявление | `id`, `extra_json?` |
+| `ads_update` | Обновить объявление | `id`, `status?`, `extra_json?` |
 | `ads_delete` | Удалить объявления | `ids` (max 10) |
 | `ads_moderate` | Отправить на модерацию | `ids` (max 10) |
 | `ads_suspend` | Приостановить объявления | `ids` (max 10) |
@@ -57,7 +57,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Tool | Описание | Параметры |
 |---|---|---|
 | `keywords_list` | Список ключевых слов | `campaign_ids` (max 10) |
-| `keywords_update` | Изменить ставку | `id`, `bid` (micro-units) |
+| `keywords_update` | Обновить ключевое слово | `id`, `bid?`, `context_bid?`, `status?`, `extra_json?` |
 | `keywords_add` | Добавить ключевое слово | `ad_group_id`, `keyword`, `bid?` |
 | `keywords_delete` | Удалить ключевые слова | `ids` (max 10) |
 | `keywords_suspend` | Приостановить ключевые слова | `ids` (max 10) |
@@ -189,8 +189,8 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Покажи активные кампании | `campaigns_list(state="ON")` |
 | Создай кампанию | `campaigns_add(name="...", start_date="2024-01-01")` |
 | Сколько объявлений в кампании 123? | `ads_list(campaign_ids="123")` → count |
-| Включи кампанию 456 | `campaigns_update(id="456", state="ON")` |
-| Отключи кампанию 456 | `campaigns_update(id="456", state="OFF")` |
+| Включи кампанию 456 | `campaigns_update(id="456", status="ON")` |
+| Отключи кампанию 456 | `campaigns_update(id="456", status="OFF")` |
 | Ключевые слова кампании 789 | `keywords_list(campaign_ids="789")` |
 | Изменить ставку ключевого слова на 15 руб | `keywords_update(id="99999", bid="15000000")` |
 | Статистика за последнюю неделю | `reports_get(date_from="...", date_to="...")` |

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -25,7 +25,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 |---|---|---|
 | `campaigns_list` | Список кампаний | `state?` (ON/OFF) |
 | `campaigns_update` | Обновить кампанию | `id`, `name?`, `status?`, `budget?`, `extra_json?` |
-| `campaigns_add` | Создать кампанию | `name`, `start_date` |
+| `campaigns_add` | Создать кампанию | `name`, `start_date`, `campaign_type?`, `budget?`, `end_date?`, `extra_json?` |
 | `campaigns_delete` | Удалить кампании | `ids` (max 10) |
 | `campaigns_archive` | Архивировать кампании | `ids` (max 10) |
 | `campaigns_unarchive` | Разархивировать кампании | `ids` (max 10) |
@@ -44,7 +44,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Tool | Описание | Параметры |
 |---|---|---|
 | `ads_list` | Список объявлений | `campaign_ids` (max 10) |
-| `ads_add` | Создать объявление | `ad_group_id`, `title?`, `text?`, `href?` |
+| `ads_add` | Создать объявление | `ad_group_id`, `ad_type?`, `title?`, `text?`, `href?`, `extra_json?` |
 | `ads_update` | Обновить объявление | `id`, `status?`, `extra_json?` |
 | `ads_delete` | Удалить объявления | `ids` (max 10) |
 | `ads_moderate` | Отправить на модерацию | `ids` (max 10) |
@@ -58,7 +58,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 |---|---|---|
 | `keywords_list` | Список ключевых слов | `campaign_ids` (max 10) |
 | `keywords_update` | Обновить ключевое слово | `id`, `bid?`, `context_bid?`, `status?`, `extra_json?` |
-| `keywords_add` | Добавить ключевое слово | `ad_group_id`, `keyword`, `bid?` |
+| `keywords_add` | Добавить ключевое слово | `ad_group_id`, `keyword`, `bid?`, `context_bid?`, `user_param_1?`, `user_param_2?`, `extra_json?` |
 | `keywords_delete` | Удалить ключевые слова | `ids` (max 10) |
 | `keywords_suspend` | Приостановить ключевые слова | `ids` (max 10) |
 | `keywords_resume` | Возобновить ключевые слова | `ids` (max 10) |
@@ -69,7 +69,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Tool | Описание | Параметры |
 |---|---|---|
 | `keyword_bids_list` | Список ставок на ключевые слова | `campaign_ids`, `ad_group_ids?`, `keyword_ids?` |
-| `keyword_bids_set` | Установить ставку на ключевое слово | `keyword_id`, `bid?`, `context_bid?` |
+| `keyword_bids_set` | Установить ставку на ключевое слово | `keyword_id`, `search_bid?`, `network_bid?`, `extra_json?` |
 
 ### Ставки
 | Tool | Описание | Параметры |
@@ -130,11 +130,11 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `smart_targets_delete` | Удалить смарт-таргеты | `ids` (max 10) |
 | `smart_ad_targets_list` | Список смарт-таргетов объявлений | `ad_group_ids` |
 | `smart_ad_targets_add` | Добавить смарт-таргет объявлений | `ad_group_id`, `target_type`, `extra_json?` |
-| `smart_ad_targets_update` | Обновить смарт-таргет объявлений | `id`, `extra_json` |
+| `smart_ad_targets_update` | Обновить смарт-таргет объявлений | `id`, `target_type?`, `extra_json?` |
 | `smart_ad_targets_delete` | Удалить смарт-таргет объявлений | `id` |
 | `negative_keyword_shared_sets_list` | Список наборов минус-слов | `ids?` |
 | `negative_keyword_shared_sets_add` | Добавить набор минус-слов | `name`, `keywords` |
-| `negative_keyword_shared_sets_update` | Обновить набор минус-слов | `id`, `name?`, `keywords?` |
+| `negative_keyword_shared_sets_update` | Обновить набор минус-слов | `id`, `name?`, `keywords?`, `extra_json?` |
 | `negative_keyword_shared_sets_delete` | Удалить набор минус-слов | `id` |
 | `businesses_list` | Список бизнесов | `ids?` |
 

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -1,6 +1,6 @@
 """Tests for ads MCP tool."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -76,11 +76,35 @@ class TestAdsCrudOperations:
     def test_ads_add(self):
         """Test adding a new ad."""
         mock_result = {"Id": 999, "Text": "New ad text"}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = ads_add(ad_group_id="1", text="New ad text")
+        runner = _mock_runner(mock_result)
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            result = ads_add(
+                ad_group_id="1",
+                ad_type="TEXT_AD",
+                title="Title",
+                text="New ad text",
+                href="https://example.com",
+                extra_json='{"Mobile":"YES"}',
+            )
             assert result["Id"] == 999
+            runner.run_json.assert_called_once_with(
+                [
+                    "ads",
+                    "add",
+                    "--adgroup-id",
+                    "1",
+                    "--type",
+                    "TEXT_AD",
+                    "--title",
+                    "Title",
+                    "--text",
+                    "New ad text",
+                    "--href",
+                    "https://example.com",
+                    "--json",
+                    '{"Mobile":"YES"}',
+                ]
+            )
 
     def test_ads_update(self):
         """Test updating an ad."""
@@ -110,8 +134,6 @@ class TestAdsCrudOperations:
                     "SUSPENDED",
                     "--json",
                     '{"TextAd": {"Title": "New"}}',
-                    "--format",
-                    "json",
                 ]
             )
 
@@ -125,12 +147,16 @@ class TestAdsCrudOperations:
 
     def test_ads_delete_success(self):
         """Test deleting ads successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_delete(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "delete", "--id", "111"]),
+                    call(["ads", "delete", "--id", "222"]),
+                ]
+            )
 
     def test_ads_delete_batch_limit(self):
         """Test batch limit validation for delete."""
@@ -141,12 +167,16 @@ class TestAdsCrudOperations:
 
     def test_ads_moderate_success(self):
         """Test submitting ads for moderation."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_moderate(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "moderate", "--id", "111"]),
+                    call(["ads", "moderate", "--id", "222"]),
+                ]
+            )
 
     def test_ads_moderate_batch_limit(self):
         """Test batch limit validation for moderate."""
@@ -157,12 +187,16 @@ class TestAdsCrudOperations:
 
     def test_ads_suspend_success(self):
         """Test suspending ads."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_suspend(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "suspend", "--id", "111"]),
+                    call(["ads", "suspend", "--id", "222"]),
+                ]
+            )
 
     def test_ads_suspend_batch_limit(self):
         """Test batch limit validation for suspend."""
@@ -173,12 +207,16 @@ class TestAdsCrudOperations:
 
     def test_ads_resume_success(self):
         """Test resuming suspended ads."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_resume(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "resume", "--id", "111"]),
+                    call(["ads", "resume", "--id", "222"]),
+                ]
+            )
 
     def test_ads_resume_batch_limit(self):
         """Test batch limit validation for resume."""
@@ -189,12 +227,16 @@ class TestAdsCrudOperations:
 
     def test_ads_archive_success(self):
         """Test archiving ads."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_archive(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "archive", "--id", "111"]),
+                    call(["ads", "archive", "--id", "222"]),
+                ]
+            )
 
     def test_ads_archive_batch_limit(self):
         """Test batch limit validation for archive."""
@@ -205,12 +247,16 @@ class TestAdsCrudOperations:
 
     def test_ads_unarchive_success(self):
         """Test unarchiving ads."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_unarchive(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["ads", "unarchive", "--id", "111"]),
+                    call(["ads", "unarchive", "--id", "222"]),
+                ]
+            )
 
     def test_ads_unarchive_batch_limit(self):
         """Test batch limit validation for unarchive."""

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -88,26 +88,40 @@ class TestAdsCrudOperations:
         with patch(
             "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
         ):
-            result = ads_update(id="111", extra_json='{"Status": "SUSPENDED"}')
+            result = ads_update(id="111", status="SUSPENDED")
             assert result["Id"] == 111
 
     def test_ads_update_argv_composition(self):
         """Test that update passes correct argv to CLI."""
         runner = _mock_runner({"Id": 111})
         with patch("server.tools.ads.get_runner", return_value=runner):
-            ads_update(id="111", extra_json='{"TextAd": {"Title": "New"}}')
+            ads_update(
+                id="111",
+                status="SUSPENDED",
+                extra_json='{"TextAd": {"Title": "New"}}',
+            )
             runner.run_json.assert_called_once_with(
                 [
                     "ads",
                     "update",
                     "--id",
                     "111",
+                    "--status",
+                    "SUSPENDED",
                     "--json",
                     '{"TextAd": {"Title": "New"}}',
                     "--format",
                     "json",
                 ]
             )
+
+    def test_ads_update_requires_changes(self):
+        """Test that empty updates are rejected before CLI call."""
+        runner = _mock_runner({"Id": 111})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            result = ads_update(id="111")
+            assert result["error"] == "missing_update_fields"
+            runner.run_json.assert_not_called()
 
     def test_ads_delete_success(self):
         """Test deleting ads successfully."""

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -1,6 +1,6 @@
 """Tests for campaign MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -160,8 +160,6 @@ class TestCampaignsUpdate:
                 "5000",
                 "--json",
                 '{"Notification": {"SmsSettings": {"Events": ["MONITORING"]}}}',
-                "--format",
-                "json",
             ]
         )
         assert result["budget"] == 5000
@@ -182,20 +180,48 @@ class TestCampaignsCrudOperations:
     def test_campaigns_add(self):
         """Test adding a new campaign."""
         mock_result = {"Id": 99999, "Name": "New Campaign"}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = campaigns_add(name="New Campaign", start_date="2026-01-01")
+        runner = _mock_runner(mock_result)
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_add(
+                name="New Campaign",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                budget="5000",
+                end_date="2026-12-31",
+                extra_json='{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"}}}',
+            )
             assert result["Id"] == 99999
+            runner.run_json.assert_called_once_with(
+                [
+                    "campaigns",
+                    "add",
+                    "--name",
+                    "New Campaign",
+                    "--start-date",
+                    "2026-01-01",
+                    "--type",
+                    "TEXT_CAMPAIGN",
+                    "--budget",
+                    "5000",
+                    "--end-date",
+                    "2026-12-31",
+                    "--json",
+                    '{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"}}}',
+                ]
+            )
 
     def test_campaigns_delete_success(self):
         """Test deleting campaigns successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_delete(ids="12345,67890")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["campaigns", "delete", "--id", "12345"]),
+                    call(["campaigns", "delete", "--id", "67890"]),
+                ]
+            )
 
     def test_campaigns_delete_batch_limit(self):
         """Test batch limit validation for delete."""
@@ -206,12 +232,16 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_archive_success(self):
         """Test archiving campaigns successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_archive(ids="12345,67890")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["campaigns", "archive", "--id", "12345"]),
+                    call(["campaigns", "archive", "--id", "67890"]),
+                ]
+            )
 
     def test_campaigns_archive_batch_limit(self):
         """Test batch limit validation for archive."""
@@ -222,12 +252,16 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_unarchive_success(self):
         """Test unarchiving campaigns successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_unarchive(ids="12345,67890")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["campaigns", "unarchive", "--id", "12345"]),
+                    call(["campaigns", "unarchive", "--id", "67890"]),
+                ]
+            )
 
     def test_campaigns_unarchive_batch_limit(self):
         """Test batch limit validation for unarchive."""
@@ -238,12 +272,13 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_suspend_success(self):
         """Test suspending campaigns successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_suspend(ids="12345")
             assert result["success"] is True
+            runner.run_json.assert_called_once_with(
+                ["campaigns", "suspend", "--id", "12345"]
+            )
 
     def test_campaigns_suspend_batch_limit(self):
         """Test batch limit validation for suspend."""
@@ -254,12 +289,13 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_resume_success(self):
         """Test resuming campaigns successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.campaigns.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_resume(ids="12345")
             assert result["success"] is True
+            runner.run_json.assert_called_once_with(
+                ["campaigns", "resume", "--id", "12345"]
+            )
 
     def test_campaigns_resume_batch_limit(self):
         """Test batch limit validation for resume."""

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -79,9 +79,9 @@ class TestCampaignsUpdate:
             "server.tools.campaigns.get_runner",
             return_value=_mock_runner({"Id": 67890, "State": "ON"}),
         ):
-            result = campaigns_update(id="67890", state="ON")
+            result = campaigns_update(id="67890", status="ON")
             assert result["success"] is True
-            assert result["state"] == "ON"
+            assert result["status"] == "ON"
 
     def test_disable_campaign(self):
         """Test 9: Disable a campaign."""
@@ -89,21 +89,21 @@ class TestCampaignsUpdate:
             "server.tools.campaigns.get_runner",
             return_value=_mock_runner({"Id": 12345, "State": "OFF"}),
         ):
-            result = campaigns_update(id="12345", state="OFF")
+            result = campaigns_update(id="12345", status="OFF")
             assert result["success"] is True
 
-    def test_invalid_state(self):
-        """Test: Invalid state value."""
-        result = campaigns_update(id="12345", state="INVALID")
+    def test_invalid_budget(self):
+        """Test: Invalid budget value."""
+        result = campaigns_update(id="12345", budget="-1")
         assert "error" in result
-        assert result["error"] == "invalid_state"
+        assert result["error"] == "invalid_budget"
 
     def test_not_found_campaign(self):
         """Test 10: Nonexistent campaign."""
         runner = MagicMock()
         runner.run_json.side_effect = Exception("Campaign 999 not found")
         with patch("server.tools.campaigns.get_runner", return_value=runner):
-            result = campaigns_update(id="999", state="ON")
+            result = campaigns_update(id="999", status="ON")
             assert "error" in result
             assert result["error"] == "not_found"
 
@@ -115,7 +115,7 @@ class TestCampaignsUpdate:
             patch("server.tools.campaigns.get_runner", return_value=runner),
             patch("server.tools._try_refresh_token", return_value=None),
         ):
-            result = campaigns_update(id="12345", state="ON")
+            result = campaigns_update(id="12345", status="ON")
             assert result["error"] == "auth_expired"
 
     def test_auth_error_refresh_retries(self):
@@ -131,8 +131,49 @@ class TestCampaignsUpdate:
             ),
             patch("server.tools._try_refresh_token", return_value="new-token"),
         ):
-            result = campaigns_update(id="12345", state="ON")
+            result = campaigns_update(id="12345", status="ON")
             assert result["success"] is True
+
+    def test_campaigns_update_argv_composition(self):
+        """Test that update passes the expanded CLI surface."""
+        runner = _mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(
+                id="12345",
+                name="Renamed",
+                status="SUSPENDED",
+                budget="5000",
+                extra_json='{"Notification": {"SmsSettings": {"Events": ["MONITORING"]}}}',
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "campaigns",
+                "update",
+                "--id",
+                "12345",
+                "--name",
+                "Renamed",
+                "--status",
+                "SUSPENDED",
+                "--budget",
+                "5000",
+                "--json",
+                '{"Notification": {"SmsSettings": {"Events": ["MONITORING"]}}}',
+                "--format",
+                "json",
+            ]
+        )
+        assert result["budget"] == 5000
+
+    def test_campaigns_update_requires_changes(self):
+        """Test that empty updates are rejected before CLI call."""
+        runner = _mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(id="12345")
+
+        assert result["error"] == "missing_update_fields"
+        runner.run_json.assert_not_called()
 
 
 class TestCampaignsCrudOperations:

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -51,22 +51,44 @@ def test_dynamic_ads_list_empty():
 
 def test_dynamic_ads_add():
     mock_result = {"Id": 300}
-    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)
+    ) as mock:
         result = dynamic_ads_add(
             ad_group_id="200", target_data='{"Name": "Test", "Conditions": []}'
         )
         assert result["Id"] == 300
+        mock.return_value.run_json.assert_called_once_with(
+            [
+                "dynamicads",
+                "add",
+                "--adgroup-id",
+                "200",
+                "--json",
+                '{"Name": "Test", "Conditions": []}',
+            ]
+        )
 
 
 def test_dynamic_ads_update():
     mock_result = {"success": True}
-    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)
+    ) as mock:
         result = dynamic_ads_update(id="100", extra_json='{"Conditions": []}')
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            ["dynamicads", "update", "--id", "100", "--json", '{"Conditions": []}']
+        )
 
 
 def test_dynamic_ads_delete():
     mock_result = {"success": True}
-    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.dynamic_ads.get_runner", return_value=_mock_runner(mock_result)
+    ) as mock:
         result = dynamic_ads_delete(id="100")
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            ["dynamicads", "delete", "--id", "100"]
+        )

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -107,16 +107,27 @@ class TestKeywordBidsSet:
             assert "10" in call_args
             assert "--network-bid" in call_args
             assert "5" in call_args
+            assert "--format" not in call_args
 
-    def test_keyword_bids_set_no_optional_bids(self):
-        """Test setting keyword bid with no optional bids."""
+    def test_keyword_bids_set_with_json(self):
+        """Test setting keyword bids with additional JSON."""
         mock_result = {"success": True}
         with patch(
             "server.tools.keyword_bids.get_runner",
             return_value=_mock_runner(mock_result),
         ) as mock:
-            result = keyword_bids_set(keyword_id="111")
+            result = keyword_bids_set(
+                keyword_id="111", extra_json='{"AutoBudget":"YES"}'
+            )
             assert result["success"] is True
             call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--search-bid" not in call_args
-            assert "--network-bid" not in call_args
+            assert "--json" in call_args
+            assert '{"AutoBudget":"YES"}' in call_args
+
+    def test_keyword_bids_set_requires_changes(self):
+        """Reject no-op updates before calling CLI."""
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keyword_bids.get_runner", return_value=runner):
+            result = keyword_bids_set(keyword_id="111")
+            assert result["error"] == "missing_update_fields"
+            runner.run_json.assert_not_called()

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -88,8 +88,23 @@ class TestKeywordBidsSet:
             "server.tools.keyword_bids.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = keyword_bids_set(keyword_id="111", search_bid="10.5")
+            result = keyword_bids_set(keyword_id="111", search_bid="10")
             assert result["success"] is True
+
+    def test_keyword_bids_set_invalid_bid(self):
+        """Test that non-integer bid is rejected."""
+        result = keyword_bids_set(keyword_id="111", search_bid="abc")
+        assert result["error"] == "invalid_value"
+
+    def test_keyword_bids_set_negative_bid(self):
+        """Test that negative bid is rejected."""
+        result = keyword_bids_set(keyword_id="111", search_bid="-5")
+        assert result["error"] == "invalid_value"
+
+    def test_keyword_bids_set_zero_bid(self):
+        """Test that zero bid is rejected."""
+        result = keyword_bids_set(keyword_id="111", search_bid="0")
+        assert result["error"] == "invalid_value"
 
     def test_keyword_bids_set_both_bids(self):
         """Test setting both search and network bids."""

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -63,6 +63,49 @@ def test_keywords_update_invalid_bid():
     assert result["error"] == "invalid_bid"
 
 
+def test_keywords_update_argv_composition():
+    """Test that update passes the expanded CLI surface."""
+    runner = _mock_runner({})
+    with patch("server.tools.keywords.get_runner", return_value=runner):
+        result = keywords_update(
+            id="99999",
+            bid="15000000",
+            context_bid="9000000",
+            status="SUSPENDED",
+            extra_json='{"StrategyPriority": "HIGH"}',
+        )
+
+    runner.run_json.assert_called_once_with(
+        [
+            "keywords",
+            "update",
+            "--id",
+            "99999",
+            "--bid",
+            "15000000",
+            "--context-bid",
+            "9000000",
+            "--status",
+            "SUSPENDED",
+            "--json",
+            '{"StrategyPriority": "HIGH"}',
+            "--format",
+            "json",
+        ]
+    )
+    assert result["context_bid"] == 9000000
+
+
+def test_keywords_update_requires_changes():
+    """Test that empty updates are rejected before CLI call."""
+    runner = _mock_runner({})
+    with patch("server.tools.keywords.get_runner", return_value=runner):
+        result = keywords_update(id="99999")
+
+    assert result["error"] == "missing_update_fields"
+    runner.run_json.assert_not_called()
+
+
 class TestKeywordsCrudOperations:
     """Tests for keyword CRUD operations (add, delete, suspend, resume)."""
 

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,6 +1,6 @@
 """Tests for keyword MCP tools."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -89,8 +89,6 @@ def test_keywords_update_argv_composition():
             "SUSPENDED",
             "--json",
             '{"StrategyPriority": "HIGH"}',
-            "--format",
-            "json",
         ]
     )
     assert result["context_bid"] == 9000000
@@ -111,21 +109,51 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add(self):
         """Test adding a keyword to an ad group."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = keywords_add(ad_group_id="1", keyword="buy shoes")
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            result = keywords_add(
+                ad_group_id="1",
+                keyword="buy shoes",
+                bid="10",
+                context_bid="5",
+                user_param_1="summer",
+                user_param_2="sale",
+                extra_json='{"Priority":"HIGH"}',
+            )
             assert result["success"] is True
+            runner.run_json.assert_called_once_with(
+                [
+                    "keywords",
+                    "add",
+                    "--adgroup-id",
+                    "1",
+                    "--keyword",
+                    "buy shoes",
+                    "--bid",
+                    "10",
+                    "--context-bid",
+                    "5",
+                    "--user-param-1",
+                    "summer",
+                    "--user-param-2",
+                    "sale",
+                    "--json",
+                    '{"Priority":"HIGH"}',
+                ]
+            )
 
     def test_keywords_delete_success(self):
         """Test deleting keywords successfully."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_delete(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["keywords", "delete", "--id", "111"]),
+                    call(["keywords", "delete", "--id", "222"]),
+                ]
+            )
 
     def test_keywords_delete_batch_limit(self):
         """Test batch limit validation for delete."""
@@ -136,12 +164,16 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_suspend_success(self):
         """Test suspending keywords."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_suspend(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["keywords", "suspend", "--id", "111"]),
+                    call(["keywords", "suspend", "--id", "222"]),
+                ]
+            )
 
     def test_keywords_suspend_batch_limit(self):
         """Test batch limit validation for suspend."""
@@ -152,12 +184,16 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_resume_success(self):
         """Test resuming suspended keywords."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)
-        ):
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_resume(ids="111,222")
             assert result["success"] is True
+            runner.run_json.assert_has_calls(
+                [
+                    call(["keywords", "resume", "--id", "111"]),
+                    call(["keywords", "resume", "--id", "222"]),
+                ]
+            )
 
     def test_keywords_resume_batch_limit(self):
         """Test batch limit validation for resume."""
@@ -168,10 +204,16 @@ class TestKeywordsCrudOperations:
 
 
 def test_keywords_archive_success():
-    mock_result = {"success": True}
-    with patch("server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)):
+    runner = _mock_runner({"success": True})
+    with patch("server.tools.keywords.get_runner", return_value=runner):
         result = keywords_archive(ids="111,222")
         assert result["success"] is True
+        runner.run_json.assert_has_calls(
+            [
+                call(["keywords", "archive", "--id", "111"]),
+                call(["keywords", "archive", "--id", "222"]),
+            ]
+        )
 
 
 def test_keywords_archive_batch_limit():
@@ -182,10 +224,16 @@ def test_keywords_archive_batch_limit():
 
 
 def test_keywords_unarchive_success():
-    mock_result = {"success": True}
-    with patch("server.tools.keywords.get_runner", return_value=_mock_runner(mock_result)):
+    runner = _mock_runner({"success": True})
+    with patch("server.tools.keywords.get_runner", return_value=runner):
         result = keywords_unarchive(ids="111,222")
         assert result["success"] is True
+        runner.run_json.assert_has_calls(
+            [
+                call(["keywords", "unarchive", "--id", "111"]),
+                call(["keywords", "unarchive", "--id", "222"]),
+            ]
+        )
 
 
 def test_keywords_unarchive_batch_limit():

--- a/tests/test_live_unsafe.py
+++ b/tests/test_live_unsafe.py
@@ -45,14 +45,14 @@ def test_live_campaigns_update_rolls_back(live_token_getter):
     )
 
     try:
-        update_result = campaigns_update(id=campaign_id, state="ON")
+        update_result = campaigns_update(id=campaign_id, status="ON")
         assert update_result.get("success") is True, update_result
 
         updated = _find_campaign(campaign_id)
         assert updated.get("State") == "ON", updated
     finally:
         try:
-            rollback = campaigns_update(id=campaign_id, state="OFF")
+            rollback = campaigns_update(id=campaign_id, status="OFF")
             assert rollback.get("success") is True, rollback
             restored = _find_campaign(campaign_id)
             assert restored.get("State") == "OFF", restored

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -49,20 +49,66 @@ def test_nkss_list_empty():
 
 def test_nkss_add():
     mock_result = {"Id": 200}
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
         result = negative_keyword_shared_sets_add(name="New list", keywords="bad,word")
         assert result["Id"] == 200
+        mock.return_value.run_json.assert_called_once_with(
+            [
+                "negativekeywordsharedsets",
+                "add",
+                "--name",
+                "New list",
+                "--keywords",
+                "bad,word",
+            ]
+        )
 
 
 def test_nkss_update():
     mock_result = {"success": True}
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
-        result = negative_keyword_shared_sets_update(id="100", name="Updated")
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
+        result = negative_keyword_shared_sets_update(
+            id="100", name="Updated", extra_json='{"Keywords":["bad"]}'
+        )
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            [
+                "negativekeywordsharedsets",
+                "update",
+                "--id",
+                "100",
+                "--name",
+                "Updated",
+                "--json",
+                '{"Keywords":["bad"]}',
+            ]
+        )
+
+
+def test_nkss_update_requires_changes():
+    runner = _mock_runner({"success": True})
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner", return_value=runner
+    ):
+        result = negative_keyword_shared_sets_update(id="100")
+        assert result["error"] == "missing_update_fields"
+        runner.run_json.assert_not_called()
 
 
 def test_nkss_delete():
     mock_result = {"success": True}
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
         result = negative_keyword_shared_sets_delete(id="100")
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            ["negativekeywordsharedsets", "delete", "--id", "100"]
+        )

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -30,19 +30,28 @@ def _mock_runner(return_value):
 
 
 def test_nkss_list():
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner(SAMPLE_SETS),
+    ):
         result = negative_keyword_shared_sets_list()
         assert len(result) == 1
 
 
 def test_nkss_list_with_ids():
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner(SAMPLE_SETS)):
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner(SAMPLE_SETS),
+    ):
         result = negative_keyword_shared_sets_list(ids="100")
         assert len(result) == 1
 
 
 def test_nkss_list_empty():
-    with patch("server.tools.negative_keyword_shared_sets.get_runner", return_value=_mock_runner([])):
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=_mock_runner([]),
+    ):
         result = negative_keyword_shared_sets_list()
         assert result == []
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -154,7 +154,9 @@ def test_reports_list_types():
         "REACH_AND_FREQUENCY_CAMPAIGN_REPORT",
         "SEARCH_QUERY_PERFORMANCE_REPORT",
     ]
-    with patch("server.tools.reports.get_runner", return_value=_mock_runner(expected_types)):
+    runner = _mock_runner(expected_types)
+    with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_list_types()
         assert len(result) == 7
         assert "CAMPAIGN_PERFORMANCE_REPORT" in result
+        runner.run_json.assert_called_once_with(["reports", "list-types"])

--- a/tests/test_smart_ad_targets.py
+++ b/tests/test_smart_ad_targets.py
@@ -19,7 +19,13 @@ def setup():
 
 
 SAMPLE_TARGETS = [
-    {"Id": 100, "CampaignId": 300, "AdGroupId": 200, "Status": "ACCEPTED", "ServingStatus": "ELIGIBLE"},
+    {
+        "Id": 100,
+        "CampaignId": 300,
+        "AdGroupId": 200,
+        "Status": "ACCEPTED",
+        "ServingStatus": "ELIGIBLE",
+    },
 ]
 
 
@@ -30,13 +36,18 @@ def _mock_runner(return_value):
 
 
 def test_smart_ad_targets_list():
-    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(SAMPLE_TARGETS)):
+    with patch(
+        "server.tools.smart_ad_targets.get_runner",
+        return_value=_mock_runner(SAMPLE_TARGETS),
+    ):
         result = smart_ad_targets_list(ad_group_ids="200")
         assert len(result) == 1
 
 
 def test_smart_ad_targets_list_empty():
-    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner([])):
+    with patch(
+        "server.tools.smart_ad_targets.get_runner", return_value=_mock_runner([])
+    ):
         result = smart_ad_targets_list(ad_group_ids="200")
         assert result == []
 

--- a/tests/test_smart_ad_targets.py
+++ b/tests/test_smart_ad_targets.py
@@ -43,20 +43,72 @@ def test_smart_ad_targets_list_empty():
 
 def test_smart_ad_targets_add():
     mock_result = {"Id": 400}
-    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
-        result = smart_ad_targets_add(ad_group_id="200", target_type="RETARGETING")
+    with patch(
+        "server.tools.smart_ad_targets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
+        result = smart_ad_targets_add(
+            ad_group_id="200",
+            target_type="RETARGETING",
+            extra_json='{"Condition":"URL_CONTAINS"}',
+        )
         assert result["Id"] == 400
+        mock.return_value.run_json.assert_called_once_with(
+            [
+                "smartadtargets",
+                "add",
+                "--adgroup-id",
+                "200",
+                "--type",
+                "RETARGETING",
+                "--json",
+                '{"Condition":"URL_CONTAINS"}',
+            ]
+        )
 
 
 def test_smart_ad_targets_update():
     mock_result = {"success": True}
-    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
-        result = smart_ad_targets_update(id="100", extra_json='{"Type": "RETARGETING"}')
+    with patch(
+        "server.tools.smart_ad_targets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
+        result = smart_ad_targets_update(
+            id="100",
+            target_type="RETARGETING",
+            extra_json='{"Condition":"URL_CONTAINS"}',
+        )
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            [
+                "smartadtargets",
+                "update",
+                "--id",
+                "100",
+                "--type",
+                "RETARGETING",
+                "--json",
+                '{"Condition":"URL_CONTAINS"}',
+            ]
+        )
+
+
+def test_smart_ad_targets_update_requires_changes():
+    runner = _mock_runner({"success": True})
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
+        result = smart_ad_targets_update(id="100")
+        assert result["error"] == "missing_update_fields"
+        runner.run_json.assert_not_called()
 
 
 def test_smart_ad_targets_delete():
     mock_result = {"success": True}
-    with patch("server.tools.smart_ad_targets.get_runner", return_value=_mock_runner(mock_result)):
+    with patch(
+        "server.tools.smart_ad_targets.get_runner",
+        return_value=_mock_runner(mock_result),
+    ) as mock:
         result = smart_ad_targets_delete(id="100")
         assert result["success"] is True
+        mock.return_value.run_json.assert_called_once_with(
+            ["smartadtargets", "delete", "--id", "100"]
+        )


### PR DESCRIPTION
## Summary
- fix MCP server script startup for the expanded tool registry
- align ads/campaigns/keywords update wrappers with current CLI surface
- add issue #43 parity doc and sync skill docs/tests

## Testing
- python3 -m pytest tests/test_ads.py tests/test_campaigns.py tests/test_keywords.py tests/test_server.py
- ruff check server/main.py server/tools/ads.py server/tools/campaigns.py server/tools/keywords.py tests/test_ads.py tests/test_campaigns.py tests/test_keywords.py
- mypy server/main.py server/tools/ads.py server/tools/campaigns.py server/tools/keywords.py

Closes #43