### PR TITLE
feat(ads): add ads_update MCP tool

### DIFF
--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -59,3 +59,39 @@ def ads_list(campaign_ids: str) -> list[dict] | dict:
     return runner.run_json(
         ["ads", "get", "--campaign-ids", campaign_ids, "--format", "json"]
     )
+
+
+@mcp.tool()
+@handle_cli_errors
+def ads_update(
+    id: str, status: str | None = None, extra_json: str | None = None
+) -> dict:
+    """Update ad fields via direct-cli.
+
+    Args:
+        id: Ad ID to update.
+        status: Optional new ad status.
+        extra_json: Optional JSON string forwarded to direct-cli --json.
+    """
+    if not status and not extra_json:
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: status, extra_json",
+        ).__dict__
+
+    args = ["ads", "update", "--id", id]
+    if status:
+        args.extend(["--status", status])
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
+
+    runner = get_runner()
+    runner.run_json(args)
+
+    result: dict[str, object] = {"success": True, "id": id}
+    if status:
+        result["status"] = status
+    if extra_json:
+        result["extra_json"] = extra_json
+    return result

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -25,6 +25,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `campaigns_list` | Список кампаний | `state?` (ON/OFF) |
 | `campaigns_update` | Изменить статус кампании | `id`, `state` (ON/OFF) |
 | `ads_list` | Объявления в кампаниях | `campaign_ids` (comma-separated, max 10) |
+| `ads_update` | Обновить объявление | `id`, `status?`, `extra_json?` |
 | `keywords_list` | Ключевые слова | `campaign_ids` |
 | `keywords_update` | Изменить ставку | `id`, `bid` (micro-units) |
 | `reports_get` | Статистика | `date_from?`, `date_to?` |
@@ -39,6 +40,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Покажи все кампании | `campaigns_list()` |
 | Покажи активные кампании | `campaigns_list(state="ON")` |
 | Сколько объявлений в кампании 123? | `ads_list(campaign_ids="123")` → count |
+| Переведи объявление 111 в новый статус | `ads_update(id="111", status="SUSPENDED")` |
 | Включи кампанию 456 | `campaigns_update(id="456", state="ON")` |
 | Отключи кампанию 456 | `campaigns_update(id="456", state="OFF")` |
 | Ключевые слова кампании 789 | `keywords_list(campaign_ids="789")` |

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 import server.tools
-from server.tools.ads import ads_list
+from server.tools.ads import ads_list, ads_update
 
 
 @pytest.fixture(autouse=True)
@@ -58,3 +58,47 @@ def test_ads_empty():
     with patch("server.tools.ads.get_runner", return_value=_mock_runner([])):
         result = ads_list(campaign_ids="12345")
         assert result == []
+
+
+def test_ads_update_status_success():
+    """Update ad status through direct-cli."""
+    runner = _mock_runner({"result": "ok"})
+    with patch("server.tools.ads.get_runner", return_value=runner):
+        result = ads_update(id="111", status="SUSPENDED")
+
+    runner.run_json.assert_called_once_with(
+        ["ads", "update", "--id", "111", "--status", "SUSPENDED", "--format", "json"]
+    )
+    assert result == {"success": True, "id": "111", "status": "SUSPENDED"}
+
+
+def test_ads_update_extra_json_success():
+    """Pass through additional JSON update payload."""
+    runner = _mock_runner({"result": "ok"})
+    with patch("server.tools.ads.get_runner", return_value=runner):
+        result = ads_update(id="111", extra_json='{"TextAd":{"Title":"New title"}}')
+
+    runner.run_json.assert_called_once_with(
+        [
+            "ads",
+            "update",
+            "--id",
+            "111",
+            "--json",
+            '{"TextAd":{"Title":"New title"}}',
+            "--format",
+            "json",
+        ]
+    )
+    assert result == {
+        "success": True,
+        "id": "111",
+        "extra_json": '{"TextAd":{"Title":"New title"}}',
+    }
+
+
+def test_ads_update_requires_changes():
+    """Reject empty updates before calling the CLI."""
+    result = ads_update(id="111")
+
+    assert result["error"] == "missing_update_fields"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ EXPECTED_TOOLS = {
     "campaigns_list",
     "campaigns_update",
     "ads_list",
+    "ads_update",
     "keywords_list",
     "keywords_update",
     "reports_get",


### PR DESCRIPTION
## Summary
- add `ads_update` MCP tool wrapping `direct ads update`
- add tests for status updates, raw JSON updates, and empty-update validation
- expose the tool in `tests/test_server.py` and `skills/yandex-direct/SKILL.md`

## Testing
- python3 -m pytest tests/test_ads.py tests/test_server.py
- ruff check server/tools/ads.py tests/test_ads.py tests/test_server.py