### PR TITLE
fix: align all MCP tool parameters with direct-cli

### DIFF
--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -17,13 +17,15 @@ def adextensions_list(
         types: Comma-separated extension types to filter (optional).
     """
     cmd = ["adextensions", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        cmd.extend(["--ids", ids])
-    if types is not None and types.strip():
-        cmd.extend(["--types", types])
+        cmd.extend(["--ids", normalized_ids])
+    normalized_types = types.strip() if types is not None else None
+    if normalized_types:
+        cmd.extend(["--types", normalized_types])
     runner = get_runner()
     result = runner.run_json(cmd)
     return result

--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -2,29 +2,38 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import run_single_id_batch
 
 
 @mcp.tool()
 @handle_cli_errors
-def adextensions_list(ids: str) -> list[dict] | dict:
+def adextensions_list(
+    ids: str | None = None, types: str | None = None
+) -> list[dict] | dict:
     """List ad extensions.
 
     Args:
-        ids: Comma-separated extension IDs (empty string for all extensions).
+        ids: Comma-separated extension IDs (optional).
+        types: Comma-separated extension types to filter (optional).
     """
+    cmd = ["adextensions", "get", "--format", "json"]
+    if ids is not None:
+        cmd.extend(["--ids", ids])
+    if types is not None:
+        cmd.extend(["--types", types])
     runner = get_runner()
-    result = runner.run_json(["adextensions", "get", "--ids", ids, "--format", "json"])
+    result = runner.run_json(cmd)
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def adextensions_add(extension_type: str, extension_data: str) -> dict:
+def adextensions_add(extension_type: str, extra_json: str) -> dict:
     """Add an ad extension.
 
     Args:
-        extension_type: Type of extension (e.g., "Call", "Message", "Rating").
-        extension_data: JSON string describing the extension.
+        extension_type: Type of extension (e.g., "CALLOUT", "SITELINK").
+        extra_json: JSON string describing the extension content.
     """
     runner = get_runner()
     result = runner.run_json(
@@ -33,10 +42,8 @@ def adextensions_add(extension_type: str, extension_data: str) -> dict:
             "add",
             "--type",
             extension_type,
-            "--data",
-            extension_data,
-            "--format",
-            "json",
+            "--json",
+            extra_json,
         ]
     )
     return result
@@ -50,14 +57,4 @@ def adextensions_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated extension IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["adextensions", "delete", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "adextensions", "delete", ids)

--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
-from server.tools.helpers import run_single_id_batch
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
@@ -17,9 +17,12 @@ def adextensions_list(
         types: Comma-separated extension types to filter (optional).
     """
     cmd = ["adextensions", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
         cmd.extend(["--ids", ids])
-    if types is not None:
+    if types is not None and types.strip():
         cmd.extend(["--types", types])
     runner = get_runner()
     result = runner.run_json(cmd)

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -34,7 +34,7 @@ def adgroups_list(
         if batch_error:
             return batch_error.__dict__
         args.extend(["--campaign-ids", campaign_ids])
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = _check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -29,16 +29,20 @@ def adgroups_list(
         types: Filter by types (optional).
     """
     args = ["adgroups", "get", "--format", "json"]
-    if campaign_ids is not None:
-        batch_error = _check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = _check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--campaign-ids", campaign_ids])
-    if ids is not None and ids.strip():
-        batch_error = _check_batch_limit(ids)
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = _check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--ids", ids])
+        args.extend(["--ids", normalized_ids])
     if status is not None:
         args.extend(["--status", status])
     if types is not None:

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -14,65 +14,107 @@ def _check_batch_limit(ids_str: str) -> ToolError | None:
 
 @mcp.tool()
 @handle_cli_errors
-def adgroups_list(campaign_ids: str) -> list[dict] | dict:
-    """List ad groups in specified campaigns.
+def adgroups_list(
+    campaign_ids: str | None = None,
+    ids: str | None = None,
+    status: str | None = None,
+    types: str | None = None,
+) -> list[dict] | dict:
+    """List ad groups.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        campaign_ids: Comma-separated campaign IDs (optional, max 10).
+        ids: Comma-separated ad group IDs (optional, max 10).
+        status: Filter by status (optional).
+        types: Filter by types (optional).
     """
-    batch_error = _check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    args = ["adgroups", "get", "--format", "json"]
+    if campaign_ids is not None:
+        batch_error = _check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--campaign-ids", campaign_ids])
+    if ids is not None:
+        batch_error = _check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--ids", ids])
+    if status is not None:
+        args.extend(["--status", status])
+    if types is not None:
+        args.extend(["--types", types])
 
     runner = get_runner()
-    return runner.run_json(
-        ["adgroups", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def adgroups_add(campaign_id: str, name: str, region_ids: str) -> dict:
+def adgroups_add(
+    campaign_id: str,
+    name: str,
+    region_ids: str | None = None,
+    type: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Create a new ad group.
 
     Args:
         campaign_id: Campaign ID to add the ad group to.
         name: Ad group name.
-        region_ids: Comma-separated region IDs for targeting.
+        region_ids: Comma-separated region IDs for targeting (optional).
+        type: Ad group type (optional, default TEXT_AD_GROUP).
+        extra_json: JSON string with additional parameters (optional).
     """
+    args = [
+        "adgroups",
+        "add",
+        "--campaign-id",
+        campaign_id,
+        "--name",
+        name,
+    ]
+    if type is not None:
+        args.extend(["--type", type])
+    if region_ids is not None:
+        args.extend(["--region-ids", region_ids])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "adgroups",
-            "add",
-            "--campaign-id",
-            campaign_id,
-            "--name",
-            name,
-            "--region-ids",
-            region_ids,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def adgroups_update(id: str, name: str) -> dict:
+def adgroups_update(
+    id: str,
+    name: str | None = None,
+    status: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Update an ad group.
 
     Args:
         id: Ad group ID to update.
-        name: New name for the ad group.
+        name: New name for the ad group (optional).
+        status: New status (optional).
+        extra_json: JSON string with additional parameters (optional).
     """
+    if not any((name, status, extra_json)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: name, status, extra_json",
+        ).__dict__
 
+    args = ["adgroups", "update", "--id", id]
+    if name is not None:
+        args.extend(["--name", name])
+    if status is not None:
+        args.extend(["--status", status])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(
-        ["adgroups", "update", "--id", id, "--name", name, "--format", "json"]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
@@ -83,10 +125,6 @@ def adgroups_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated ad group IDs (max 10).
     """
-    batch_error = _check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
+    from server.tools.helpers import run_single_id_batch
 
-    runner = get_runner()
-    result = runner.run_json(["adgroups", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "adgroups", "delete", ids)

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -29,9 +29,7 @@ def adgroups_list(
         types: Filter by types (optional).
     """
     args = ["adgroups", "get", "--format", "json"]
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = _check_batch_limit(normalized_campaign_ids)
         if batch_error:

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -68,7 +68,7 @@ def ads_list(
     args = ["ads", "get", "--format", "json"]
     if campaign_ids is not None:
         args.extend(["--campaign-ids", campaign_ids])
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = _check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -38,27 +38,51 @@ def _get_foreign_campaign_id(ids_str: str) -> str | None:
 
 @mcp.tool()
 @handle_cli_errors
-def ads_list(campaign_ids: str) -> list[dict] | dict:
-    """List ads in specified campaigns.
+def ads_list(
+    campaign_ids: str | None = None,
+    ids: str | None = None,
+    ad_group_ids: str | None = None,
+    status: str | None = None,
+) -> list[dict] | dict:
+    """List ads.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        campaign_ids: Comma-separated campaign IDs (optional, max 10).
+        ids: Comma-separated ad IDs (optional, max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
+        status: Filter by status (optional).
     """
-    batch_error = _check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    if campaign_ids is not None:
+        batch_error = _check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        foreign_id = _get_foreign_campaign_id(campaign_ids)
+        if foreign_id:
+            return ToolError(
+                error="foreign_campaign",
+                message=(
+                    f"Campaign {foreign_id} is unavailable — belongs to another account"
+                ),
+            ).__dict__
 
-    foreign_id = _get_foreign_campaign_id(campaign_ids)
-    if foreign_id:
-        return ToolError(
-            error="foreign_campaign",
-            message=f"Campaign {foreign_id} is unavailable — belongs to another account",
-        ).__dict__
+    args = ["ads", "get", "--format", "json"]
+    if campaign_ids is not None:
+        args.extend(["--campaign-ids", campaign_ids])
+    if ids is not None:
+        batch_error = _check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--ids", ids])
+    if ad_group_ids is not None:
+        batch_error = _check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--adgroup-ids", ad_group_ids])
+    if status is not None:
+        args.extend(["--status", status])
 
     runner = get_runner()
-    return runner.run_json(
-        ["ads", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -52,9 +52,7 @@ def ads_list(
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
         status: Filter by status (optional).
     """
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = _check_batch_limit(normalized_campaign_ids)
         if batch_error:
@@ -77,9 +75,7 @@ def ads_list(
         if batch_error:
             return batch_error.__dict__
         args.extend(["--ids", normalized_ids])
-    normalized_ad_group_ids = (
-        ad_group_ids.strip() if ad_group_ids is not None else None
-    )
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
     if normalized_ad_group_ids:
         batch_error = _check_batch_limit(normalized_ad_group_ids)
         if batch_error:

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -52,11 +52,14 @@ def ads_list(
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
         status: Filter by status (optional).
     """
-    if campaign_ids is not None:
-        batch_error = _check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = _check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        foreign_id = _get_foreign_campaign_id(campaign_ids)
+        foreign_id = _get_foreign_campaign_id(normalized_campaign_ids)
         if foreign_id:
             return ToolError(
                 error="foreign_campaign",
@@ -66,18 +69,22 @@ def ads_list(
             ).__dict__
 
     args = ["ads", "get", "--format", "json"]
-    if campaign_ids is not None:
-        args.extend(["--campaign-ids", campaign_ids])
-    if ids is not None and ids.strip():
-        batch_error = _check_batch_limit(ids)
+    if normalized_campaign_ids:
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = _check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--ids", ids])
-    if ad_group_ids is not None:
-        batch_error = _check_batch_limit(ad_group_ids)
+        args.extend(["--ids", normalized_ids])
+    normalized_ad_group_ids = (
+        ad_group_ids.strip() if ad_group_ids is not None else None
+    )
+    if normalized_ad_group_ids:
+        batch_error = _check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--adgroup-ids", ad_group_ids])
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
     if status is not None:
         args.extend(["--status", status])
 

--- a/server/tools/agency.py
+++ b/server/tools/agency.py
@@ -14,7 +14,7 @@ def agency_clients_list(ids: str | None = None) -> list[dict] | dict:
     """
     runner = get_runner()
     cmd = ["agencyclients", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         cmd.extend(["--ids", ids])
 
     result = runner.run_json(cmd)

--- a/server/tools/agency.py
+++ b/server/tools/agency.py
@@ -6,16 +6,16 @@ from server.tools import get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def agency_clients_list(login: str | None = None) -> list[dict] | dict:
+def agency_clients_list(ids: str | None = None) -> list[dict] | dict:
     """List agency clients.
 
     Args:
-        login: Optional agency login to filter by.
+        ids: Comma-separated client IDs to filter by (optional).
     """
     runner = get_runner()
     cmd = ["agencyclients", "get", "--format", "json"]
-    if login is not None:
-        cmd.extend(["--login", login])
+    if ids is not None:
+        cmd.extend(["--ids", ids])
 
     result = runner.run_json(cmd)
     return result
@@ -23,49 +23,28 @@ def agency_clients_list(login: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def agency_clients_add(login: str, client_info: str) -> dict:
+def agency_clients_add(client_json: str) -> dict:
     """Add a client to an agency.
 
     Args:
-        login: Agency login.
-        client_info: JSON string containing client information.
+        client_json: JSON string containing client information.
     """
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "agencyclients",
-            "add",
-            "--login",
-            login,
-            "--client-info",
-            client_info,
-            "--format",
-            "json",
-        ]
-    )
+    result = runner.run_json(["agencyclients", "add", "--json", client_json])
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def agency_clients_delete(login: str, client_login: str) -> dict:
+def agency_clients_delete(id: str) -> dict:
     """Remove a client from an agency.
 
+    Note: The Yandex Direct API does not actually support deleting
+    agency clients. This tool is kept for completeness.
+
     Args:
-        login: Agency login.
-        client_login: Client login to remove.
+        id: Client ID to remove.
     """
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "agencyclients",
-            "delete",
-            "--login",
-            login,
-            "--client-login",
-            client_login,
-            "--format",
-            "json",
-        ]
-    )
+    result = runner.run_json(["agencyclients", "delete", "--id", id])
     return result

--- a/server/tools/agency.py
+++ b/server/tools/agency.py
@@ -14,8 +14,9 @@ def agency_clients_list(ids: str | None = None) -> list[dict] | dict:
     """
     runner = get_runner()
     cmd = ["agencyclients", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        cmd.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        cmd.extend(["--ids", normalized_ids])
 
     result = runner.run_json(cmd)
     return result

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -2,55 +2,75 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
 @handle_cli_errors
-def audience_targets_list(campaign_ids: str) -> list[dict] | dict:
-    """List audience targets for specified campaigns.
+def audience_targets_list(
+    campaign_ids: str | None = None,
+    ad_group_ids: str | None = None,
+    ids: str | None = None,
+) -> list[dict] | dict:
+    """List audience targets.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        campaign_ids: Comma-separated campaign IDs (optional, max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
+        ids: Comma-separated audience target IDs (optional, max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    args = ["audiencetargets", "get", "--format", "json"]
+    if campaign_ids is not None:
+        batch_error = check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--campaign-ids", campaign_ids])
+    if ad_group_ids is not None:
+        batch_error = check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--adgroup-ids", ad_group_ids])
+    if ids is not None:
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--ids", ids])
 
     runner = get_runner()
-    result = runner.run_json(
-        ["audiencetargets", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def audience_targets_add(campaign_id: str, ad_group_id: str, audience_id: str) -> dict:
-    """Add an audience target to a campaign ad group.
+def audience_targets_add(
+    ad_group_id: str,
+    retargeting_list_id: str,
+    bid: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
+    """Add an audience target to an ad group.
 
     Args:
-        campaign_id: Campaign ID to add target to.
         ad_group_id: Ad group ID to add target to.
-        audience_id: Audience segment ID to target.
+        retargeting_list_id: Retargeting list ID to target.
+        bid: Optional bid amount in currency units (will be converted to
+            micro-units).
+        extra_json: Optional JSON string with additional parameters.
     """
+    args = [
+        "audiencetargets",
+        "add",
+        "--adgroup-id",
+        ad_group_id,
+        "--retargeting-list-id",
+        retargeting_list_id,
+    ]
+    if bid is not None:
+        args.extend(["--bid", bid])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "audiencetargets",
-            "add",
-            "--campaign-id",
-            campaign_id,
-            "--ad-group-id",
-            ad_group_id,
-            "--audience-id",
-            audience_id,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
@@ -61,17 +81,7 @@ def audience_targets_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated audience target IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["audiencetargets", "delete", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "audiencetargets", "delete", ids)
 
 
 @mcp.tool()
@@ -82,17 +92,7 @@ def audience_targets_suspend(ids: str) -> dict:
     Args:
         ids: Comma-separated audience target IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["audiencetargets", "suspend", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "audiencetargets", "suspend", ids)
 
 
 @mcp.tool()
@@ -103,14 +103,4 @@ def audience_targets_resume(ids: str) -> dict:
     Args:
         ids: Comma-separated audience target IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["audiencetargets", "resume", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "audiencetargets", "resume", ids)

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -20,21 +20,26 @@ def audience_targets_list(
         ids: Comma-separated audience target IDs (optional, max 10).
     """
     args = ["audiencetargets", "get", "--format", "json"]
-    if campaign_ids is not None:
-        batch_error = check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--campaign-ids", campaign_ids])
-    if ad_group_ids is not None:
-        batch_error = check_batch_limit(ad_group_ids)
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
+    if normalized_ad_group_ids:
+        batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--adgroup-ids", ad_group_ids])
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--ids", ids])
+        args.extend(["--ids", normalized_ids])
 
     runner = get_runner()
     return runner.run_json(args)
@@ -53,8 +58,7 @@ def audience_targets_add(
     Args:
         ad_group_id: Ad group ID to add target to.
         retargeting_list_id: Retargeting list ID to target.
-        bid: Optional bid amount in currency units (will be converted to
-            micro-units).
+        bid: Optional bid amount passed directly to the CLI.
         extra_json: Optional JSON string with additional parameters.
     """
     args = [

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -20,9 +20,7 @@ def audience_targets_list(
         ids: Comma-separated audience target IDs (optional, max 10).
     """
     args = ["audiencetargets", "get", "--format", "json"]
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -30,7 +30,7 @@ def audience_targets_list(
         if batch_error:
             return batch_error.__dict__
         args.extend(["--adgroup-ids", ad_group_ids])
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -18,9 +18,7 @@ def bidmodifiers_list(
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
     args = ["bidmodifiers", "get", "--format", "json"]
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -1,91 +1,82 @@
 """MCP tools for bid modifier management."""
 
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import (
-    check_batch_limit,
-    validate_positive_int,
-    validate_state,
-)
+from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
 @handle_cli_errors
-def bidmodifiers_list(campaign_ids: str) -> list[dict] | dict:
-    """List bid modifiers for specified campaigns.
+def bidmodifiers_list(
+    campaign_ids: str | None = None,
+    ad_group_ids: str | None = None,
+) -> list[dict] | dict:
+    """List bid modifiers.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        campaign_ids: Comma-separated campaign IDs (optional, max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    batch_error = check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    args = ["bidmodifiers", "get", "--format", "json"]
+    if campaign_ids is not None:
+        batch_error = check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--campaign-ids", campaign_ids])
+    if ad_group_ids is not None:
+        batch_error = check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--adgroup-ids", ad_group_ids])
 
     runner = get_runner()
-    return runner.run_json(
-        ["bidmodifiers", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def bidmodifiers_set(campaign_id: str, modifier_type: str, value: str) -> dict:
+def bidmodifiers_set(
+    campaign_id: str,
+    modifier_type: str,
+    value: str,
+    extra_json: str | None = None,
+) -> dict:
     """Set bid modifier for a campaign.
 
     Args:
         campaign_id: Campaign ID.
-        modifier_type: Type of modifier (e.g., "MULTIPLIER").
-        value: Modifier value. Must be a positive integer.
+        modifier_type: Type of modifier (e.g., "DEMOGRAPHICS", "MOBILE").
+        value: Modifier value (float, e.g. "1.5" for 50% increase).
+        extra_json: Optional JSON string with additional parameters.
     """
-    type_error = validate_state(modifier_type, ("MULTIPLIER",))
-    if type_error:
-        return type_error.__dict__
-
-    value_result = validate_positive_int(value, "value")
-    if isinstance(value_result, ToolError):
-        return value_result.__dict__
-
+    args = [
+        "bidmodifiers",
+        "set",
+        "--campaign-id",
+        campaign_id,
+        "--type",
+        modifier_type,
+        "--value",
+        value,
+    ]
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "bidmodifiers",
-            "set",
-            "--campaign-id",
-            campaign_id,
-            "--type",
-            modifier_type,
-            "--value",
-            str(value_result),
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def bidmodifiers_toggle(id: str, enabled: bool) -> dict:
+def bidmodifiers_toggle(id: str, enabled: bool = True) -> dict:
     """Toggle bid modifier on/off.
 
     Args:
         id: Modifier ID.
         enabled: True to enable, False to disable.
     """
+    flag = "--enabled" if enabled else "--disabled"
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "bidmodifiers",
-            "toggle",
-            "--id",
-            id,
-            "--enabled",
-            str(enabled).lower(),
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(["bidmodifiers", "toggle", "--id", id, flag])
 
 
 @mcp.tool()
@@ -96,12 +87,6 @@ def bidmodifiers_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated modifier IDs (max 10).
     """
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
+    from server.tools.helpers import run_single_id_batch
 
-    runner = get_runner()
-    result = runner.run_json(
-        ["bidmodifiers", "delete", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "bidmodifiers", "delete", ids)

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -18,16 +18,20 @@ def bidmodifiers_list(
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
     args = ["bidmodifiers", "get", "--format", "json"]
-    if campaign_ids is not None:
-        batch_error = check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--campaign-ids", campaign_ids])
-    if ad_group_ids is not None:
-        batch_error = check_batch_limit(ad_group_ids)
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
+    if normalized_ad_group_ids:
+        batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--adgroup-ids", ad_group_ids])
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
 
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -20,21 +20,26 @@ def bids_list(
         keyword_ids: Comma-separated keyword IDs (optional, max 10).
     """
     args = ["bids", "get", "--format", "json"]
-    if campaign_ids is not None:
-        batch_error = check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--campaign-ids", campaign_ids])
-    if ad_group_ids is not None:
-        batch_error = check_batch_limit(ad_group_ids)
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
+    if normalized_ad_group_ids:
+        batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--adgroup-ids", ad_group_ids])
-    if keyword_ids is not None:
-        batch_error = check_batch_limit(keyword_ids)
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
+    normalized_keyword_ids = keyword_ids.strip() if keyword_ids is not None else None
+    if normalized_keyword_ids:
+        batch_error = check_batch_limit(normalized_keyword_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--keyword-ids", keyword_ids])
+        args.extend(["--keyword-ids", normalized_keyword_ids])
 
     runner = get_runner()
     return runner.run_json(args)
@@ -51,8 +56,8 @@ def bids_set(
 
     Args:
         campaign_id: Campaign ID.
-        bid: Bid amount in currency units (will be converted to
-            micro-units). E.g. "15" for 15 RUB.
+        bid: Bid value passed directly to the CLI. Use the units and
+            format expected by the underlying command.
         extra_json: Optional JSON string with additional parameters.
     """
     if bid is None and extra_json is None:

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -20,9 +20,7 @@ def bids_list(
         keyword_ids: Comma-separated keyword IDs (optional, max 10).
     """
     args = ["bids", "get", "--format", "json"]
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -1,7 +1,7 @@
 """MCP tools for bid management."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
 
 
@@ -55,6 +55,12 @@ def bids_set(
             micro-units). E.g. "15" for 15 RUB.
         extra_json: Optional JSON string with additional parameters.
     """
+    if bid is None and extra_json is None:
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: bid, extra_json",
+        ).__dict__
+
     args = ["bids", "set", "--campaign-id", campaign_id]
     if bid is not None:
         args.extend(["--bid", bid])

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -1,60 +1,64 @@
 """MCP tools for bid management."""
 
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit, validate_positive_int
+from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
 @handle_cli_errors
-def bids_list(campaign_ids: str) -> list[dict] | dict:
-    """List bids for specified campaigns.
+def bids_list(
+    campaign_ids: str | None = None,
+    ad_group_ids: str | None = None,
+    keyword_ids: str | None = None,
+) -> list[dict] | dict:
+    """List bids.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        campaign_ids: Comma-separated campaign IDs (optional, max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
+        keyword_ids: Comma-separated keyword IDs (optional, max 10).
     """
-    batch_error = check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    args = ["bids", "get", "--format", "json"]
+    if campaign_ids is not None:
+        batch_error = check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--campaign-ids", campaign_ids])
+    if ad_group_ids is not None:
+        batch_error = check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--adgroup-ids", ad_group_ids])
+    if keyword_ids is not None:
+        batch_error = check_batch_limit(keyword_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--keyword-ids", keyword_ids])
 
     runner = get_runner()
-    return runner.run_json(
-        ["bids", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def bids_set(campaign_id: str, bid: str, context_bid: str | None = None) -> dict:
+def bids_set(
+    campaign_id: str,
+    bid: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Set bid for a campaign.
 
     Args:
         campaign_id: Campaign ID.
-        bid: Bid amount in micro-units (e.g., 15 RUB = 15000000). Must be a positive integer.
-        context_bid: Optional context bid amount in micro-units. Must be a positive integer if provided.
+        bid: Bid amount in currency units (will be converted to
+            micro-units). E.g. "15" for 15 RUB.
+        extra_json: Optional JSON string with additional parameters.
     """
-    bid_result = validate_positive_int(bid, "bid")
-    if isinstance(bid_result, ToolError):
-        return bid_result.__dict__
-    bid_value = bid_result
-
-    cmd = [
-        "bids",
-        "set",
-        "--campaign-id",
-        campaign_id,
-        "--bid",
-        str(bid_value),
-        "--format",
-        "json",
-    ]
-
-    if context_bid is not None:
-        context_result = validate_positive_int(context_bid, "context_bid")
-        if isinstance(context_result, ToolError):
-            return context_result.__dict__
-        cmd.extend(["--context-bid", str(context_result)])
-
+    args = ["bids", "set", "--campaign-id", campaign_id]
+    if bid is not None:
+        args.extend(["--bid", bid])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(cmd)
-    return result
+    return runner.run_json(args)

--- a/server/tools/businesses.py
+++ b/server/tools/businesses.py
@@ -13,7 +13,8 @@ def businesses_list(ids: str | None = None) -> list[dict] | dict:
         ids: Comma-separated business IDs (optional).
     """
     args = ["businesses", "get", "--format", "json"]
-    if ids:
-        args.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -30,11 +30,12 @@ def campaigns_list(
         ).__dict__
 
     args = ["campaigns", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--ids", ids])
+        args.extend(["--ids", normalized_ids])
     if status is not None:
         args.extend(["--status", status])
     if types is not None:

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -7,11 +7,20 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def campaigns_list(state: str | None = None) -> list[dict] | dict:
-    """List advertising campaigns, optionally filtered by state.
+def campaigns_list(
+    state: str | None = None,
+    ids: str | None = None,
+    status: str | None = None,
+    types: str | None = None,
+) -> list[dict] | dict:
+    """List advertising campaigns, optionally filtered.
 
     Args:
-        state: Filter by campaign state ("ON" or "OFF"). If None, returns all campaigns.
+        state: Filter by campaign state ("ON" or "OFF"). If None,
+            returns all campaigns. Applied client-side.
+        ids: Comma-separated campaign IDs (optional, max 10).
+        status: Filter by status, e.g. "ACTIVE", "SUSPENDED" (optional).
+        types: Filter by types, e.g. "TEXT_CAMPAIGN" (optional).
     """
     if state is not None and state not in ("ON", "OFF"):
         return ToolError(
@@ -19,8 +28,16 @@ def campaigns_list(state: str | None = None) -> list[dict] | dict:
             message=f"State must be 'ON' or 'OFF', got '{state}'",
         ).__dict__
 
+    args = ["campaigns", "get", "--format", "json"]
+    if ids is not None:
+        args.extend(["--ids", ids])
+    if status is not None:
+        args.extend(["--status", status])
+    if types is not None:
+        args.extend(["--types", types])
+
     runner = get_runner()
-    result = runner.run_json(["campaigns", "get", "--format", "json"])
+    result = runner.run_json(args)
 
     if isinstance(result, list) and state:
         result = [c for c in result if c.get("State") == state]

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -3,6 +3,7 @@
 from server.cli.runner import CliAuthError, CliNotFoundError
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
@@ -29,7 +30,10 @@ def campaigns_list(
         ).__dict__
 
     args = ["campaigns", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
         args.extend(["--ids", ids])
     if status is not None:
         args.extend(["--status", status])

--- a/server/tools/changes.py
+++ b/server/tools/changes.py
@@ -1,7 +1,7 @@
 """MCP tools for checking changes in Yandex.Direct."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 
 @mcp.tool()
@@ -30,7 +30,13 @@ def changes_checkcamp(campaign_ids: str, timestamp: str) -> dict:
     """
     from server.tools.helpers import check_batch_limit
 
-    batch_error = check_batch_limit(campaign_ids)
+    normalized_campaign_ids = campaign_ids.strip()
+    if not normalized_campaign_ids:
+        return ToolError(
+            error="missing_campaign_ids",
+            message="Provide at least one campaign ID.",
+        ).__dict__
+    batch_error = check_batch_limit(normalized_campaign_ids)
     if batch_error:
         return batch_error.__dict__
 
@@ -40,7 +46,7 @@ def changes_checkcamp(campaign_ids: str, timestamp: str) -> dict:
             "changes",
             "check-camp",
             "--campaign-ids",
-            campaign_ids,
+            normalized_campaign_ids,
             "--timestamp",
             timestamp,
             "--format",

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -14,7 +14,7 @@ def clients_get(ids: str | None = None) -> dict:
     """
     runner = get_runner()
     cmd = ["clients", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         cmd.extend(["--ids", ids])
 
     result = runner.run_json(cmd)

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -6,16 +6,16 @@ from server.tools import get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def clients_get(login: str | None = None) -> dict:
+def clients_get(ids: str | None = None) -> dict:
     """Get client information.
 
     Args:
-        login: Optional client login to retrieve specific client info.
+        ids: Comma-separated client IDs (optional).
     """
     runner = get_runner()
     cmd = ["clients", "get", "--format", "json"]
-    if login is not None:
-        cmd.extend(["--login", login])
+    if ids is not None:
+        cmd.extend(["--ids", ids])
 
     result = runner.run_json(cmd)
     return result
@@ -23,15 +23,22 @@ def clients_get(login: str | None = None) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def clients_update(login: str, fields: str) -> dict:
+def clients_update(client_id: str, extra_json: str) -> dict:
     """Update client information.
 
     Args:
-        login: Client login to update.
-        fields: JSON string containing fields to update.
+        client_id: Client ID to update.
+        extra_json: JSON string containing fields to update.
     """
     runner = get_runner()
     result = runner.run_json(
-        ["clients", "update", "--login", login, "--fields", fields, "--format", "json"]
+        [
+            "clients",
+            "update",
+            "--client-id",
+            client_id,
+            "--json",
+            extra_json,
+        ]
     )
     return result

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -14,8 +14,9 @@ def clients_get(ids: str | None = None) -> dict:
     """
     runner = get_runner()
     cmd = ["clients", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        cmd.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        cmd.extend(["--ids", normalized_ids])
 
     result = runner.run_json(cmd)
     return result

--- a/server/tools/creatives.py
+++ b/server/tools/creatives.py
@@ -14,9 +14,11 @@ def creatives_list(ids: str | None = None, campaign_ids: str | None = None) -> d
         campaign_ids: Comma-separated campaign IDs (optional).
     """
     args = ["creatives", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        args.extend(["--ids", ids])
-    if campaign_ids is not None and campaign_ids.strip():
-        args.extend(["--campaign-ids", campaign_ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
+    if normalized_campaign_ids:
+        args.extend(["--campaign-ids", normalized_campaign_ids])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/creatives.py
+++ b/server/tools/creatives.py
@@ -6,11 +6,17 @@ from server.tools import get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def creatives_list(ids: str) -> dict:
-    """List creatives by IDs.
+def creatives_list(ids: str | None = None, campaign_ids: str | None = None) -> dict:
+    """List creatives.
 
     Args:
-        ids: Comma-separated creative IDs.
+        ids: Comma-separated creative IDs (optional).
+        campaign_ids: Comma-separated campaign IDs (optional).
     """
+    args = ["creatives", "get", "--format", "json"]
+    if ids is not None:
+        args.extend(["--ids", ids])
+    if campaign_ids is not None:
+        args.extend(["--campaign-ids", campaign_ids])
     runner = get_runner()
-    return runner.run_json(["creatives", "get", "--ids", ids, "--format", "json"])
+    return runner.run_json(args)

--- a/server/tools/creatives.py
+++ b/server/tools/creatives.py
@@ -14,9 +14,9 @@ def creatives_list(ids: str | None = None, campaign_ids: str | None = None) -> d
         campaign_ids: Comma-separated campaign IDs (optional).
     """
     args = ["creatives", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         args.extend(["--ids", ids])
-    if campaign_ids is not None:
+    if campaign_ids is not None and campaign_ids.strip():
         args.extend(["--campaign-ids", campaign_ids])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/dictionaries.py
+++ b/server/tools/dictionaries.py
@@ -1,45 +1,42 @@
 """MCP tools for Yandex.Direct dictionaries."""
 
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools import get_runner, handle_cli_errors
 
-ALLOWED_DICTIONARY_TYPES = (
-    "GeographyRegions",
-    "TimeZones",
+ALLOWED_DICTIONARY_NAMES = (
     "Currencies",
+    "MetroStations",
+    "GeoRegions",
+    "TimeZones",
     "Constants",
     "AdCategories",
     "OperationSystemVersions",
-    "MobileOperatingSystemVersions",
-    "DeviceTypes",
-    "AgeRanges",
-    "Genders",
+    "ProductivityAssertions",
+    "SupplySidePlatforms",
     "Interests",
 )
 
 
 @mcp.tool()
 @handle_cli_errors
-def dictionaries_get(dictionary_type: str, locale: str | None = None) -> dict:
+def dictionaries_get(names: str) -> dict:
     """Get dictionary data.
 
     Args:
-        dictionary_type: Type of dictionary to retrieve. Must be one of:
-            GeographyRegions, TimeZones, Currencies, Constants, AdCategories,
-            OperationSystemVersions, MobileOperatingSystemVersions, DeviceTypes,
-            AgeRanges, Genders, Interests
-        locale: Optional locale code (e.g., "ru", "en").
+        names: Comma-separated dictionary names to retrieve.
+            Available: Currencies, MetroStations, GeoRegions, TimeZones,
+            Constants, AdCategories, OperationSystemVersions,
+            ProductivityAssertions, SupplySidePlatforms, Interests.
     """
-    if dictionary_type not in ALLOWED_DICTIONARY_TYPES:
-        return ToolError(
-            error="invalid_type",
-            message=f"Dictionary type must be one of {ALLOWED_DICTIONARY_TYPES}. Got: '{dictionary_type}'",
-        ).__dict__
-
     runner = get_runner()
-    cmd = ["dictionaries", "get", "--type", dictionary_type, "--format", "json"]
-    if locale is not None:
-        cmd.extend(["--locale", locale])
-
-    result = runner.run_json(cmd)
+    result = runner.run_json(
+        ["dictionaries", "get", "--names", names, "--format", "json"]
+    )
     return result
+
+
+@mcp.tool()
+@handle_cli_errors
+def dictionaries_list_names() -> list[str]:
+    """List available dictionary names."""
+    return list(ALLOWED_DICTIONARY_NAMES)

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -1,7 +1,7 @@
 """MCP tools for dynamic ad (webpage) management."""
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 
 @mcp.tool()
@@ -12,9 +12,22 @@ def dynamic_ads_list(ad_group_ids: str) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs.
     """
+    normalized_ad_group_ids = ad_group_ids.strip()
+    if not normalized_ad_group_ids:
+        return ToolError(
+            error="missing_ad_group_ids",
+            message="Provide at least one ad group ID.",
+        ).__dict__
     runner = get_runner()
     return runner.run_json(
-        ["dynamicads", "get", "--adgroup-ids", ad_group_ids, "--format", "json"]
+        [
+            "dynamicads",
+            "get",
+            "--adgroup-ids",
+            normalized_ad_group_ids,
+            "--format",
+            "json",
+        ]
     )
 
 

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -1,121 +1,99 @@
-"""MCP tools for dynamic target management.
+"""MCP tools for dynamic ad targets (legacy aliases).
 
-NOTE: The direct-cli does not expose a ``dynamictargets`` subcommand.
-The CLI provides ``dynamicads`` (see dynamic_ads.py) instead.
-These tools are kept as placeholders until the CLI adds a matching command.
+These tools wrap the ``dynamictargets`` CLI subcommand, which is an alias
+for ``dynamicads``.  Prefer the canonical wrappers in ``dynamic_ads.py``
+— the tools here are kept for backward compatibility with existing
+skill/prompt references.
 """
 
-import json
-
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools import get_runner, handle_cli_errors
+
+from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_targets_list(ad_group_ids: str) -> list[dict] | dict:
-    """List dynamic targets for specified ad groups.
+def dynamic_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
+    """List dynamic ad targets.
 
     Args:
-        ad_group_ids: Comma-separated ad group IDs (max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    from server.tools.helpers import check_batch_limit
+    if ad_group_ids is not None:
+        batch_error = check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
 
-    batch_error = check_batch_limit(ad_group_ids)
-    if batch_error:
-        return batch_error.__dict__
-
+    args = ["dynamictargets", "get", "--format", "json"]
+    if ad_group_ids:
+        args.extend(["--adgroup-ids", ad_group_ids])
     runner = get_runner()
-    result = runner.run_json(
-        ["dynamictargets", "get", "--ad-group-ids", ad_group_ids, "--format", "json"]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_targets_add(ad_group_id: str, conditions: str) -> dict:
-    """Add a dynamic target to an ad group.
+def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
+    """Add a dynamic ad target.
 
     Args:
-        ad_group_id: Ad group ID to add target to.
-        conditions: JSON string with dynamic target conditions.
+        ad_group_id: Ad group ID.
+        target_data: JSON string with target data (must include Name and Conditions).
     """
-    # Validate JSON format
-    try:
-        json.loads(conditions)
-    except json.JSONDecodeError as e:
-        return ToolError(
-            error="invalid_json",
-            message=f"Conditions must be valid JSON. Got: '{conditions}'. Error: {e}",
-        ).__dict__
-
     runner = get_runner()
-    result = runner.run_json(
+    return runner.run_json(
         [
             "dynamictargets",
             "add",
-            "--ad-group-id",
+            "--adgroup-id",
             ad_group_id,
-            "--conditions",
-            conditions,
+            "--json",
+            target_data,
             "--format",
             "json",
         ]
     )
-    return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_targets_update(id: str, conditions: str) -> dict:
-    """Update a dynamic target.
+def dynamic_targets_update(id: str, extra_json: str) -> dict:
+    """Update a dynamic ad target.
 
     Args:
-        id: Dynamic target ID to update.
-        conditions: JSON string with new conditions.
+        id: Target ID.
+        extra_json: JSON string with fields to update.
     """
-    # Validate JSON format
-    try:
-        json.loads(conditions)
-    except json.JSONDecodeError as e:
-        return ToolError(
-            error="invalid_json",
-            message=f"Conditions must be valid JSON. Got: '{conditions}'. Error: {e}",
-        ).__dict__
-
     runner = get_runner()
-    result = runner.run_json(
+    return runner.run_json(
         [
             "dynamictargets",
             "update",
             "--id",
             id,
-            "--conditions",
-            conditions,
+            "--json",
+            extra_json,
             "--format",
             "json",
         ]
     )
-    return result
 
 
 @mcp.tool()
 @handle_cli_errors
 def dynamic_targets_delete(ids: str) -> dict:
-    """Delete dynamic targets.
+    """Delete dynamic ad targets.
 
     Args:
-        ids: Comma-separated dynamic target IDs (max 10).
+        ids: Comma-separated target IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
     batch_error = check_batch_limit(ids)
     if batch_error:
         return batch_error.__dict__
 
     runner = get_runner()
     result = runner.run_json(
-        ["dynamictargets", "delete", "--ids", ids, "--format", "json"]
+        ["dynamictargets", "delete", "--id", ids, "--format", "json"]
     )
     return result

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -20,9 +20,7 @@ def dynamic_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    normalized_ad_group_ids = (
-        ad_group_ids.strip() if ad_group_ids is not None else None
-    )
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
     if normalized_ad_group_ids:
         batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -1,9 +1,9 @@
-"""MCP tools for dynamic ad targets (legacy aliases).
+"""Legacy compatibility wrappers for dynamic ad target MCP tools.
 
-These tools wrap the ``dynamictargets`` CLI subcommand, which is an alias
-for ``dynamicads``.  Prefer the canonical wrappers in ``dynamic_ads.py``
-— the tools here are kept for backward compatibility with existing
-skill/prompt references.
+These tools preserve historical MCP names used by prompts and skills.
+The audited direct-cli surface does not guarantee a working
+``dynamictargets`` subcommand, so callers should prefer the canonical
+wrappers in ``dynamic_ads.py``.
 """
 
 from server.main import mcp

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -26,7 +26,7 @@ def dynamic_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
         if batch_error:
             return batch_error.__dict__
 
-    args = ["dynamictargets", "get", "--format", "json"]
+    args = ["dynamicads", "get", "--format", "json"]
     if normalized_ad_group_ids:
         args.extend(["--adgroup-ids", normalized_ad_group_ids])
     runner = get_runner()
@@ -45,7 +45,7 @@ def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
     runner = get_runner()
     return runner.run_json(
         [
-            "dynamictargets",
+            "dynamicads",
             "add",
             "--adgroup-id",
             ad_group_id,
@@ -69,7 +69,7 @@ def dynamic_targets_update(id: str, extra_json: str) -> dict:
     runner = get_runner()
     return runner.run_json(
         [
-            "dynamictargets",
+            "dynamicads",
             "update",
             "--id",
             id,
@@ -89,4 +89,4 @@ def dynamic_targets_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated target IDs (max 10).
     """
-    return run_single_id_batch(get_runner(), "dynamictargets", "delete", ids)
+    return run_single_id_batch(get_runner(), "dynamicads", "delete", ids)

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -1,4 +1,9 @@
-"""MCP tools for dynamic target management."""
+"""MCP tools for dynamic target management.
+
+NOTE: The direct-cli does not expose a ``dynamictargets`` subcommand.
+The CLI provides ``dynamicads`` (see dynamic_ads.py) instead.
+These tools are kept as placeholders until the CLI adds a matching command.
+"""
 
 import json
 

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -9,7 +9,7 @@ skill/prompt references.
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
-from server.tools.helpers import check_batch_limit
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
@@ -20,14 +20,17 @@ def dynamic_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    if ad_group_ids is not None:
-        batch_error = check_batch_limit(ad_group_ids)
+    normalized_ad_group_ids = (
+        ad_group_ids.strip() if ad_group_ids is not None else None
+    )
+    if normalized_ad_group_ids:
+        batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
 
     args = ["dynamictargets", "get", "--format", "json"]
-    if ad_group_ids:
-        args.extend(["--adgroup-ids", ad_group_ids])
+    if normalized_ad_group_ids:
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -88,12 +91,4 @@ def dynamic_targets_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated target IDs (max 10).
     """
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["dynamictargets", "delete", "--id", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "dynamictargets", "delete", ids)

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -6,17 +6,18 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def feeds_list(ids: str) -> dict:
-    """List feeds by IDs.
+def feeds_list(ids: str | None = None) -> dict:
+    """List feeds.
 
     Args:
-        ids: Comma-separated feed IDs.
+        ids: Comma-separated feed IDs (optional, omit for all feeds).
     """
+    args = ["feeds", "get", "--format", "json"]
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
     runner = get_runner()
-    normalized_ids = ids.strip()
-    return runner.run_json(
-        ["feeds", "get", "--ids", normalized_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -2,7 +2,6 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
@@ -19,48 +18,51 @@ def feeds_list(ids: str) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def feeds_add(name: str, url: str) -> dict:
+def feeds_add(name: str, url: str, extra_json: str | None = None) -> dict:
     """Add a new feed.
 
     Args:
         name: Feed name.
         url: Feed URL.
+        extra_json: JSON string with additional parameters (optional).
     """
+    args = ["feeds", "add", "--name", name, "--url", url]
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    return runner.run_json(
-        ["feeds", "add", "--name", name, "--url", url, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def feeds_update(id: str, name: str | None = None, url: str | None = None) -> dict:
+def feeds_update(
+    id: str,
+    name: str | None = None,
+    url: str | None = None,
+    extra_json: str | None = None,
+) -> dict:
     """Update an existing feed.
 
     Args:
         id: Feed ID to update.
         name: Optional new feed name.
         url: Optional new feed URL.
+        extra_json: Optional JSON string with additional parameters.
     """
-    if name is None and url is None:
+    if not any((name, url, extra_json)):
         return ToolError(
-            error="nothing_to_update",
-            message="At least one field (name, url) must be provided for update",
+            error="missing_update_fields",
+            message="Provide at least one of: name, url, extra_json",
         ).__dict__
 
-    runner = get_runner()
-    args = [
-        "feeds",
-        "update",
-        "--id",
-        id,
-        "--format",
-        "json",
-    ]
+    args = ["feeds", "update", "--id", id]
     if name is not None:
         args.extend(["--name", name])
     if url is not None:
         args.extend(["--url", url])
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
+    runner = get_runner()
     return runner.run_json(args)
 
 
@@ -72,9 +74,6 @@ def feeds_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated feed IDs (max 10).
     """
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
+    from server.tools.helpers import run_single_id_batch
 
-    runner = get_runner()
-    return runner.run_json(["feeds", "delete", "--ids", ids, "--format", "json"])
+    return run_single_id_batch(get_runner(), "feeds", "delete", ids)

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -13,7 +13,10 @@ def feeds_list(ids: str) -> dict:
         ids: Comma-separated feed IDs.
     """
     runner = get_runner()
-    return runner.run_json(["feeds", "get", "--ids", ids, "--format", "json"])
+    normalized_ids = ids.strip()
+    return runner.run_json(
+        ["feeds", "get", "--ids", normalized_ids, "--format", "json"]
+    )
 
 
 @mcp.tool()

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -52,6 +52,11 @@ def run_single_id_batch(runner, resource: str, action: str, ids_str: str) -> dic
         return batch_error.__dict__
 
     ids = parse_ids(ids_str)
+    if not ids:
+        return ToolError(
+            error="missing_ids",
+            message=f"Provide at least one {resource} ID.",
+        ).__dict__
     results = [runner.run_json([resource, action, "--id", item_id]) for item_id in ids]
     if len(results) == 1:
         return results[0]

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -57,11 +57,23 @@ def run_single_id_batch(runner, resource: str, action: str, ids_str: str) -> dic
             error="missing_ids",
             message=f"Provide at least one {resource} ID.",
         ).__dict__
-    results = [runner.run_json([resource, action, "--id", item_id]) for item_id in ids]
+    results = []
+    succeeded = []
+    failed = []
+    for item_id in ids:
+        try:
+            result = runner.run_json([resource, action, "--id", item_id])
+            results.append(result)
+            succeeded.append(item_id)
+        except Exception as e:
+            results.append({"success": False, "id": item_id, "error": str(e)})
+            failed.append(item_id)
     if len(results) == 1:
         return results[0]
-    success = all(
-        not isinstance(result, dict) or result.get("success", True) is not False
-        for result in results
-    )
-    return {"success": success, "ids": ids, "results": results}
+    return {
+        "success": len(failed) == 0,
+        "ids": ids,
+        "succeeded": succeeded,
+        "failed": failed,
+        "results": results,
+    }

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -1,5 +1,11 @@
 """Shared helpers for MCP tool modules."""
 
+from server.cli.runner import (
+    CliAuthError,
+    CliNotFoundError,
+    CliRegistrationError,
+    CliTimeoutError,
+)
 from server.tools import ToolError
 
 MAX_BATCH_SIZE = 10
@@ -65,6 +71,8 @@ def run_single_id_batch(runner, resource: str, action: str, ids_str: str) -> dic
             result = runner.run_json([resource, action, "--id", item_id])
             results.append(result)
             succeeded.append(item_id)
+        except (CliAuthError, CliNotFoundError, CliRegistrationError, CliTimeoutError):
+            raise
         except Exception as e:
             results.append({"success": False, "id": item_id, "error": str(e)})
             failed.append(item_id)

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -14,8 +14,9 @@ def adimages_list(ids: str | None = None) -> list[dict] | dict:
     """
     runner = get_runner()
     cmd = ["adimages", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        cmd.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        cmd.extend(["--ids", normalized_ids])
     result = runner.run_json(cmd)
     return result
 

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -6,46 +6,41 @@ from server.tools import get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def adimages_list(ids: str) -> list[dict] | dict:
+def adimages_list(ids: str | None = None) -> list[dict] | dict:
     """List ad images.
 
     Args:
-        ids: Comma-separated image IDs (empty string for all images).
+        ids: Comma-separated image IDs (optional, empty for all images).
     """
     runner = get_runner()
-    result = runner.run_json(["adimages", "get", "--ids", ids, "--format", "json"])
+    cmd = ["adimages", "get", "--format", "json"]
+    if ids is not None:
+        cmd.extend(["--ids", ids])
+    result = runner.run_json(cmd)
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def adimages_add(image_data: str) -> dict:
+def adimages_add(image_json: str) -> dict:
     """Add an ad image.
 
     Args:
-        image_data: JSON string with image data (base64 encoded).
+        image_json: JSON string with image data (e.g. base64-encoded).
     """
     runner = get_runner()
-    result = runner.run_json(
-        ["adimages", "add", "--data", image_data, "--format", "json"]
-    )
+    result = runner.run_json(["adimages", "add", "--json", image_json])
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def adimages_delete(ids: str) -> dict:
-    """Delete ad images.
+def adimages_delete(hash_value: str) -> dict:
+    """Delete an ad image by its hash.
 
     Args:
-        ids: Comma-separated image IDs (max 10).
+        hash_value: Ad image hash to delete.
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
     runner = get_runner()
-    result = runner.run_json(["adimages", "delete", "--ids", ids, "--format", "json"])
+    result = runner.run_json(["adimages", "delete", "--hash", hash_value])
     return result

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -39,6 +39,10 @@ def adimages_add(image_json: str) -> dict:
 def adimages_delete(hash_value: str) -> dict:
     """Delete an ad image by its hash.
 
+    Note: The previous ``ids`` parameter accepted comma-separated IDs,
+    but the CLI only supports deleting a single image at a time via
+    ``--hash``.  The old parameter was always incorrect.
+
     Args:
         hash_value: Ad image hash to delete.
     """

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -14,7 +14,7 @@ def adimages_list(ids: str | None = None) -> list[dict] | dict:
     """
     runner = get_runner()
     cmd = ["adimages", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         cmd.extend(["--ids", ids])
     result = runner.run_json(cmd)
     return result

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -19,12 +19,15 @@ def keyword_bids_list(
         keyword_ids: Comma-separated keyword IDs (optional).
     """
     args = ["keywordbids", "get", "--format", "json"]
-    if campaign_ids:
-        args.extend(["--campaign-ids", campaign_ids])
-    if ad_group_ids:
-        args.extend(["--adgroup-ids", ad_group_ids])
-    if keyword_ids:
-        args.extend(["--keyword-ids", keyword_ids])
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
+    if normalized_campaign_ids:
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
+    if normalized_ad_group_ids:
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
+    normalized_keyword_ids = keyword_ids.strip() if keyword_ids is not None else None
+    if normalized_keyword_ids:
+        args.extend(["--keyword-ids", normalized_keyword_ids])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -25,13 +25,26 @@ def keywords_list(campaign_ids: str) -> list[dict] | dict:
     Args:
         campaign_ids: Comma-separated campaign IDs (max 10).
     """
-    batch_error = _check_batch_limit(campaign_ids)
+    normalized_campaign_ids = campaign_ids.strip()
+    if not normalized_campaign_ids:
+        return ToolError(
+            error="missing_campaign_ids",
+            message="Provide at least one campaign ID.",
+        ).__dict__
+    batch_error = _check_batch_limit(normalized_campaign_ids)
     if batch_error:
         return batch_error.__dict__
 
     runner = get_runner()
     return runner.run_json(
-        ["keywords", "get", "--campaign-ids", campaign_ids, "--format", "json"]
+        [
+            "keywords",
+            "get",
+            "--campaign-ids",
+            normalized_campaign_ids,
+            "--format",
+            "json",
+        ]
     )
 
 

--- a/server/tools/leads.py
+++ b/server/tools/leads.py
@@ -15,9 +15,7 @@ def leads_list(campaign_ids: str | None = None) -> dict:
             If None, returns leads for all campaigns.
     """
     args = ["leads", "get", "--format", "json"]
-    normalized_campaign_ids = (
-        campaign_ids.strip() if campaign_ids is not None else None
-    )
+    normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
         batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:

--- a/server/tools/leads.py
+++ b/server/tools/leads.py
@@ -7,31 +7,19 @@ from server.tools.helpers import check_batch_limit
 
 @mcp.tool()
 @handle_cli_errors
-def leads_list(
-    campaign_ids: str, date_from: str | None = None, date_to: str | None = None
-) -> dict:
+def leads_list(campaign_ids: str | None = None) -> dict:
     """List leads for specified campaigns.
 
     Args:
         campaign_ids: Comma-separated campaign IDs (max 10).
-        date_from: Optional start date in YYYY-MM-DD format.
-        date_to: Optional end date in YYYY-MM-DD format.
+            If None, returns leads for all campaigns.
     """
-    batch_error = check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    args = ["leads", "get", "--format", "json"]
+    if campaign_ids is not None:
+        batch_error = check_batch_limit(campaign_ids)
+        if batch_error:
+            return batch_error.__dict__
+        args.extend(["--campaign-ids", campaign_ids])
 
     runner = get_runner()
-    args = [
-        "leads",
-        "get",
-        "--campaign-ids",
-        campaign_ids,
-        "--format",
-        "json",
-    ]
-    if date_from is not None:
-        args.extend(["--date-from", date_from])
-    if date_to is not None:
-        args.extend(["--date-to", date_to])
     return runner.run_json(args)

--- a/server/tools/leads.py
+++ b/server/tools/leads.py
@@ -15,11 +15,14 @@ def leads_list(campaign_ids: str | None = None) -> dict:
             If None, returns leads for all campaigns.
     """
     args = ["leads", "get", "--format", "json"]
-    if campaign_ids is not None:
-        batch_error = check_batch_limit(campaign_ids)
+    normalized_campaign_ids = (
+        campaign_ids.strip() if campaign_ids is not None else None
+    )
+    if normalized_campaign_ids:
+        batch_error = check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        args.extend(["--campaign-ids", campaign_ids])
+        args.extend(["--campaign-ids", normalized_campaign_ids])
 
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -13,8 +13,9 @@ def negative_keyword_shared_sets_list(ids: str | None = None) -> list[dict] | di
         ids: Comma-separated set IDs (optional).
     """
     args = ["negativekeywordsharedsets", "get", "--format", "json"]
-    if ids:
-        args.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -1,9 +1,9 @@
-"""MCP tools for negative keyword shared sets (legacy aliases).
+"""Legacy compatibility wrappers for negative keyword shared set tools.
 
-These tools wrap the ``negativekeywords`` CLI subcommand, which is an alias
-for ``negativekeywordsharedsets``.  Prefer the canonical wrappers in
-``negative_keyword_shared_sets.py`` — the tools here are kept for
-backward compatibility with existing skill/prompt references.
+These tools preserve historical MCP names used by prompts and skills.
+The audited direct-cli surface does not guarantee a working
+``negativekeywords`` subcommand, so callers should prefer the canonical
+wrappers in ``negative_keyword_shared_sets.py``.
 """
 
 from server.main import mcp

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -7,7 +7,7 @@ wrappers in ``negative_keyword_shared_sets.py``.
 """
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 from server.tools.helpers import check_batch_limit, run_single_id_batch
 
@@ -71,6 +71,12 @@ def negative_keywords_update(
         name: New set name (optional).
         keywords: New comma-separated negative keywords (optional).
     """
+    if not any((name, keywords)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: name, keywords",
+        ).__dict__
+
     args = ["negativekeywordsharedsets", "update", "--id", id]
     if name is not None:
         args.extend(["--name", name])

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -9,7 +9,7 @@ backward compatibility with existing skill/prompt references.
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
-from server.tools.helpers import check_batch_limit
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
@@ -20,14 +20,15 @@ def negative_keywords_list(ids: str | None = None) -> list[dict] | dict:
     Args:
         ids: Comma-separated set IDs (optional, max 10).
     """
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
 
     args = ["negativekeywords", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        args.extend(["--ids", ids])
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -88,12 +89,4 @@ def negative_keywords_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated set IDs (max 10).
     """
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["negativekeywords", "delete", "--id", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "negativekeywords", "delete", ids)

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -26,7 +26,7 @@ def negative_keywords_list(ids: str | None = None) -> list[dict] | dict:
         if batch_error:
             return batch_error.__dict__
 
-    args = ["negativekeywords", "get", "--format", "json"]
+    args = ["negativekeywordsharedsets", "get", "--format", "json"]
     if normalized_ids:
         args.extend(["--ids", normalized_ids])
     runner = get_runner()
@@ -45,7 +45,7 @@ def negative_keywords_add(name: str, keywords: str) -> dict:
     runner = get_runner()
     return runner.run_json(
         [
-            "negativekeywords",
+            "negativekeywordsharedsets",
             "add",
             "--name",
             name,
@@ -71,7 +71,7 @@ def negative_keywords_update(
         name: New set name (optional).
         keywords: New comma-separated negative keywords (optional).
     """
-    args = ["negativekeywords", "update", "--id", id]
+    args = ["negativekeywordsharedsets", "update", "--id", id]
     if name is not None:
         args.extend(["--name", name])
     if keywords is not None:
@@ -89,4 +89,4 @@ def negative_keywords_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated set IDs (max 10).
     """
-    return run_single_id_batch(get_runner(), "negativekeywords", "delete", ids)
+    return run_single_id_batch(get_runner(), "negativekeywordsharedsets", "delete", ids)

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -20,13 +20,13 @@ def negative_keywords_list(ids: str | None = None) -> list[dict] | dict:
     Args:
         ids: Comma-separated set IDs (optional, max 10).
     """
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__
 
     args = ["negativekeywords", "get", "--format", "json"]
-    if ids:
+    if ids is not None and ids.strip():
         args.extend(["--ids", ids])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -1,4 +1,10 @@
-"""MCP tools for negative keyword management."""
+"""MCP tools for negative keyword management.
+
+NOTE: The direct-cli does not expose a ``negativekeywords`` subcommand.
+The CLI only provides ``negativekeywordsharedsets`` (see
+negative_keyword_shared_sets.py).  These tools are kept as placeholders
+until the CLI adds support for campaign-level negative keywords.
+"""
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors

--- a/server/tools/negative_keywords.py
+++ b/server/tools/negative_keywords.py
@@ -1,9 +1,9 @@
-"""MCP tools for negative keyword management.
+"""MCP tools for negative keyword shared sets (legacy aliases).
 
-NOTE: The direct-cli does not expose a ``negativekeywords`` subcommand.
-The CLI only provides ``negativekeywordsharedsets`` (see
-negative_keyword_shared_sets.py).  These tools are kept as placeholders
-until the CLI adds support for campaign-level negative keywords.
+These tools wrap the ``negativekeywords`` CLI subcommand, which is an alias
+for ``negativekeywordsharedsets``.  Prefer the canonical wrappers in
+``negative_keyword_shared_sets.py`` — the tools here are kept for
+backward compatibility with existing skill/prompt references.
 """
 
 from server.main import mcp
@@ -14,79 +14,79 @@ from server.tools.helpers import check_batch_limit
 
 @mcp.tool()
 @handle_cli_errors
-def negative_keywords_list(campaign_ids: str) -> list[dict] | dict:
-    """List negative keywords in specified campaigns.
+def negative_keywords_list(ids: str | None = None) -> list[dict] | dict:
+    """List negative keyword shared sets.
 
     Args:
-        campaign_ids: Comma-separated campaign IDs (max 10).
+        ids: Comma-separated set IDs (optional, max 10).
     """
-    batch_error = check_batch_limit(campaign_ids)
-    if batch_error:
-        return batch_error.__dict__
+    if ids is not None:
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
 
+    args = ["negativekeywords", "get", "--format", "json"]
+    if ids:
+        args.extend(["--ids", ids])
     runner = get_runner()
-    return runner.run_json(
-        ["negativekeywords", "get", "--campaign-ids", campaign_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def negative_keywords_add(campaign_id: str, keywords: str) -> dict:
-    """Add negative keywords to a campaign.
+def negative_keywords_add(name: str, keywords: str) -> dict:
+    """Add a negative keyword shared set.
 
     Args:
-        campaign_id: Campaign ID.
-        keywords: Comma-separated keyword list to add as negative keywords.
+        name: Set name.
+        keywords: Comma-separated negative keywords.
     """
     runner = get_runner()
-    result = runner.run_json(
+    return runner.run_json(
         [
             "negativekeywords",
             "add",
-            "--campaign-id",
-            campaign_id,
+            "--name",
+            name,
             "--keywords",
             keywords,
             "--format",
             "json",
         ]
     )
-    return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def negative_keywords_update(id: str, keywords: str) -> dict:
-    """Update negative keyword set.
+def negative_keywords_update(
+    id: str,
+    name: str | None = None,
+    keywords: str | None = None,
+) -> dict:
+    """Update a negative keyword shared set.
 
     Args:
-        id: Negative keyword set ID.
-        keywords: Comma-separated keyword list to set as negative keywords.
+        id: Set ID.
+        name: New set name (optional).
+        keywords: New comma-separated negative keywords (optional).
     """
+    args = ["negativekeywords", "update", "--id", id]
+    if name is not None:
+        args.extend(["--name", name])
+    if keywords is not None:
+        args.extend(["--keywords", keywords])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "negativekeywords",
-            "update",
-            "--id",
-            id,
-            "--keywords",
-            keywords,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
 def negative_keywords_delete(ids: str) -> dict:
-    """Delete negative keyword sets.
+    """Delete negative keyword shared sets.
 
     Args:
-        ids: Comma-separated negative keyword set IDs (max 10).
+        ids: Comma-separated set IDs (max 10).
     """
     batch_error = check_batch_limit(ids)
     if batch_error:
@@ -94,6 +94,6 @@ def negative_keywords_delete(ids: str) -> dict:
 
     runner = get_runner()
     result = runner.run_json(
-        ["negativekeywords", "delete", "--ids", ids, "--format", "json"]
+        ["negativekeywords", "delete", "--id", ids, "--format", "json"]
     )
     return result

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -17,9 +17,9 @@ def retargeting_list(
         types: Comma-separated types to filter by (optional).
     """
     args = ["retargeting", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         args.extend(["--ids", ids])
-    if types is not None:
+    if types is not None and types.strip():
         args.extend(["--types", types])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -2,35 +2,55 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import run_single_id_batch
 
 
 @mcp.tool()
 @handle_cli_errors
-def retargeting_list(ids: str) -> list[dict] | dict:
+def retargeting_list(
+    ids: str | None = None, types: str | None = None
+) -> list[dict] | dict:
     """List retargeting lists.
 
     Args:
-        ids: Comma-separated retargeting list IDs.
+        ids: Comma-separated retargeting list IDs (optional).
+        types: Comma-separated types to filter by (optional).
     """
+    args = ["retargeting", "get", "--format", "json"]
+    if ids is not None:
+        args.extend(["--ids", ids])
+    if types is not None:
+        args.extend(["--types", types])
     runner = get_runner()
-    result = runner.run_json(["retargeting", "get", "--ids", ids, "--format", "json"])
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def retargeting_add(name: str, rule: str) -> dict:
+def retargeting_add(
+    name: str,
+    list_type: str,
+    extra_json: str | None = None,
+) -> dict:
     """Add a retargeting list.
 
     Args:
         name: Name for the retargeting list.
-        rule: JSON string with retargeting conditions.
+        list_type: List type (e.g. "AUDIENCE_SEGMENT").
+        extra_json: Optional JSON string with additional parameters.
     """
+    args = [
+        "retargeting",
+        "add",
+        "--name",
+        name,
+        "--type",
+        list_type,
+    ]
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
     runner = get_runner()
-    result = runner.run_json(
-        ["retargeting", "add", "--name", name, "--rule", rule, "--format", "json"]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
@@ -41,14 +61,4 @@ def retargeting_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated retargeting list IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["retargeting", "delete", "--ids", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "retargeting", "delete", ids)

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -17,10 +17,12 @@ def retargeting_list(
         types: Comma-separated types to filter by (optional).
     """
     args = ["retargeting", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        args.extend(["--ids", ids])
-    if types is not None and types.strip():
-        args.extend(["--types", types])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
+    normalized_types = types.strip() if types is not None else None
+    if normalized_types:
+        args.extend(["--types", normalized_types])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -2,39 +2,39 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
 @handle_cli_errors
-def sitelinks_list(ids: str) -> list[dict] | dict:
+def sitelinks_list(ids: str | None = None) -> list[dict] | dict:
     """List sitelinks sets.
 
     Args:
-        ids: Comma-separated sitelinks set IDs (max 10).
+        ids: Comma-separated sitelinks set IDs (optional, max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
+    cmd = ["sitelinks", "get", "--format", "json"]
+    if ids is not None:
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
+        cmd.extend(["--ids", ids])
     runner = get_runner()
-    result = runner.run_json(["sitelinks", "get", "--ids", ids, "--format", "json"])
+    result = runner.run_json(cmd)
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def sitelinks_add(sitelinks_data: str) -> dict:
+def sitelinks_add(links: str) -> dict:
     """Add a sitelinks set.
 
     Args:
-        sitelinks_data: JSON string describing the sitelinks set.
+        links: JSON array of sitelink objects.
+            Example: '[{"Title":"About","Href":"https://example.com/about"}]'
     """
     runner = get_runner()
-    result = runner.run_json(
-        ["sitelinks", "add", "--data", sitelinks_data, "--format", "json"]
-    )
+    result = runner.run_json(["sitelinks", "add", "--links", links])
     return result
 
 
@@ -46,12 +46,4 @@ def sitelinks_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated sitelinks set IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["sitelinks", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "sitelinks", "delete", ids)

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -14,7 +14,7 @@ def sitelinks_list(ids: str | None = None) -> list[dict] | dict:
         ids: Comma-separated sitelinks set IDs (optional, max 10).
     """
     cmd = ["sitelinks", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -14,11 +14,12 @@ def sitelinks_list(ids: str | None = None) -> list[dict] | dict:
         ids: Comma-separated sitelinks set IDs (optional, max 10).
     """
     cmd = ["sitelinks", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        cmd.extend(["--ids", ids])
+        cmd.extend(["--ids", normalized_ids])
     runner = get_runner()
     result = runner.run_json(cmd)
     return result

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -12,9 +12,22 @@ def smart_ad_targets_list(ad_group_ids: str) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs.
     """
+    normalized_ad_group_ids = ad_group_ids.strip()
+    if not normalized_ad_group_ids:
+        return ToolError(
+            error="missing_ad_group_ids",
+            message="Provide at least one ad group ID.",
+        ).__dict__
     runner = get_runner()
     return runner.run_json(
-        ["smartadtargets", "get", "--adgroup-ids", ad_group_ids, "--format", "json"]
+        [
+            "smartadtargets",
+            "get",
+            "--adgroup-ids",
+            normalized_ad_group_ids,
+            "--format",
+            "json",
+        ]
     )
 
 

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -7,7 +7,7 @@ wrappers in ``smart_ad_targets.py``.
 """
 
 from server.main import mcp
-from server.tools import get_runner, handle_cli_errors
+from server.tools import ToolError, get_runner, handle_cli_errors
 
 from server.tools.helpers import check_batch_limit, run_single_id_batch
 
@@ -72,6 +72,12 @@ def smart_targets_update(
         target_type: New target type (optional).
         extra_json: JSON string with fields to update (optional).
     """
+    if not any((target_type, extra_json)):
+        return ToolError(
+            error="missing_update_fields",
+            message="Provide at least one of: target_type, extra_json",
+        ).__dict__
+
     args = ["smartadtargets", "update", "--id", id]
     if target_type:
         args.extend(["--type", target_type])

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -1,4 +1,9 @@
-"""MCP tools for smart target management."""
+"""MCP tools for smart target management.
+
+NOTE: The direct-cli does not expose a ``smarttargets`` subcommand.
+The CLI provides ``smartadtargets`` (see smart_ad_targets.py) instead.
+These tools are kept as placeholders until the CLI adds a matching command.
+"""
 
 import json
 

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -1,111 +1,93 @@
-"""MCP tools for smart target management.
+"""MCP tools for smart ad targets (legacy aliases).
 
-NOTE: The direct-cli does not expose a ``smarttargets`` subcommand.
-The CLI provides ``smartadtargets`` (see smart_ad_targets.py) instead.
-These tools are kept as placeholders until the CLI adds a matching command.
+These tools wrap the ``smarttargets`` CLI subcommand, which is an alias
+for ``smartadtargets``.  Prefer the canonical wrappers in
+``smart_ad_targets.py`` — the tools here are kept for backward
+compatibility with existing skill/prompt references.
 """
 
-import json
-
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools import get_runner, handle_cli_errors
 
 from server.tools.helpers import check_batch_limit
 
 
 @mcp.tool()
 @handle_cli_errors
-def smart_targets_list(ad_group_ids: str) -> list[dict] | dict:
-    """List smart targets in specified ad groups.
+def smart_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
+    """List smart ad targets.
 
     Args:
-        ad_group_ids: Comma-separated ad group IDs (max 10).
+        ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    batch_error = check_batch_limit(ad_group_ids)
-    if batch_error:
-        return batch_error.__dict__
+    if ad_group_ids is not None:
+        batch_error = check_batch_limit(ad_group_ids)
+        if batch_error:
+            return batch_error.__dict__
 
+    args = ["smarttargets", "get", "--format", "json"]
+    if ad_group_ids:
+        args.extend(["--adgroup-ids", ad_group_ids])
     runner = get_runner()
-    return runner.run_json(
-        ["smarttargets", "get", "--ad-group-ids", ad_group_ids, "--format", "json"]
-    )
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def smart_targets_add(ad_group_id: str, conditions: str) -> dict:
-    """Add smart target to an ad group.
+def smart_targets_add(
+    ad_group_id: str, target_type: str, extra_json: str | None = None
+) -> dict:
+    """Add a smart ad target.
 
     Args:
         ad_group_id: Ad group ID.
-        conditions: JSON string of conditions for the smart target.
+        target_type: Target type (e.g. RETARGETING).
+        extra_json: Additional JSON parameters (optional).
     """
-    # Validate JSON format
-    try:
-        json.loads(conditions)
-    except json.JSONDecodeError as e:
-        return ToolError(
-            error="invalid_json",
-            message=f"Conditions must be valid JSON. Got: '{conditions}'. Error: {e}",
-        ).__dict__
-
+    args = [
+        "smarttargets",
+        "add",
+        "--adgroup-id",
+        ad_group_id,
+        "--type",
+        target_type,
+    ]
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "smarttargets",
-            "add",
-            "--ad-group-id",
-            ad_group_id,
-            "--conditions",
-            conditions,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
-def smart_targets_update(id: str, conditions: str) -> dict:
-    """Update smart target.
+def smart_targets_update(
+    id: str, target_type: str | None = None, extra_json: str | None = None
+) -> dict:
+    """Update a smart ad target.
 
     Args:
-        id: Smart target ID.
-        conditions: JSON string of conditions for the smart target.
+        id: Target ID.
+        target_type: New target type (optional).
+        extra_json: JSON string with fields to update (optional).
     """
-    # Validate JSON format
-    try:
-        json.loads(conditions)
-    except json.JSONDecodeError as e:
-        return ToolError(
-            error="invalid_json",
-            message=f"Conditions must be valid JSON. Got: '{conditions}'. Error: {e}",
-        ).__dict__
-
+    args = ["smarttargets", "update", "--id", id]
+    if target_type:
+        args.extend(["--type", target_type])
+    if extra_json:
+        args.extend(["--json", extra_json])
+    args.extend(["--format", "json"])
     runner = get_runner()
-    result = runner.run_json(
-        [
-            "smarttargets",
-            "update",
-            "--id",
-            id,
-            "--conditions",
-            conditions,
-            "--format",
-            "json",
-        ]
-    )
-    return result
+    return runner.run_json(args)
 
 
 @mcp.tool()
 @handle_cli_errors
 def smart_targets_delete(ids: str) -> dict:
-    """Delete smart targets.
+    """Delete smart ad targets.
 
     Args:
-        ids: Comma-separated smart target IDs (max 10).
+        ids: Comma-separated target IDs (max 10).
     """
     batch_error = check_batch_limit(ids)
     if batch_error:
@@ -113,6 +95,6 @@ def smart_targets_delete(ids: str) -> dict:
 
     runner = get_runner()
     result = runner.run_json(
-        ["smarttargets", "delete", "--ids", ids, "--format", "json"]
+        ["smarttargets", "delete", "--id", ids, "--format", "json"]
     )
     return result

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -26,7 +26,7 @@ def smart_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
         if batch_error:
             return batch_error.__dict__
 
-    args = ["smarttargets", "get", "--format", "json"]
+    args = ["smartadtargets", "get", "--format", "json"]
     if normalized_ad_group_ids:
         args.extend(["--adgroup-ids", normalized_ad_group_ids])
     runner = get_runner()
@@ -46,7 +46,7 @@ def smart_targets_add(
         extra_json: Additional JSON parameters (optional).
     """
     args = [
-        "smarttargets",
+        "smartadtargets",
         "add",
         "--adgroup-id",
         ad_group_id,
@@ -72,7 +72,7 @@ def smart_targets_update(
         target_type: New target type (optional).
         extra_json: JSON string with fields to update (optional).
     """
-    args = ["smarttargets", "update", "--id", id]
+    args = ["smartadtargets", "update", "--id", id]
     if target_type:
         args.extend(["--type", target_type])
     if extra_json:
@@ -90,4 +90,4 @@ def smart_targets_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated target IDs (max 10).
     """
-    return run_single_id_batch(get_runner(), "smarttargets", "delete", ids)
+    return run_single_id_batch(get_runner(), "smartadtargets", "delete", ids)

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -1,9 +1,9 @@
-"""MCP tools for smart ad targets (legacy aliases).
+"""Legacy compatibility wrappers for smart ad target MCP tools.
 
-These tools wrap the ``smarttargets`` CLI subcommand, which is an alias
-for ``smartadtargets``.  Prefer the canonical wrappers in
-``smart_ad_targets.py`` — the tools here are kept for backward
-compatibility with existing skill/prompt references.
+These tools preserve historical MCP names used by prompts and skills.
+The audited direct-cli surface does not guarantee a working
+``smarttargets`` subcommand, so callers should prefer the canonical
+wrappers in ``smart_ad_targets.py``.
 """
 
 from server.main import mcp

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -20,9 +20,7 @@ def smart_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    normalized_ad_group_ids = (
-        ad_group_ids.strip() if ad_group_ids is not None else None
-    )
+    normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
     if normalized_ad_group_ids:
         batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -9,7 +9,7 @@ compatibility with existing skill/prompt references.
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
-from server.tools.helpers import check_batch_limit
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
@@ -20,14 +20,17 @@ def smart_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
     Args:
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
     """
-    if ad_group_ids is not None:
-        batch_error = check_batch_limit(ad_group_ids)
+    normalized_ad_group_ids = (
+        ad_group_ids.strip() if ad_group_ids is not None else None
+    )
+    if normalized_ad_group_ids:
+        batch_error = check_batch_limit(normalized_ad_group_ids)
         if batch_error:
             return batch_error.__dict__
 
     args = ["smarttargets", "get", "--format", "json"]
-    if ad_group_ids:
-        args.extend(["--adgroup-ids", ad_group_ids])
+    if normalized_ad_group_ids:
+        args.extend(["--adgroup-ids", normalized_ad_group_ids])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -89,12 +92,4 @@ def smart_targets_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated target IDs (max 10).
     """
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(
-        ["smarttargets", "delete", "--id", ids, "--format", "json"]
-    )
-    return result
+    return run_single_id_batch(get_runner(), "smarttargets", "delete", ids)

--- a/server/tools/turbo_pages.py
+++ b/server/tools/turbo_pages.py
@@ -6,11 +6,31 @@ from server.tools import get_runner, handle_cli_errors
 
 @mcp.tool()
 @handle_cli_errors
-def turbo_pages_list(ids: str) -> dict:
-    """List turbo pages by IDs.
+def turbo_pages_list(ids: str | None = None) -> dict:
+    """List turbo pages.
 
     Args:
-        ids: Comma-separated turbo page IDs.
+        ids: Comma-separated turbo page IDs (optional).
     """
+    args = ["turbopages", "get", "--format", "json"]
+    if ids is not None:
+        args.extend(["--ids", ids])
     runner = get_runner()
-    return runner.run_json(["turbopages", "get", "--ids", ids, "--format", "json"])
+    return runner.run_json(args)
+
+
+@mcp.tool()
+@handle_cli_errors
+def turbo_pages_add(name: str, url: str, extra_json: str | None = None) -> dict:
+    """Add a turbo page.
+
+    Args:
+        name: Page name.
+        url: Page URL.
+        extra_json: Optional JSON string with additional parameters.
+    """
+    args = ["turbopages", "add", "--name", name, "--url", url]
+    if extra_json is not None:
+        args.extend(["--json", extra_json])
+    runner = get_runner()
+    return runner.run_json(args)

--- a/server/tools/turbo_pages.py
+++ b/server/tools/turbo_pages.py
@@ -13,8 +13,9 @@ def turbo_pages_list(ids: str | None = None) -> dict:
         ids: Comma-separated turbo page IDs (optional).
     """
     args = ["turbopages", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        args.extend(["--ids", ids])
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        args.extend(["--ids", normalized_ids])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/turbo_pages.py
+++ b/server/tools/turbo_pages.py
@@ -13,7 +13,7 @@ def turbo_pages_list(ids: str | None = None) -> dict:
         ids: Comma-separated turbo page IDs (optional).
     """
     args = ["turbopages", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         args.extend(["--ids", ids])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -14,7 +14,7 @@ def vcards_list(ids: str | None = None) -> list[dict] | dict:
         ids: Comma-separated vCard IDs (optional, max 10).
     """
     cmd = ["vcards", "get", "--format", "json"]
-    if ids is not None:
+    if ids is not None and ids.strip():
         batch_error = check_batch_limit(ids)
         if batch_error:
             return batch_error.__dict__

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -14,11 +14,12 @@ def vcards_list(ids: str | None = None) -> list[dict] | dict:
         ids: Comma-separated vCard IDs (optional, max 10).
     """
     cmd = ["vcards", "get", "--format", "json"]
-    if ids is not None and ids.strip():
-        batch_error = check_batch_limit(ids)
+    normalized_ids = ids.strip() if ids is not None else None
+    if normalized_ids:
+        batch_error = check_batch_limit(normalized_ids)
         if batch_error:
             return batch_error.__dict__
-        cmd.extend(["--ids", ids])
+        cmd.extend(["--ids", normalized_ids])
     runner = get_runner()
     result = runner.run_json(cmd)
     return result

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -2,39 +2,38 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
 @mcp.tool()
 @handle_cli_errors
-def vcards_list(ids: str) -> list[dict] | dict:
+def vcards_list(ids: str | None = None) -> list[dict] | dict:
     """List vCards.
 
     Args:
-        ids: Comma-separated vCard IDs (max 10).
+        ids: Comma-separated vCard IDs (optional, max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
+    cmd = ["vcards", "get", "--format", "json"]
+    if ids is not None:
+        batch_error = check_batch_limit(ids)
+        if batch_error:
+            return batch_error.__dict__
+        cmd.extend(["--ids", ids])
     runner = get_runner()
-    result = runner.run_json(["vcards", "get", "--ids", ids, "--format", "json"])
+    result = runner.run_json(cmd)
     return result
 
 
 @mcp.tool()
 @handle_cli_errors
-def vcards_add(vcard_data: str) -> dict:
+def vcards_add(vcard_json: str) -> dict:
     """Add a vCard.
 
     Args:
-        vcard_data: JSON string describing the vCard.
+        vcard_json: JSON string describing the vCard.
     """
     runner = get_runner()
-    result = runner.run_json(
-        ["vcards", "add", "--data", vcard_data, "--format", "json"]
-    )
+    result = runner.run_json(["vcards", "add", "--json", vcard_json])
     return result
 
 
@@ -46,12 +45,4 @@ def vcards_delete(ids: str) -> dict:
     Args:
         ids: Comma-separated vCard IDs (max 10).
     """
-    from server.tools.helpers import check_batch_limit
-
-    batch_error = check_batch_limit(ids)
-    if batch_error:
-        return batch_error.__dict__
-
-    runner = get_runner()
-    result = runner.run_json(["vcards", "delete", "--ids", ids, "--format", "json"])
-    return result
+    return run_single_id_batch(get_runner(), "vcards", "delete", ids)

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -89,16 +89,16 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Tool | Описание | Параметры |
 |---|---|---|
 | `sitelinks_list` | Список наборов ссылок | `ids` (max 10) |
-| `sitelinks_add` | Добавить набор ссылок | `sitelinks_data` (JSON) |
+| `sitelinks_add` | Добавить набор ссылок | `links` (JSON) |
 | `sitelinks_delete` | Удалить наборы ссылок | `ids` (max 10) |
 | `vcards_list` | Список визиток | `ids` (max 10) |
-| `vcards_add` | Добавить визитку | `vcard_data` (JSON) |
+| `vcards_add` | Добавить визитку | `vcard_json` (JSON) |
 | `vcards_delete` | Удалить визитки | `ids` (max 10) |
-| `adimages_list` | Список изображений | `ids` |
-| `adimages_add` | Добавить изображение | `image_data` (base64) |
-| `adimages_delete` | Удалить изображения | `ids` |
+| `adimages_list` | Список изображений | `ids?` |
+| `adimages_add` | Добавить изображение | `image_json` (base64) |
+| `adimages_delete` | Удалить изображения | `hash_value` |
 | `adextensions_list` | Список расширений | `ids` |
-| `adextensions_add` | Добавить расширение | `extension_type`, `extension_data` (JSON) |
+| `adextensions_add` | Добавить расширение | `extension_type`, `extra_json` (JSON) |
 | `adextensions_delete` | Удалить расширения | `ids` |
 
 ### Таргетинг и аудитории
@@ -112,21 +112,21 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | `retargeting_list` | Список ретаргетингов | `ids` |
 | `retargeting_add` | Добавить ретаргетинг | `name`, `rule` (JSON) |
 | `retargeting_delete` | Удалить ретаргетинги | `ids` (max 10) |
-| `dynamic_targets_list` | Список динамических таргетов | `ad_group_ids` (max 10) |
-| `dynamic_targets_add` | Добавить динамический таргет | `ad_group_id`, `conditions` (JSON) |
-| `dynamic_targets_update` | Обновить динамический таргет | `id`, `conditions` (JSON) |
+| `dynamic_targets_list` | Список динамических таргетов | `ad_group_ids?` (max 10) |
+| `dynamic_targets_add` | Добавить динамический таргет | `ad_group_id`, `target_data` (JSON) |
+| `dynamic_targets_update` | Обновить динамический таргет | `id`, `extra_json` (JSON) |
 | `dynamic_targets_delete` | Удалить динамические таргеты | `ids` (max 10) |
 | `dynamic_ads_list` | Список динамических объявлений | `ad_group_ids` |
 | `dynamic_ads_add` | Добавить динамическое объявление | `ad_group_id`, `target_data` (JSON) |
 | `dynamic_ads_update` | Обновить динамическое объявление | `id`, `extra_json` (JSON) |
 | `dynamic_ads_delete` | Удалить динамические объявления | `id` |
-| `negative_keywords_list` | Список минус-слов | `campaign_ids` (max 10) |
-| `negative_keywords_add` | Добавить минус-слова | `campaign_id`, `keywords` |
-| `negative_keywords_update` | Обновить минус-слова | `id`, `keywords` |
+| `negative_keywords_list` | Список минус-слов | `ids?` (max 10) |
+| `negative_keywords_add` | Добавить минус-слова | `name`, `keywords` |
+| `negative_keywords_update` | Обновить минус-слова | `id`, `name?`, `keywords?` |
 | `negative_keywords_delete` | Удалить минус-слова | `ids` (max 10) |
-| `smart_targets_list` | Список смарт-таргетов | `ad_group_ids` (max 10) |
-| `smart_targets_add` | Добавить смарт-таргет | `ad_group_id`, `conditions` (JSON) |
-| `smart_targets_update` | Обновить смарт-таргет | `id`, `conditions` (JSON) |
+| `smart_targets_list` | Список смарт-таргетов | `ad_group_ids?` (max 10) |
+| `smart_targets_add` | Добавить смарт-таргет | `ad_group_id`, `target_type`, `extra_json?` |
+| `smart_targets_update` | Обновить смарт-таргет | `id`, `target_type?`, `extra_json?` |
 | `smart_targets_delete` | Удалить смарт-таргеты | `ids` (max 10) |
 | `smart_ad_targets_list` | Список смарт-таргетов объявлений | `ad_group_ids` |
 | `smart_ad_targets_add` | Добавить смарт-таргет объявлений | `ad_group_id`, `target_type`, `extra_json?` |
@@ -149,11 +149,11 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 ### Клиенты и агентство
 | Tool | Описание | Параметры |
 |---|---|---|
-| `clients_get` | Информация о клиенте | `login?` |
-| `clients_update` | Обновить клиента | `login`, `fields` (JSON) |
-| `agency_clients_list` | Клиенты агентства | `login?` |
-| `agency_clients_add` | Добавить клиента агентству | `login`, `client_info` (JSON) |
-| `agency_clients_delete` | Удалить клиента из агентства | `login`, `client_login` |
+| `clients_get` | Информация о клиенте | `ids?` |
+| `clients_update` | Обновить клиента | `client_id`, `extra_json` (JSON) |
+| `agency_clients_list` | Клиенты агентства | `ids?` |
+| `agency_clients_add` | Добавить клиента агентству | `client_json` (JSON) |
+| `agency_clients_delete` | Удалить клиента из агентства | `id` |
 
 ### Исследования и отчёты
 | Tool | Описание | Параметры |

--- a/tests/test_adgroups.py
+++ b/tests/test_adgroups.py
@@ -34,8 +34,8 @@ def _mock_runner(return_value):
 class TestAdgroupsList:
     """Tests for adgroups_list tool."""
 
-    def test_adgroups_list_success(self):
-        """Test listing ad groups successfully."""
+    def test_adgroups_list_by_campaign(self):
+        """Test listing ad groups by campaign."""
         with patch(
             "server.tools.adgroups.get_runner",
             return_value=_mock_runner(SAMPLE_ADGROUPS),
@@ -46,13 +46,16 @@ class TestAdgroupsList:
 
     def test_adgroups_list_empty(self):
         """Test empty ad groups list."""
-        with patch("server.tools.adgroups.get_runner", return_value=_mock_runner([])):
+        with patch(
+            "server.tools.adgroups.get_runner",
+            return_value=_mock_runner([]),
+        ):
             result = adgroups_list(campaign_ids="12345")
             assert result == []
 
     def test_adgroups_list_batch_limit(self):
         """Test batch limit validation."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = adgroups_list(campaign_ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
@@ -65,43 +68,61 @@ class TestAdgroupsAdd:
         """Test adding an ad group successfully."""
         mock_result = {"Id": 123, "Name": "New Ad Group"}
         with patch(
-            "server.tools.adgroups.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.adgroups.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = adgroups_add(
-                campaign_id="12345", name="New Ad Group", region_ids="1,2"
-            )
+            result = adgroups_add(campaign_id="12345", name="New Ad Group")
             assert result["Id"] == 123
+
+    def test_adgroups_add_with_type(self):
+        """Test adding ad group with type parameter."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 124}
+        with patch(
+            "server.tools.adgroups.get_runner",
+            return_value=runner,
+        ):
+            adgroups_add(
+                campaign_id="12345",
+                name="Test",
+                type="MOBILE_AD_GROUP",
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--type" in call_args
+            assert "MOBILE_AD_GROUP" in call_args
 
 
 class TestAdgroupsUpdate:
     """Tests for adgroups_update tool."""
 
-    def test_adgroups_update_success(self):
-        """Test updating an ad group successfully."""
+    def test_adgroups_update_name(self):
+        """Test updating an ad group name."""
         mock_result = {"Id": 123, "Name": "Updated Name"}
         with patch(
-            "server.tools.adgroups.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.adgroups.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
             result = adgroups_update(id="123", name="Updated Name")
             assert result["Id"] == 123
 
-    def test_adgroups_update_argv_composition(self):
-        """Test that update passes correct argv to CLI."""
-        runner = _mock_runner({"Id": 123})
-        with patch("server.tools.adgroups.get_runner", return_value=runner):
-            adgroups_update(id="123", name="New Name")
-            runner.run_json.assert_called_once_with(
-                [
-                    "adgroups",
-                    "update",
-                    "--id",
-                    "123",
-                    "--name",
-                    "New Name",
-                    "--format",
-                    "json",
-                ]
-            )
+    def test_adgroups_update_requires_fields(self):
+        """Test that updating with no fields returns error."""
+        result = adgroups_update(id="123")
+        assert "error" in result
+        assert result["error"] == "missing_update_fields"
+
+    def test_adgroups_update_with_status(self):
+        """Test updating with status."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 123}
+        with patch(
+            "server.tools.adgroups.get_runner",
+            return_value=runner,
+        ):
+            adgroups_update(id="123", status="SUSPENDED")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--status" in call_args
+            assert "SUSPENDED" in call_args
 
 
 class TestAdgroupsDelete:
@@ -111,14 +132,15 @@ class TestAdgroupsDelete:
         """Test deleting ad groups successfully."""
         mock_result = {"success": True}
         with patch(
-            "server.tools.adgroups.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.adgroups.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = adgroups_delete(ids="1,2,3")
+            result = adgroups_delete(ids="1")
             assert result["success"] is True
 
     def test_adgroups_delete_batch_limit(self):
         """Test batch limit validation."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = adgroups_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_adgroups.py
+++ b/tests/test_adgroups.py
@@ -44,6 +44,16 @@ class TestAdgroupsList:
             assert len(result) == 2
             assert result[0]["Id"] == 1
 
+    def test_adgroups_list_ignores_blank_campaign_ids(self):
+        """Test blank campaign IDs behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = SAMPLE_ADGROUPS
+        with patch("server.tools.adgroups.get_runner", return_value=runner):
+            result = adgroups_list(campaign_ids="   ")
+            assert len(result) == 2
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+
     def test_adgroups_list_empty(self):
         """Test empty ad groups list."""
         with patch(

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -48,6 +48,19 @@ def test_ads_list_success():
         assert len(result) == 2
 
 
+def test_ads_list_ignores_blank_filters():
+    """Test blank filters behave like no filter."""
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_ADS
+    with patch("server.tools.ads.get_runner", return_value=runner):
+        result = ads_list(campaign_ids="   ", ad_group_ids="   ", ids="   ")
+        assert len(result) == 2
+        call_args = runner.run_json.call_args[0][0]
+        assert "--campaign-ids" not in call_args
+        assert "--adgroup-ids" not in call_args
+        assert "--ids" not in call_args
+
+
 def test_ads_foreign_campaign():
     """Test 12: Campaign belongs to second account (73-77M range)."""
     result = ads_list(campaign_ids="75000001")

--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -67,6 +67,17 @@ class TestAgencyClientsList:
             result = agency_clients_list()
             assert result == mock_result
 
+    def test_list_agency_clients_trims_ids_before_cli(self):
+        """Test client IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Clients": []}
+        with patch("server.tools.agency.get_runner", return_value=runner):
+            agency_clients_list(ids=" 123,456 ")
+
+        runner.run_json.assert_called_once_with(
+            ["agencyclients", "get", "--format", "json", "--ids", "123,456"]
+        )
+
 
 class TestAgencyClientsAdd:
     """Test scenarios for agency_clients_add."""

--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -43,18 +43,18 @@ class TestAgencyClientsList:
             result = agency_clients_list()
             assert result == mock_result
 
-    def test_list_agency_clients_with_login(self):
-        """Test listing agency clients filtered by login."""
+    def test_list_agency_clients_with_ids(self):
+        """Test listing agency clients filtered by IDs."""
         mock_result = {"Clients": [{"Login": "client1", "FirstName": "John"}]}
         runner = MagicMock()
         runner.run_json.return_value = mock_result
 
         with patch("server.tools.agency.get_runner", return_value=runner):
-            result = agency_clients_list(login="agency1")
+            result = agency_clients_list(ids="123,456")
             runner.run_json.assert_called_once()
             call_args = runner.run_json.call_args[0][0]
-            assert "--login" in call_args
-            assert "agency1" in call_args
+            assert "--ids" in call_args
+            assert "123,456" in call_args
             assert result == mock_result
 
     def test_list_empty_agency_clients(self):
@@ -78,13 +78,14 @@ class TestAgencyClientsAdd:
             "FirstName": "Alice",
             "LastName": "Johnson",
         }
-        with patch(
-            "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            client_info = '{"FirstName": "Alice", "LastName": "Johnson"}'
-            result = agency_clients_add(login="agency1", client_info=client_info)
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
+        with patch("server.tools.agency.get_runner", return_value=runner):
+            client_json = '{"FirstName": "Alice", "LastName": "Johnson"}'
+            result = agency_clients_add(client_json=client_json)
             assert result == mock_result
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
     def test_add_client_with_grants(self):
         """Test adding client with specific grants."""
@@ -96,19 +97,8 @@ class TestAgencyClientsAdd:
             "server.tools.agency.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            client_info = '{"Grants": ["CampaignManagement", "ReportManagement"]}'
-            result = agency_clients_add(login="agency1", client_info=client_info)
-            assert result == mock_result
-
-    def test_add_client_minimal_info(self):
-        """Test adding client with minimal information."""
-        mock_result = {"Login": "new_client"}
-        with patch(
-            "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            client_info = "{}"
-            result = agency_clients_add(login="agency1", client_info=client_info)
+            client_json = '{"Grants": ["CampaignManagement"]}'
+            result = agency_clients_add(client_json=client_json)
             assert result == mock_result
 
 
@@ -117,25 +107,12 @@ class TestAgencyClientsDelete:
 
     def test_delete_client_from_agency(self):
         """Test removing a client from an agency."""
-        mock_result = {"Success": True, "Login": "client1"}
-        with patch(
-            "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            result = agency_clients_delete(login="agency1", client_login="client1")
+        mock_result = {"Success": True}
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
+        with patch("server.tools.agency.get_runner", return_value=runner):
+            result = agency_clients_delete(id="123")
             assert result == mock_result
-
-    def test_delete_client_with_result(self):
-        """Test deletion with detailed result."""
-        mock_result = {
-            "Success": True,
-            "Login": "client1",
-            "AgencyLogin": "agency1",
-        }
-        with patch(
-            "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            result = agency_clients_delete(login="agency1", client_login="client1")
-            assert result == mock_result
-            assert result["Success"] is True
+            call_args = runner.run_json.call_args[0][0]
+            assert "--id" in call_args
+            assert "123" in call_args

--- a/tests/test_audience.py
+++ b/tests/test_audience.py
@@ -82,6 +82,20 @@ class TestAudienceTargetsList:
             call_args = runner.run_json.call_args[0][0]
             assert "--ids" in call_args
 
+    def test_list_audience_targets_ignores_blank_ids(self, mock_audience_targets):
+        """Test blank filters behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_audience_targets
+        with patch("server.tools.audience.get_runner", return_value=runner):
+            result = audience_targets_list(
+                campaign_ids="   ", ad_group_ids="   ", ids="   "
+            )
+            assert len(result) == 2
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+            assert "--adgroup-ids" not in call_args
+            assert "--ids" not in call_args
+
     def test_list_audience_targets_batch_limit(self):
         """Test batch limit validation for list."""
         ids = ",".join(str(i) for i in range(1, 12))

--- a/tests/test_audience.py
+++ b/tests/test_audience.py
@@ -12,7 +12,6 @@ from server.tools.audience import (
     audience_targets_resume,
     audience_targets_suspend,
 )
-from server.cli.runner import CliAuthError
 
 
 @pytest.fixture(autouse=True)
@@ -27,16 +26,14 @@ def mock_audience_targets():
     return [
         {
             "Id": 101,
-            "CampaignId": 12345,
             "AdGroupId": 67890,
-            "AudienceId": 555,
+            "RetargetingListId": 555,
             "State": "ON",
         },
         {
             "Id": 102,
-            "CampaignId": 12345,
             "AdGroupId": 67891,
-            "AudienceId": 556,
+            "RetargetingListId": 556,
             "State": "ON",
         },
     ]
@@ -52,24 +49,42 @@ def _mock_runner(return_value):
 class TestAudienceTargetsList:
     """Tests for audience_targets_list."""
 
-    def test_list_audience_targets_success(self, mock_audience_targets):
-        """Test listing audience targets successfully."""
+    def test_list_audience_targets_by_campaign(self, mock_audience_targets):
+        """Test listing audience targets by campaign IDs."""
         with patch(
             "server.tools.audience.get_runner",
             return_value=_mock_runner(mock_audience_targets),
         ):
-            result = audience_targets_list(campaign_ids="12345,67890")
+            result = audience_targets_list(campaign_ids="12345")
             assert len(result) == 2
 
-    def test_list_audience_targets_empty(self):
-        """Test listing audience targets with empty result."""
-        with patch("server.tools.audience.get_runner", return_value=_mock_runner([])):
-            result = audience_targets_list(campaign_ids="12345")
-            assert result == []
+    def test_list_audience_targets_by_ad_group(self):
+        """Test listing audience targets by ad group IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.audience.get_runner",
+            return_value=runner,
+        ):
+            audience_targets_list(ad_group_ids="67890")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--adgroup-ids" in call_args
+
+    def test_list_audience_targets_by_ids(self):
+        """Test listing audience targets by IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.audience.get_runner",
+            return_value=runner,
+        ):
+            audience_targets_list(ids="101,102")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" in call_args
 
     def test_list_audience_targets_batch_limit(self):
         """Test batch limit validation for list."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = audience_targets_list(campaign_ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
@@ -82,32 +97,41 @@ class TestAudienceTargetsAdd:
         """Test adding an audience target successfully."""
         mock_result = {
             "Id": 103,
-            "CampaignId": 12345,
             "AdGroupId": 67892,
-            "AudienceId": 557,
+            "RetargetingListId": 557,
             "State": "ON",
         }
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
         with patch(
-            "server.tools.audience.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.audience.get_runner",
+            return_value=runner,
         ):
             result = audience_targets_add(
-                campaign_id="12345", ad_group_id="67892", audience_id="557"
+                ad_group_id="67892",
+                retargeting_list_id="557",
             )
             assert result["Id"] == 103
-            assert result["CampaignId"] == 12345
+            call_args = runner.run_json.call_args[0][0]
+            assert "--adgroup-id" in call_args
+            assert "--retargeting-list-id" in call_args
 
-    def test_add_audience_target_auth_error(self):
-        """Test auth error during audience target add."""
+    def test_add_audience_target_with_bid(self):
+        """Test adding with bid parameter."""
         runner = MagicMock()
-        runner.run_json.side_effect = CliAuthError("Token expired")
-        with (
-            patch("server.tools.audience.get_runner", return_value=runner),
-            patch("server.tools._try_refresh_token", return_value=None),
+        runner.run_json.return_value = {"Id": 104}
+        with patch(
+            "server.tools.audience.get_runner",
+            return_value=runner,
         ):
-            result = audience_targets_add(
-                campaign_id="12345", ad_group_id="67892", audience_id="557"
+            audience_targets_add(
+                ad_group_id="67892",
+                retargeting_list_id="557",
+                bid="15.5",
             )
-            assert result["error"] == "auth_expired"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--bid" in call_args
+            assert "15.5" in call_args
 
 
 class TestAudienceTargetsDelete:
@@ -117,14 +141,15 @@ class TestAudienceTargetsDelete:
         """Test deleting audience targets successfully."""
         mock_result = {"success": True}
         with patch(
-            "server.tools.audience.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.audience.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = audience_targets_delete(ids="101,102")
+            result = audience_targets_delete(ids="101")
             assert result["success"] is True
 
     def test_delete_audience_targets_batch_limit(self):
         """Test batch limit validation for delete."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = audience_targets_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
@@ -137,14 +162,15 @@ class TestAudienceTargetsSuspend:
         """Test suspending audience targets successfully."""
         mock_result = {"success": True}
         with patch(
-            "server.tools.audience.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.audience.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = audience_targets_suspend(ids="101,102")
+            result = audience_targets_suspend(ids="101")
             assert result["success"] is True
 
     def test_suspend_audience_targets_batch_limit(self):
         """Test batch limit validation for suspend."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = audience_targets_suspend(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
@@ -157,14 +183,15 @@ class TestAudienceTargetsResume:
         """Test resuming audience targets successfully."""
         mock_result = {"success": True}
         with patch(
-            "server.tools.audience.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.audience.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = audience_targets_resume(ids="101,102")
+            result = audience_targets_resume(ids="101")
             assert result["success"] is True
 
     def test_resume_audience_targets_batch_limit(self):
         """Test batch limit validation for resume."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = audience_targets_resume(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -19,7 +19,7 @@ def setup():
 
 
 SAMPLE_BIDMODIFIERS = [
-    {"Id": 1, "CampaignId": 12345, "Type": "MULTIPLIER", "Value": 100},
+    {"Id": 1, "CampaignId": 12345, "Type": "DEMOGRAPHICS", "Value": 100},
 ]
 
 
@@ -33,7 +33,7 @@ def _mock_runner(return_value):
 class TestBidModifiersList:
     """Tests for bidmodifiers_list tool."""
 
-    def test_bidmodifiers_list_success(self):
+    def test_bidmodifiers_list_by_campaign(self):
         """Test listing bid modifiers for campaigns."""
         with patch(
             "server.tools.bidmodifiers.get_runner",
@@ -42,6 +42,18 @@ class TestBidModifiersList:
             result = bidmodifiers_list(campaign_ids="12345")
             assert len(result) == 1
             assert result[0]["CampaignId"] == 12345
+
+    def test_bidmodifiers_list_by_ad_group(self):
+        """Test listing bid modifiers by ad group IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.bidmodifiers.get_runner",
+            return_value=runner,
+        ):
+            bidmodifiers_list(ad_group_ids="67890")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--adgroup-ids" in call_args
 
     def test_bidmodifiers_list_batch_limit(self):
         """Test batch limit validation for bidmodifiers_list."""
@@ -62,41 +74,28 @@ class TestBidModifiersSet:
             return_value=_mock_runner(mock_result),
         ):
             result = bidmodifiers_set(
-                campaign_id="12345", modifier_type="MULTIPLIER", value="100"
+                campaign_id="12345",
+                modifier_type="DEMOGRAPHICS",
+                value="1.5",
             )
             assert result["success"] is True
 
-    def test_bidmodifiers_set_invalid_type(self):
-        """Test bidmodifiers_set with invalid modifier type."""
-        result = bidmodifiers_set(
-            campaign_id="12345", modifier_type="INVALID", value="100"
-        )
-        assert "error" in result
-        assert result["error"] == "invalid_state"
-
-    def test_bidmodifiers_set_invalid_value_negative(self):
-        """Test bidmodifiers_set with negative value."""
-        result = bidmodifiers_set(
-            campaign_id="12345", modifier_type="MULTIPLIER", value="-100"
-        )
-        assert "error" in result
-        assert result["error"] == "invalid_value"
-
-    def test_bidmodifiers_set_invalid_value_zero(self):
-        """Test bidmodifiers_set with zero value."""
-        result = bidmodifiers_set(
-            campaign_id="12345", modifier_type="MULTIPLIER", value="0"
-        )
-        assert "error" in result
-        assert result["error"] == "invalid_value"
-
-    def test_bidmodifiers_set_invalid_value_non_numeric(self):
-        """Test bidmodifiers_set with non-numeric value."""
-        result = bidmodifiers_set(
-            campaign_id="12345", modifier_type="MULTIPLIER", value="abc"
-        )
-        assert "error" in result
-        assert result["error"] == "invalid_value"
+    def test_bidmodifiers_set_with_extra_json(self):
+        """Test setting bid modifier with extra JSON."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch(
+            "server.tools.bidmodifiers.get_runner",
+            return_value=runner,
+        ):
+            bidmodifiers_set(
+                campaign_id="12345",
+                modifier_type="DEMOGRAPHICS",
+                value="1.5",
+                extra_json='{"Level":"ADGROUP"}',
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
 
 class TestBidModifiersToggle:
@@ -111,10 +110,8 @@ class TestBidModifiersToggle:
         ) as mock:
             result = bidmodifiers_toggle(id="1", enabled=True)
             assert result["success"] is True
-            # Verify the CLI command uses lowercase true
             call_args = mock.return_value.run_json.call_args[0][0]
             assert "--enabled" in call_args
-            assert "true" in call_args
 
     def test_bidmodifiers_toggle_disable(self):
         """Test disabling a bid modifier."""
@@ -125,10 +122,8 @@ class TestBidModifiersToggle:
         ) as mock:
             result = bidmodifiers_toggle(id="1", enabled=False)
             assert result["success"] is True
-            # Verify the CLI command uses lowercase false
             call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--enabled" in call_args
-            assert "false" in call_args
+            assert "--disabled" in call_args
 
 
 class TestBidModifiersDelete:
@@ -141,7 +136,7 @@ class TestBidModifiersDelete:
             "server.tools.bidmodifiers.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = bidmodifiers_delete(ids="1,2,3")
+            result = bidmodifiers_delete(ids="1")
             assert result["success"] is True
 
     def test_bidmodifiers_delete_batch_limit(self):

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -55,6 +55,17 @@ class TestBidModifiersList:
             call_args = runner.run_json.call_args[0][0]
             assert "--adgroup-ids" in call_args
 
+    def test_bidmodifiers_list_ignores_blank_ids(self):
+        """Test blank filters behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = SAMPLE_BIDMODIFIERS
+        with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
+            result = bidmodifiers_list(campaign_ids="   ", ad_group_ids="   ")
+            assert len(result) == 1
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+            assert "--adgroup-ids" not in call_args
+
     def test_bidmodifiers_list_batch_limit(self):
         """Test batch limit validation for bidmodifiers_list."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -67,7 +67,9 @@ class TestBidsList:
         runner = MagicMock()
         runner.run_json.return_value = SAMPLE_BIDS
         with patch("server.tools.bids.get_runner", return_value=runner):
-            result = bids_list(campaign_ids="   ", ad_group_ids="   ", keyword_ids="   ")
+            result = bids_list(
+                campaign_ids="   ", ad_group_ids="   ", keyword_ids="   "
+            )
             assert len(result) == 1
             call_args = runner.run_json.call_args[0][0]
             assert "--campaign-ids" not in call_args

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -62,6 +62,18 @@ class TestBidsList:
             call_args = runner.run_json.call_args[0][0]
             assert "--keyword-ids" in call_args
 
+    def test_bids_list_ignores_blank_filters(self):
+        """Test blank filters behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = SAMPLE_BIDS
+        with patch("server.tools.bids.get_runner", return_value=runner):
+            result = bids_list(campaign_ids="   ", ad_group_ids="   ", keyword_ids="   ")
+            assert len(result) == 1
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+            assert "--adgroup-ids" not in call_args
+            assert "--keyword-ids" not in call_args
+
     def test_bids_list_batch_limit(self):
         """Test batch limit validation for bids_list."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -31,11 +31,36 @@ class TestBidsList:
     def test_bids_list_success(self):
         """Test listing bids for campaigns."""
         with patch(
-            "server.tools.bids.get_runner", return_value=_mock_runner(SAMPLE_BIDS)
+            "server.tools.bids.get_runner",
+            return_value=_mock_runner(SAMPLE_BIDS),
         ):
             result = bids_list(campaign_ids="12345")
             assert len(result) == 1
             assert result[0]["CampaignId"] == 12345
+
+    def test_bids_list_by_ad_group(self):
+        """Test listing bids by ad group IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.bids.get_runner",
+            return_value=runner,
+        ):
+            bids_list(ad_group_ids="67890")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--adgroup-ids" in call_args
+
+    def test_bids_list_by_keyword(self):
+        """Test listing bids by keyword IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.bids.get_runner",
+            return_value=runner,
+        ):
+            bids_list(keyword_ids="111,222")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--keyword-ids" in call_args
 
     def test_bids_list_batch_limit(self):
         """Test batch limit validation for bids_list."""
@@ -51,47 +76,29 @@ class TestBidsSet:
     def test_bids_set_success(self):
         """Test setting bid successfully."""
         mock_result = {"success": True}
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
         with patch(
-            "server.tools.bids.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.bids.get_runner",
+            return_value=runner,
         ):
-            result = bids_set(campaign_id="12345", bid="15000000")
+            result = bids_set(campaign_id="12345", bid="15")
             assert result["success"] is True
+            call_args = runner.run_json.call_args[0][0]
+            assert "--bid" in call_args
 
-    def test_bids_set_with_context_bid(self):
-        """Test setting bid with context bid."""
-        mock_result = {"success": True}
+    def test_bids_set_with_extra_json(self):
+        """Test setting bid with extra JSON parameters."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
         with patch(
-            "server.tools.bids.get_runner", return_value=_mock_runner(mock_result)
-        ) as mock:
-            result = bids_set(
-                campaign_id="12345", bid="15000000", context_bid="12000000"
+            "server.tools.bids.get_runner",
+            return_value=runner,
+        ):
+            bids_set(
+                campaign_id="12345",
+                bid="15",
+                extra_json='{"ContextBid":12000000}',
             )
-            assert result["success"] is True
-            # Verify the CLI command includes context bid
-            call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--context-bid" in call_args
-            assert "12000000" in call_args
-
-    def test_bids_set_invalid_bid_negative(self):
-        """Test bids_set with negative bid."""
-        result = bids_set(campaign_id="12345", bid="-100")
-        assert "error" in result
-        assert result["error"] == "invalid_value"
-
-    def test_bids_set_invalid_bid_zero(self):
-        """Test bids_set with zero bid."""
-        result = bids_set(campaign_id="12345", bid="0")
-        assert "error" in result
-        assert result["error"] == "invalid_value"
-
-    def test_bids_set_invalid_bid_non_numeric(self):
-        """Test bids_set with non-numeric bid."""
-        result = bids_set(campaign_id="12345", bid="abc")
-        assert "error" in result
-        assert result["error"] == "invalid_value"
-
-    def test_bids_set_invalid_context_bid(self):
-        """Test bids_set with invalid context bid."""
-        result = bids_set(campaign_id="12345", bid="15000000", context_bid="invalid")
-        assert "error" in result
-        assert result["error"] == "invalid_value"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -102,3 +102,15 @@ class TestBidsSet:
             )
             call_args = runner.run_json.call_args[0][0]
             assert "--json" in call_args
+
+    def test_bids_set_requires_update_fields(self):
+        """Test setting bid rejects empty updates before CLI call."""
+        runner = MagicMock()
+        with patch(
+            "server.tools.bids.get_runner",
+            return_value=runner,
+        ):
+            result = bids_set(campaign_id="12345")
+
+        assert result["error"] == "missing_update_fields"
+        runner.run_json.assert_not_called()

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -44,6 +44,17 @@ def test_businesses_list_with_ids():
         assert len(result) == 1
 
 
+def test_businesses_list_trims_ids():
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_BUSINESSES
+    with patch("server.tools.businesses.get_runner", return_value=runner):
+        businesses_list(ids=" 100 ")
+
+    runner.run_json.assert_called_once_with(
+        ["businesses", "get", "--format", "json", "--ids", "100"]
+    )
+
+
 def test_businesses_list_empty():
     with patch(
         "server.tools.businesses.get_runner",

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -75,6 +75,17 @@ class TestCampaignsList:
         result = campaigns_list(ids=ids)
         assert result["error"] == "batch_limit"
 
+    def test_list_campaigns_trims_ids_before_cli(self, mock_campaigns):
+        """Test campaign IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_campaigns
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_list(ids=" 12345,67890 ")
+
+        runner.run_json.assert_called_once_with(
+            ["campaigns", "get", "--format", "json", "--ids", "12345,67890"]
+        )
+
 
 class TestCampaignsUpdate:
     """Test scenarios 9-10."""

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -69,6 +69,12 @@ class TestCampaignsList:
             result = campaigns_list()
             assert result == []
 
+    def test_list_campaigns_batch_limit(self):
+        """Test batch limit validation for campaign IDs."""
+        ids = ",".join(str(i) for i in range(1, 12))
+        result = campaigns_list(ids=ids)
+        assert result["error"] == "batch_limit"
+
 
 class TestCampaignsUpdate:
     """Test scenarios 9-10."""

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -85,6 +85,28 @@ class TestChangesCheckCamp:
             )
             assert result == mock_result
 
+    def test_check_campaign_changes_trims_ids(self):
+        """Test campaign IDs are normalized before argv construction."""
+        runner = _mock_runner({"Campaigns": []})
+        with patch("server.tools.changes.get_runner", return_value=runner):
+            changes_checkcamp(
+                campaign_ids=" 12345,67890 ",
+                timestamp="2026-01-01T00:00:00Z",
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "changes",
+                "check-camp",
+                "--campaign-ids",
+                "12345,67890",
+                "--timestamp",
+                "2026-01-01T00:00:00Z",
+                "--format",
+                "json",
+            ]
+        )
+
     def test_check_campaign_changes_batch_limit(self):
         """Test batch limit validation."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
@@ -104,6 +126,11 @@ class TestChangesCheckCamp:
                 campaign_ids=ids, timestamp="2026-01-01T00:00:00Z"
             )
             assert result == mock_result
+
+    def test_check_campaign_changes_requires_ids(self):
+        """Test blank campaign IDs are rejected."""
+        result = changes_checkcamp(campaign_ids="   ", timestamp="2026-01-01T00:00:00Z")
+        assert result["error"] == "missing_campaign_ids"
 
 
 class TestChangesCheckDict:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -53,6 +53,18 @@ class TestClientsGet:
             assert "123" in call_args
             assert result == mock_result
 
+    def test_get_client_trims_ids(self):
+        """Test client IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Clients": []}
+
+        with patch("server.tools.clients.get_runner", return_value=runner):
+            clients_get(ids=" 123 ")
+
+        runner.run_json.assert_called_once_with(
+            ["clients", "get", "--format", "json", "--ids", "123"]
+        )
+
     def test_get_empty_clients(self):
         """Test with no clients."""
         mock_result = {"Clients": []}

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -39,18 +39,18 @@ class TestClientsGet:
             result = clients_get()
             assert result == mock_result
 
-    def test_get_client_by_login(self):
-        """Test getting specific client by login."""
-        mock_result = {"Login": "client1", "FirstName": "John", "LastName": "Doe"}
+    def test_get_client_by_ids(self):
+        """Test getting specific client by IDs."""
+        mock_result = {"Clients": [{"Login": "client1", "FirstName": "John"}]}
         runner = MagicMock()
         runner.run_json.return_value = mock_result
 
         with patch("server.tools.clients.get_runner", return_value=runner):
-            result = clients_get(login="client1")
+            result = clients_get(ids="123")
             runner.run_json.assert_called_once()
             call_args = runner.run_json.call_args[0][0]
-            assert "--login" in call_args
-            assert "client1" in call_args
+            assert "--ids" in call_args
+            assert "123" in call_args
             assert result == mock_result
 
     def test_get_empty_clients(self):
@@ -69,33 +69,32 @@ class TestClientsUpdate:
 
     def test_update_client(self):
         """Test updating client information."""
-        mock_result = {"Login": "client1", "FirstName": "John", "LastName": "Smith"}
-        with patch(
-            "server.tools.clients.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            fields = '{"FirstName": "John", "LastName": "Smith"}'
-            result = clients_update(login="client1", fields=fields)
+        mock_result = {
+            "Login": "client1",
+            "FirstName": "John",
+            "LastName": "Smith",
+        }
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
+        with patch("server.tools.clients.get_runner", return_value=runner):
+            extra_json = '{"FirstName": "John", "LastName": "Smith"}'
+            result = clients_update(client_id="123", extra_json=extra_json)
             assert result == mock_result
+            call_args = runner.run_json.call_args[0][0]
+            assert "--client-id" in call_args
+            assert "123" in call_args
+            assert "--json" in call_args
 
     def test_update_client_with_grants(self):
         """Test updating client with grants."""
-        mock_result = {"Login": "client1", "Grants": ["CampaignManagement"]}
+        mock_result = {
+            "Login": "client1",
+            "Grants": ["CampaignManagement"],
+        }
         with patch(
             "server.tools.clients.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            fields = '{"Grants": ["CampaignManagement"]}'
-            result = clients_update(login="client1", fields=fields)
-            assert result == mock_result
-
-    def test_update_client_empty_fields(self):
-        """Test updating with empty fields JSON."""
-        mock_result = {"Login": "client1"}
-        with patch(
-            "server.tools.clients.get_runner",
-            return_value=_mock_runner(mock_result),
-        ):
-            fields = "{}"
-            result = clients_update(login="client1", fields=fields)
+            extra_json = '{"Grants": ["CampaignManagement"]}'
+            result = clients_update(client_id="123", extra_json=extra_json)
             assert result == mock_result

--- a/tests/test_creatives.py
+++ b/tests/test_creatives.py
@@ -45,3 +45,23 @@ class TestCreativesList:
             call_args = runner.run_json.call_args[0][0]
             assert "--campaign-ids" in call_args
             assert "12345" in call_args
+
+    def test_creatives_list_trims_filters(self):
+        """Test creative filters are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.creatives.get_runner", return_value=runner):
+            creatives_list(ids=" 1 ", campaign_ids=" 12345 ")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "creatives",
+                "get",
+                "--format",
+                "json",
+                "--ids",
+                "1",
+                "--campaign-ids",
+                "12345",
+            ]
+        )

--- a/tests/test_creatives.py
+++ b/tests/test_creatives.py
@@ -27,7 +27,21 @@ class TestCreativesList:
         """Test listing creatives by IDs."""
         mock_result = {"creatives": [{"id": 1, "name": "Creative 1"}]}
         with patch(
-            "server.tools.creatives.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.creatives.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
             result = creatives_list(ids="1")
             assert "creatives" in result
+
+    def test_creatives_list_by_campaign(self):
+        """Test listing creatives by campaign IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.creatives.get_runner",
+            return_value=runner,
+        ):
+            creatives_list(campaign_ids="12345")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" in call_args
+            assert "12345" in call_args

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import server.tools
-from server.tools.dictionaries import dictionaries_get
+from server.tools.dictionaries import dictionaries_get, dictionaries_list_names
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +31,7 @@ class TestDictionariesGet:
             "server.tools.dictionaries.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dictionaries_get(dictionary_type="GeographyRegions")
+            result = dictionaries_get(names="GeoRegions")
             assert result == mock_result
 
     def test_get_time_zones(self):
@@ -41,7 +41,7 @@ class TestDictionariesGet:
             "server.tools.dictionaries.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dictionaries_get(dictionary_type="TimeZones")
+            result = dictionaries_get(names="TimeZones")
             assert result == mock_result
 
     def test_get_currencies(self):
@@ -51,7 +51,7 @@ class TestDictionariesGet:
             "server.tools.dictionaries.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dictionaries_get(dictionary_type="Currencies")
+            result = dictionaries_get(names="Currencies")
             assert result == mock_result
 
     def test_get_constants(self):
@@ -61,49 +61,40 @@ class TestDictionariesGet:
             "server.tools.dictionaries.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dictionaries_get(dictionary_type="Constants")
+            result = dictionaries_get(names="Constants")
             assert result == mock_result
 
-    def test_get_with_locale(self):
-        """Test getting dictionary with locale parameter."""
-        mock_result = {"Regions": [{"Id": 1, "Name": "Москва"}]}
+    def test_get_multiple_dictionaries(self):
+        """Test getting multiple dictionaries at once."""
+        mock_result = {"Currencies": [], "GeoRegions": []}
         runner = MagicMock()
         runner.run_json.return_value = mock_result
 
         with patch("server.tools.dictionaries.get_runner", return_value=runner):
-            dictionaries_get(dictionary_type="GeographyRegions", locale="ru")
-            runner.run_json.assert_called_once()
+            result = dictionaries_get(names="Currencies,GeoRegions")
+            assert result == mock_result
             call_args = runner.run_json.call_args[0][0]
-            assert "--locale" in call_args
-            assert "ru" in call_args
+            assert "--names" in call_args
+            assert "Currencies,GeoRegions" in call_args
 
-    def test_invalid_dictionary_type(self):
-        """Test with invalid dictionary type."""
-        result = dictionaries_get(dictionary_type="InvalidType")
-        assert "error" in result
-        assert result["error"] == "invalid_type"
+    def test_passes_names_flag(self):
+        """Verify the CLI flag --names is used."""
+        runner = MagicMock()
+        runner.run_json.return_value = {}
 
-    def test_all_valid_dictionary_types(self):
-        """Test all valid dictionary types are accepted."""
-        valid_types = (
-            "GeographyRegions",
-            "TimeZones",
-            "Currencies",
-            "Constants",
-            "AdCategories",
-            "OperationSystemVersions",
-            "MobileOperatingSystemVersions",
-            "DeviceTypes",
-            "AgeRanges",
-            "Genders",
-            "Interests",
-        )
+        with patch("server.tools.dictionaries.get_runner", return_value=runner):
+            dictionaries_get(names="Currencies")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--names" in call_args
+            assert "Currencies" in call_args
 
-        for dict_type in valid_types:
-            mock_result = {"Test": "data"}
-            with patch(
-                "server.tools.dictionaries.get_runner",
-                return_value=_mock_runner(mock_result),
-            ):
-                result = dictionaries_get(dictionary_type=dict_type)
-                assert result == mock_result
+
+class TestDictionariesListNames:
+    """Test scenarios for dictionaries_list_names."""
+
+    def test_returns_list_of_names(self):
+        result = dictionaries_list_names()
+        assert isinstance(result, list)
+        assert "Currencies" in result
+        assert "GeoRegions" in result
+        assert "TimeZones" in result

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -43,6 +43,28 @@ def test_dynamic_ads_list():
         assert len(result) == 1
 
 
+def test_dynamic_ads_list_trims_ids():
+    runner = _mock_runner(SAMPLE_TARGETS)
+    with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
+        dynamic_ads_list(ad_group_ids=" 200 ")
+
+    runner.run_json.assert_called_once_with(
+        [
+            "dynamicads",
+            "get",
+            "--adgroup-ids",
+            "200",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_dynamic_ads_list_requires_ids():
+    result = dynamic_ads_list(ad_group_ids="   ")
+    assert result["error"] == "missing_ad_group_ids"
+
+
 def test_dynamic_ads_list_empty():
     with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner([])):
         result = dynamic_ads_list(ad_group_ids="200")

--- a/tests/test_dynamic_targets.py
+++ b/tests/test_dynamic_targets.py
@@ -11,178 +11,100 @@ from server.tools.dynamic_targets import (
     dynamic_targets_list,
     dynamic_targets_update,
 )
-from server.cli.runner import CliAuthError
 
 
 @pytest.fixture(autouse=True)
 def setup_token_getter():
-    """Configure a mock token getter for all tests."""
     server.tools.set_token_getter(lambda: "test-token")
 
 
-@pytest.fixture
-def mock_dynamic_targets():
-    """Sample dynamic target data."""
-    return [
-        {
-            "Id": 301,
-            "AdGroupId": 67890,
-            "Conditions": '{"type": "page", "url": "https://example.com/product"}',
-            "State": "ON",
-        },
-        {
-            "Id": 302,
-            "AdGroupId": 67891,
-            "Conditions": '{"type": "query", "text": "buy shoes"}',
-            "State": "ON",
-        },
-    ]
+SAMPLE_TARGETS = [
+    {"Id": 301, "AdGroupId": 67890, "Name": "Product pages"},
+]
 
 
 def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
 
 
 class TestDynamicTargetsList:
-    """Tests for dynamic_targets_list."""
-
-    def test_list_dynamic_targets_success(self, mock_dynamic_targets):
-        """Test listing dynamic targets successfully."""
+    def test_list_dynamic_targets_success(self):
         with patch(
             "server.tools.dynamic_targets.get_runner",
-            return_value=_mock_runner(mock_dynamic_targets),
-        ):
-            result = dynamic_targets_list(ad_group_ids="67890,67891")
-            assert len(result) == 2
-
-    def test_list_dynamic_targets_empty(self):
-        """Test listing dynamic targets with empty result."""
-        with patch(
-            "server.tools.dynamic_targets.get_runner", return_value=_mock_runner([])
+            return_value=_mock_runner(SAMPLE_TARGETS),
         ):
             result = dynamic_targets_list(ad_group_ids="67890")
-            assert result == []
+            assert len(result) == 1
+
+    def test_list_dynamic_targets_no_ids(self):
+        with patch(
+            "server.tools.dynamic_targets.get_runner",
+            return_value=_mock_runner(SAMPLE_TARGETS),
+        ):
+            result = dynamic_targets_list()
+            assert len(result) == 1
 
     def test_list_dynamic_targets_batch_limit(self):
-        """Test batch limit validation for list."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = dynamic_targets_list(ad_group_ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
 
 
 class TestDynamicTargetsAdd:
-    """Tests for dynamic_targets_add."""
-
     def test_add_dynamic_target_success(self):
-        """Test adding a dynamic target successfully."""
-        mock_result = {
-            "Id": 303,
-            "AdGroupId": 67892,
-            "Conditions": '{"type": "page", "url": "https://example.com/special"}',
-            "State": "ON",
-        }
-        conditions = '{"type": "page", "url": "https://example.com/special"}'
+        mock_result = {"Id": 303}
+        target_data = '{"Name": "Test", "Conditions": []}'
         with patch(
             "server.tools.dynamic_targets.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dynamic_targets_add(ad_group_id="67892", conditions=conditions)
+            result = dynamic_targets_add(ad_group_id="67892", target_data=target_data)
             assert result["Id"] == 303
-            assert result["AdGroupId"] == 67892
-
-    def test_add_dynamic_target_auth_error(self):
-        """Test auth error during dynamic target add."""
-        runner = MagicMock()
-        runner.run_json.side_effect = CliAuthError("Token expired")
-        with (
-            patch("server.tools.dynamic_targets.get_runner", return_value=runner),
-            patch("server.tools._try_refresh_token", return_value=None),
-        ):
-            result = dynamic_targets_add(ad_group_id="67892", conditions="{}")
-            assert result["error"] == "auth_expired"
 
 
 class TestDynamicTargetsUpdate:
-    """Tests for dynamic_targets_update."""
-
-    def test_update_dynamic_target_with_conditions(self):
-        """Test updating a dynamic target with new conditions."""
-        mock_result = {
-            "Id": 301,
-            "AdGroupId": 67890,
-            "Conditions": '{"type": "page", "url": "https://example.com/new"}',
-            "State": "ON",
-        }
-        conditions = '{"type": "page", "url": "https://example.com/new"}'
+    def test_update_dynamic_target(self):
+        mock_result = {"Id": 301}
         with patch(
             "server.tools.dynamic_targets.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dynamic_targets_update(id="301", conditions=conditions)
+            result = dynamic_targets_update(id="301", extra_json='{"Conditions": []}')
             assert result["Id"] == 301
 
     def test_update_dynamic_target_argv_composition(self):
-        """Test that update passes correct argv to CLI."""
         runner = _mock_runner({"Id": 301})
-        conditions = '{"type": "page", "url": "https://example.com/new"}'
         with patch("server.tools.dynamic_targets.get_runner", return_value=runner):
-            dynamic_targets_update(id="301", conditions=conditions)
+            dynamic_targets_update(id="301", extra_json='{"Conditions": []}')
             runner.run_json.assert_called_once_with(
                 [
                     "dynamictargets",
                     "update",
                     "--id",
                     "301",
-                    "--conditions",
-                    conditions,
+                    "--json",
+                    '{"Conditions": []}',
                     "--format",
                     "json",
                 ]
             )
 
-    def test_update_dynamic_target_auth_error(self):
-        """Test auth error during dynamic target update."""
-        runner = MagicMock()
-        runner.run_json.side_effect = CliAuthError("Token expired")
-        with (
-            patch("server.tools.dynamic_targets.get_runner", return_value=runner),
-            patch("server.tools._try_refresh_token", return_value=None),
-        ):
-            result = dynamic_targets_update(id="301", conditions="{}")
-            assert result["error"] == "auth_expired"
-
 
 class TestDynamicTargetsDelete:
-    """Tests for dynamic_targets_delete."""
-
     def test_delete_dynamic_targets_success(self):
-        """Test deleting dynamic targets successfully."""
         mock_result = {"success": True}
         with patch(
             "server.tools.dynamic_targets.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = dynamic_targets_delete(ids="301,302")
+            result = dynamic_targets_delete(ids="301")
             assert result["success"] is True
 
     def test_delete_dynamic_targets_batch_limit(self):
-        """Test batch limit validation for delete."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = dynamic_targets_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
-
-    def test_delete_dynamic_targets_auth_error(self):
-        """Test auth error during dynamic target delete."""
-        runner = MagicMock()
-        runner.run_json.side_effect = CliAuthError("Token expired")
-        with (
-            patch("server.tools.dynamic_targets.get_runner", return_value=runner),
-            patch("server.tools._try_refresh_token", return_value=None),
-        ):
-            result = dynamic_targets_delete(ids="301")
-            assert result["error"] == "auth_expired"

--- a/tests/test_dynamic_targets.py
+++ b/tests/test_dynamic_targets.py
@@ -38,6 +38,22 @@ class TestDynamicTargetsList:
             result = dynamic_targets_list(ad_group_ids="67890")
             assert len(result) == 1
 
+    def test_dynamic_targets_use_canonical_cli_surface(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.dynamic_targets.get_runner", return_value=runner):
+            dynamic_targets_list(ad_group_ids="67890")
+            dynamic_targets_add(
+                ad_group_id="67892", target_data='{"Name": "Test", "Conditions": []}'
+            )
+            dynamic_targets_update(id="301", extra_json='{"Conditions": []}')
+            dynamic_targets_delete(ids="301")
+
+        assert runner.run_json.call_args_list[0][0][0][0] == "dynamicads"
+        assert runner.run_json.call_args_list[1][0][0][0] == "dynamicads"
+        assert runner.run_json.call_args_list[2][0][0][0] == "dynamicads"
+        assert runner.run_json.call_args_list[3][0][0][0] == "dynamicads"
+
     def test_list_dynamic_targets_ignores_blank_ids(self):
         runner = MagicMock()
         runner.run_json.return_value = SAMPLE_TARGETS
@@ -90,7 +106,7 @@ class TestDynamicTargetsUpdate:
             dynamic_targets_update(id="301", extra_json='{"Conditions": []}')
             runner.run_json.assert_called_once_with(
                 [
-                    "dynamictargets",
+                    "dynamicads",
                     "update",
                     "--id",
                     "301",
@@ -121,8 +137,8 @@ class TestDynamicTargetsDelete:
         assert result["success"] is True
         assert result["ids"] == ["301", "302"]
         assert runner.run_json.call_args_list == [
-            call(["dynamictargets", "delete", "--id", "301"]),
-            call(["dynamictargets", "delete", "--id", "302"]),
+            call(["dynamicads", "delete", "--id", "301"]),
+            call(["dynamicads", "delete", "--id", "302"]),
         ]
 
     def test_delete_dynamic_targets_batch_limit(self):

--- a/tests/test_dynamic_targets.py
+++ b/tests/test_dynamic_targets.py
@@ -1,6 +1,6 @@
 """Tests for dynamic targets MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -37,6 +37,15 @@ class TestDynamicTargetsList:
         ):
             result = dynamic_targets_list(ad_group_ids="67890")
             assert len(result) == 1
+
+    def test_list_dynamic_targets_ignores_blank_ids(self):
+        runner = MagicMock()
+        runner.run_json.return_value = SAMPLE_TARGETS
+        with patch("server.tools.dynamic_targets.get_runner", return_value=runner):
+            result = dynamic_targets_list(ad_group_ids="   ")
+            assert len(result) == 1
+            call_args = runner.run_json.call_args[0][0]
+            assert "--adgroup-ids" not in call_args
 
     def test_list_dynamic_targets_no_ids(self):
         with patch(
@@ -102,6 +111,19 @@ class TestDynamicTargetsDelete:
         ):
             result = dynamic_targets_delete(ids="301")
             assert result["success"] is True
+
+    def test_delete_dynamic_targets_batches_multiple_ids(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.dynamic_targets.get_runner", return_value=runner):
+            result = dynamic_targets_delete(ids="301,302")
+
+        assert result["success"] is True
+        assert result["ids"] == ["301", "302"]
+        assert runner.run_json.call_args_list == [
+            call(["dynamictargets", "delete", "--id", "301"]),
+            call(["dynamictargets", "delete", "--id", "302"]),
+        ]
 
     def test_delete_dynamic_targets_batch_limit(self):
         ids = ",".join(str(i) for i in range(1, 12))

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -55,19 +55,33 @@ class TestAdextensionsList:
             assert len(result) == 2
             assert result[0]["Id"] == 1
 
-    def test_list_extensions_empty_ids(self, mock_extensions):
-        """Test listing all extensions with empty ids string."""
+    def test_list_extensions_no_ids(self, mock_extensions):
+        """Test listing all extensions with no ids."""
         with patch(
             "server.tools.adextensions.get_runner",
             return_value=_mock_runner(mock_extensions),
         ):
-            result = adextensions_list(ids="")
+            result = adextensions_list()
             assert len(result) == 2
+
+    def test_list_extensions_with_types(self):
+        """Test listing extensions filtered by types."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.adextensions.get_runner",
+            return_value=runner,
+        ):
+            adextensions_list(types="CALLOUT,SITELINK")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--types" in call_args
+            assert "CALLOUT,SITELINK" in call_args
 
     def test_list_extensions_empty_result(self):
         """Test empty response returns empty list."""
         with patch(
-            "server.tools.adextensions.get_runner", return_value=_mock_runner([])
+            "server.tools.adextensions.get_runner",
+            return_value=_mock_runner([]),
         ):
             result = adextensions_list(ids="999")
             assert result == []
@@ -79,23 +93,24 @@ class TestAdextensionsAdd:
     def test_add_extension_success(self):
         """Test adding extension successfully."""
         mock_result = {"Id": 123, "Type": "Call"}
-        extension_data = '{"PhoneNumber": "+79991112233"}'
+        extra_json = '{"PhoneNumber": "+79991112233"}'
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
 
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=runner,
         ):
-            result = adextensions_add(
-                extension_type="Call", extension_data=extension_data
-            )
+            result = adextensions_add(extension_type="Call", extra_json=extra_json)
             assert result["Id"] == 123
             assert result["Type"] == "Call"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--type" in call_args
+            assert "--json" in call_args
 
     def test_add_extension_invalid_type(self):
-        """Test adding extension with invalid type."""
-        # This test verifies the tool accepts any type string
-        # Validation will happen at the CLI level
-        extension_data = '{"SomeField": "value"}'
+        """Test adding extension with non-standard type."""
+        extra_json = '{"SomeField": "value"}'
         mock_result = {"Id": 124, "Type": "UnknownType"}
 
         with patch(
@@ -103,7 +118,7 @@ class TestAdextensionsAdd:
             return_value=_mock_runner(mock_result),
         ):
             result = adextensions_add(
-                extension_type="UnknownType", extension_data=extension_data
+                extension_type="UnknownType", extra_json=extra_json
             )
             assert result["Id"] == 124
 
@@ -119,5 +134,5 @@ class TestAdextensionsDelete:
             "server.tools.adextensions.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = adextensions_delete(ids="1,2")
+            result = adextensions_delete(ids="1")
             assert result["success"] is True

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -64,6 +64,19 @@ class TestAdextensionsList:
             result = adextensions_list()
             assert len(result) == 2
 
+    def test_list_extensions_empty_ids_treated_as_missing_filter(self, mock_extensions):
+        """Test empty ids behaves like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_extensions
+        with patch(
+            "server.tools.adextensions.get_runner",
+            return_value=runner,
+        ):
+            result = adextensions_list(ids="   ")
+            assert len(result) == 2
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" not in call_args
+
     def test_list_extensions_with_types(self):
         """Test listing extensions filtered by types."""
         runner = MagicMock()
@@ -136,3 +149,12 @@ class TestAdextensionsDelete:
         ):
             result = adextensions_delete(ids="1")
             assert result["success"] is True
+
+    def test_delete_extensions_rejects_empty_ids(self):
+        """Test deleting extensions rejects empty ids."""
+        with patch(
+            "server.tools.adextensions.get_runner",
+            return_value=_mock_runner({"success": True}),
+        ):
+            result = adextensions_delete(ids="   ")
+            assert result["error"] == "missing_ids"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -90,6 +90,26 @@ class TestAdextensionsList:
             assert "--types" in call_args
             assert "CALLOUT,SITELINK" in call_args
 
+    def test_list_extensions_trims_ids_and_types(self):
+        """Test list filters are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.adextensions.get_runner", return_value=runner):
+            adextensions_list(ids=" 1,2 ", types=" CALLOUT,SITELINK ")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "adextensions",
+                "get",
+                "--format",
+                "json",
+                "--ids",
+                "1,2",
+                "--types",
+                "CALLOUT,SITELINK",
+            ]
+        )
+
     def test_list_extensions_empty_result(self):
         """Test empty response returns empty list."""
         with patch(

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -27,7 +27,8 @@ class TestFeedsList:
         """Test listing feeds by IDs."""
         mock_result = {"feeds": [{"id": 1, "name": "Feed 1"}]}
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
             result = feeds_list(ids="1")
             assert "feeds" in result
@@ -44,11 +45,27 @@ class TestFeedsAdd:
             "url": "https://example.com/feed.xml",
         }
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
             result = feeds_add(name="New Feed", url="https://example.com/feed.xml")
             assert result["name"] == "New Feed"
-            assert result["url"] == "https://example.com/feed.xml"
+
+    def test_feeds_add_with_extra_json(self):
+        """Test adding a feed with extra JSON parameters."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"id": 2}
+        with patch(
+            "server.tools.feeds.get_runner",
+            return_value=runner,
+        ):
+            feeds_add(
+                name="Test",
+                url="https://example.com/feed.xml",
+                extra_json='{"BusinessType":"RETAIL"}',
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
 
 class TestFeedsUpdate:
@@ -58,35 +75,39 @@ class TestFeedsUpdate:
         """Test updating feed name."""
         mock_result = {"id": 1, "name": "Updated Feed"}
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
             result = feeds_update(id="1", name="Updated Feed")
             assert result["name"] == "Updated Feed"
 
     def test_feeds_update_url_only(self):
         """Test updating feed URL."""
-        mock_result = {"id": 1, "url": "https://example.com/new-feed.xml"}
+        mock_result = {"id": 1, "url": "https://example.com/new.xml"}
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = feeds_update(id="1", url="https://example.com/new-feed.xml")
-            assert result["url"] == "https://example.com/new-feed.xml"
+            result = feeds_update(id="1", url="https://example.com/new.xml")
+            assert result["url"] == "https://example.com/new.xml"
 
-    def test_feeds_update_both(self):
-        """Test updating both feed name and URL."""
-        mock_result = {
-            "id": 1,
-            "name": "Updated Feed",
-            "url": "https://example.com/new-feed.xml",
-        }
+    def test_feeds_update_extra_json_only(self):
+        """Test updating with extra JSON only."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"id": 1}
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=runner,
         ):
-            result = feeds_update(
-                id="1", name="Updated Feed", url="https://example.com/new-feed.xml"
-            )
-            assert result["name"] == "Updated Feed"
-            assert result["url"] == "https://example.com/new-feed.xml"
+            feeds_update(id="1", extra_json='{"Status":"ACTIVE"}')
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
+
+    def test_feeds_update_nothing(self):
+        """Test that updating nothing returns error."""
+        result = feeds_update(id="1")
+        assert "error" in result
+        assert result["error"] == "missing_update_fields"
 
 
 class TestFeedsDelete:
@@ -96,14 +117,15 @@ class TestFeedsDelete:
         """Test deleting feeds successfully."""
         mock_result = {"success": True}
         with patch(
-            "server.tools.feeds.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.feeds.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = feeds_delete(ids="1,2")
+            result = feeds_delete(ids="1")
             assert result["success"] is True
 
     def test_feeds_delete_batch_limit(self):
         """Test batch limit validation for feeds_delete."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = feeds_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -42,8 +42,18 @@ class TestFeedsList:
             feeds_list(ids=" 1 ")
 
         runner.run_json.assert_called_once_with(
-            ["feeds", "get", "--ids", "1", "--format", "json"]
+            ["feeds", "get", "--format", "json", "--ids", "1"]
         )
+
+    def test_feeds_list_no_ids(self):
+        """Test listing all feeds without IDs."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"feeds": []}
+
+        with patch("server.tools.feeds.get_runner", return_value=runner):
+            feeds_list()
+
+        runner.run_json.assert_called_once_with(["feeds", "get", "--format", "json"])
 
 
 class TestFeedsAdd:

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -33,6 +33,18 @@ class TestFeedsList:
             result = feeds_list(ids="1")
             assert "feeds" in result
 
+    def test_feeds_list_trims_ids_before_cli(self):
+        """Test feed IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"feeds": []}
+
+        with patch("server.tools.feeds.get_runner", return_value=runner):
+            feeds_list(ids=" 1 ")
+
+        runner.run_json.assert_called_once_with(
+            ["feeds", "get", "--ids", "1", "--format", "json"]
+        )
+
 
 class TestFeedsAdd:
     """Tests for feeds_add tool."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -73,6 +73,20 @@ def test_run_single_id_batch_rejects_whitespace_ids():
     assert result["error"] == "missing_ids"
 
 
+def test_run_single_id_batch_batches_multiple_ids():
+    runner = type("Runner", (), {})()
+    runner.run_json = lambda args: {"success": True, "args": args}
+
+    result = run_single_id_batch(runner, "vcards", "delete", "1,2")
+
+    assert result["success"] is True
+    assert result["ids"] == ["1", "2"]
+    assert result["results"] == [
+        {"success": True, "args": ["vcards", "delete", "--id", "1"]},
+        {"success": True, "args": ["vcards", "delete", "--id", "2"]},
+    ]
+
+
 # --- validate_state ---
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ from server.tools import ToolError
 from server.tools.helpers import (
     check_batch_limit,
     parse_ids,
+    run_single_id_batch,
     validate_positive_int,
     validate_state,
 )
@@ -58,6 +59,18 @@ def test_check_batch_limit_custom_size():
 
 def test_check_batch_limit_empty():
     assert check_batch_limit("") is None
+
+
+def test_run_single_id_batch_rejects_empty_ids():
+    runner = object()
+    result = run_single_id_batch(runner, "vcards", "delete", "")
+    assert result["error"] == "missing_ids"
+
+
+def test_run_single_id_batch_rejects_whitespace_ids():
+    runner = object()
+    result = run_single_id_batch(runner, "vcards", "delete", "   ")
+    assert result["error"] == "missing_ids"
 
 
 # --- validate_state ---

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -80,6 +80,17 @@ class TestAdimagesList:
             result = adimages_list(ids="999")
             assert result == []
 
+    def test_list_images_trims_ids_before_cli(self, mock_images):
+        """Test image IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_images
+        with patch("server.tools.images.get_runner", return_value=runner):
+            adimages_list(ids=" 1,2 ")
+
+        runner.run_json.assert_called_once_with(
+            ["adimages", "get", "--format", "json", "--ids", "1,2"]
+        )
+
 
 class TestAdimagesAdd:
     """Tests for adimages_add tool."""

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -55,13 +55,13 @@ class TestAdimagesList:
             assert len(result) == 2
             assert result[0]["Id"] == 1
 
-    def test_list_images_empty_ids(self, mock_images):
-        """Test listing all images with empty ids string."""
+    def test_list_images_no_ids(self, mock_images):
+        """Test listing all images with no ids."""
         with patch(
             "server.tools.images.get_runner",
             return_value=_mock_runner(mock_images),
         ):
-            result = adimages_list(ids="")
+            result = adimages_list()
             assert len(result) == 2
 
     def test_list_images_empty_result(self):
@@ -77,25 +77,29 @@ class TestAdimagesAdd:
     def test_add_image_success(self):
         """Test adding image successfully."""
         mock_result = {"Id": 123, "Name": "new_image.jpg"}
-        image_data = '{"Name": "new_image.jpg", "Data": "base64_encoded_image_data"}'
+        image_json = '{"Name": "new_image.jpg", "Data": "base64data"}'
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
 
-        with patch(
-            "server.tools.images.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = adimages_add(image_data=image_data)
+        with patch("server.tools.images.get_runner", return_value=runner):
+            result = adimages_add(image_json=image_json)
             assert result["Id"] == 123
-            assert result["Name"] == "new_image.jpg"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
 
 class TestAdimagesDelete:
     """Tests for adimages_delete tool."""
 
-    def test_delete_images_success(self):
-        """Test deleting images successfully."""
+    def test_delete_image_by_hash(self):
+        """Test deleting an image by hash."""
         mock_result = {"success": True}
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
 
-        with patch(
-            "server.tools.images.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = adimages_delete(ids="1,2")
+        with patch("server.tools.images.get_runner", return_value=runner):
+            result = adimages_delete(hash_value="abc123")
             assert result["success"] is True
+            call_args = runner.run_json.call_args[0][0]
+            assert "--hash" in call_args
+            assert "abc123" in call_args

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -64,6 +64,16 @@ class TestAdimagesList:
             result = adimages_list()
             assert len(result) == 2
 
+    def test_list_images_empty_ids_treated_as_missing_filter(self, mock_images):
+        """Test empty ids behaves like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_images
+        with patch("server.tools.images.get_runner", return_value=runner):
+            result = adimages_list(ids="   ")
+            assert len(result) == 2
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" not in call_args
+
     def test_list_images_empty_result(self):
         """Test empty response returns empty list."""
         with patch("server.tools.images.get_runner", return_value=_mock_runner([])):

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -77,6 +77,32 @@ class TestKeywordBidsList:
             assert "--adgroup-ids" in call_args
             assert "222" in call_args
 
+    def test_keyword_bids_list_trims_filters(self):
+        """Test keyword bid filters are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.keyword_bids.get_runner", return_value=runner):
+            keyword_bids_list(
+                campaign_ids=" 333 ",
+                ad_group_ids=" 222 ",
+                keyword_ids=" 111 ",
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "keywordbids",
+                "get",
+                "--format",
+                "json",
+                "--campaign-ids",
+                "333",
+                "--adgroup-ids",
+                "222",
+                "--keyword-ids",
+                "111",
+            ]
+        )
+
 
 class TestKeywordBidsSet:
     """Tests for keyword_bids_set tool."""

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -44,6 +44,23 @@ def test_keywords_list():
         assert result[0]["Id"] == 99999
 
 
+def test_keywords_list_trims_campaign_ids():
+    """Test campaign IDs are normalized before argv construction."""
+    runner = _mock_runner(SAMPLE_KEYWORDS)
+    with patch("server.tools.keywords.get_runner", return_value=runner):
+        keywords_list(campaign_ids=" 12345 ")
+
+    runner.run_json.assert_called_once_with(
+        ["keywords", "get", "--campaign-ids", "12345", "--format", "json"]
+    )
+
+
+def test_keywords_list_requires_campaign_ids():
+    """Test blank campaign IDs are rejected."""
+    result = keywords_list(campaign_ids="   ")
+    assert result["error"] == "missing_campaign_ids"
+
+
 def test_keywords_update():
     """Test 15: Update bid."""
     with patch("server.tools.keywords.get_runner", return_value=_mock_runner({})):

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -32,6 +32,16 @@ class TestLeadsList:
             result = leads_list(campaign_ids="12345")
             assert "leads" in result
 
+    def test_leads_list_ignores_blank_campaign_ids(self):
+        """Test blank campaign IDs behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"leads": []}
+        with patch("server.tools.leads.get_runner", return_value=runner):
+            result = leads_list(campaign_ids="   ")
+            assert "leads" in result
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+
     def test_leads_list_no_campaign_ids(self):
         """Test listing leads without campaign IDs (all campaigns)."""
         mock_result = {"leads": [{"id": 1, "campaign_id": 12345}]}

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -24,7 +24,7 @@ class TestLeadsList:
     """Tests for leads_list tool."""
 
     def test_leads_list_basic(self):
-        """Test listing leads without date filter."""
+        """Test listing leads with campaign IDs."""
         mock_result = {"leads": [{"id": 1, "campaign_id": 12345}]}
         with patch(
             "server.tools.leads.get_runner", return_value=_mock_runner(mock_result)
@@ -32,15 +32,13 @@ class TestLeadsList:
             result = leads_list(campaign_ids="12345")
             assert "leads" in result
 
-    def test_leads_list_with_dates(self):
-        """Test listing leads with date range filter."""
+    def test_leads_list_no_campaign_ids(self):
+        """Test listing leads without campaign IDs (all campaigns)."""
         mock_result = {"leads": [{"id": 1, "campaign_id": 12345}]}
         with patch(
             "server.tools.leads.get_runner", return_value=_mock_runner(mock_result)
         ):
-            result = leads_list(
-                campaign_ids="12345", date_from="2024-01-01", date_to="2024-01-31"
-            )
+            result = leads_list()
             assert "leads" in result
 
     def test_leads_list_batch_limit(self):
@@ -49,3 +47,13 @@ class TestLeadsList:
         result = leads_list(campaign_ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
+
+    def test_leads_list_passes_campaign_ids(self):
+        """Verify CLI receives --campaign-ids flag."""
+        runner = MagicMock()
+        runner.run_json.return_value = {}
+        with patch("server.tools.leads.get_runner", return_value=runner):
+            leads_list(campaign_ids="123,456")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" in call_args
+            assert "123,456" in call_args

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -47,6 +47,26 @@ def test_nkss_list_with_ids():
         assert len(result) == 1
 
 
+def test_nkss_list_trims_ids():
+    runner = _mock_runner(SAMPLE_SETS)
+    with patch(
+        "server.tools.negative_keyword_shared_sets.get_runner",
+        return_value=runner,
+    ):
+        negative_keyword_shared_sets_list(ids=" 100 ")
+
+    runner.run_json.assert_called_once_with(
+        [
+            "negativekeywordsharedsets",
+            "get",
+            "--format",
+            "json",
+            "--ids",
+            "100",
+        ]
+    )
+
+
 def test_nkss_list_empty():
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",

--- a/tests/test_negative_keywords.py
+++ b/tests/test_negative_keywords.py
@@ -1,6 +1,6 @@
 """Tests for negative keyword MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -50,6 +50,17 @@ def test_negative_keywords_list_no_ids():
         assert len(result) == 1
 
 
+def test_negative_keywords_list_ignores_blank_ids():
+    """Test blank ids behave like no filter."""
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_SETS
+    with patch("server.tools.negative_keywords.get_runner", return_value=runner):
+        result = negative_keywords_list(ids="   ")
+        assert len(result) == 1
+        call_args = runner.run_json.call_args[0][0]
+        assert "--ids" not in call_args
+
+
 def test_negative_keywords_add():
     """Test adding a negative keyword set."""
     mock_result = {"Id": 1}
@@ -83,6 +94,19 @@ class TestNegativeKeywordsDelete:
         ):
             result = negative_keywords_delete(ids="1")
             assert result["success"] is True
+
+    def test_negative_keywords_delete_batches_multiple_ids(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.negative_keywords.get_runner", return_value=runner):
+            result = negative_keywords_delete(ids="1,2")
+
+        assert result["success"] is True
+        assert result["ids"] == ["1", "2"]
+        assert runner.run_json.call_args_list == [
+            call(["negativekeywords", "delete", "--id", "1"]),
+            call(["negativekeywords", "delete", "--id", "2"]),
+        ]
 
     def test_negative_keywords_delete_batch_limit(self):
         ids = ",".join(str(i) for i in range(1, 12))

--- a/tests/test_negative_keywords.py
+++ b/tests/test_negative_keywords.py
@@ -97,6 +97,12 @@ def test_negative_keywords_update():
         assert result["success"] is True
 
 
+def test_negative_keywords_update_requires_fields():
+    """Test missing negative keyword update fields returns a local error."""
+    result = negative_keywords_update(id="1")
+    assert result["error"] == "missing_update_fields"
+
+
 class TestNegativeKeywordsDelete:
     """Tests for negative keyword delete operations."""
 

--- a/tests/test_negative_keywords.py
+++ b/tests/test_negative_keywords.py
@@ -72,6 +72,20 @@ def test_negative_keywords_add():
         assert result["Id"] == 1
 
 
+def test_negative_keywords_use_canonical_cli_surface():
+    """Legacy wrapper should call canonical shared-set command."""
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_SETS
+    with patch("server.tools.negative_keywords.get_runner", return_value=runner):
+        negative_keywords_list(ids="1")
+        negative_keywords_add(name="Bad words", keywords="bad, awful")
+        negative_keywords_update(id="1", name="Updated")
+
+    assert runner.run_json.call_args_list[0][0][0][0] == "negativekeywordsharedsets"
+    assert runner.run_json.call_args_list[1][0][0][0] == "negativekeywordsharedsets"
+    assert runner.run_json.call_args_list[2][0][0][0] == "negativekeywordsharedsets"
+
+
 def test_negative_keywords_update():
     """Test updating a negative keyword set."""
     mock_result = {"success": True}
@@ -104,8 +118,8 @@ class TestNegativeKeywordsDelete:
         assert result["success"] is True
         assert result["ids"] == ["1", "2"]
         assert runner.run_json.call_args_list == [
-            call(["negativekeywords", "delete", "--id", "1"]),
-            call(["negativekeywords", "delete", "--id", "2"]),
+            call(["negativekeywordsharedsets", "delete", "--id", "1"]),
+            call(["negativekeywordsharedsets", "delete", "--id", "2"]),
         ]
 
     def test_negative_keywords_delete_batch_limit(self):

--- a/tests/test_negative_keywords.py
+++ b/tests/test_negative_keywords.py
@@ -1,6 +1,6 @@
 """Tests for negative keyword MCP tools."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,70 +18,74 @@ def setup():
     server.tools.set_token_getter(lambda: "test-token")
 
 
-SAMPLE_NEGATIVE_KEYWORDS = [
-    {"Id": 1, "CampaignId": 12345, "Keywords": "bad keyword, another bad"},
+SAMPLE_SETS = [
+    {"Id": 1, "Name": "Bad words", "Keywords": "bad, awful"},
 ]
 
 
 def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
 
 
 def test_negative_keywords_list():
-    """Test listing negative keywords."""
+    """Test listing negative keyword sets."""
     with patch(
         "server.tools.negative_keywords.get_runner",
-        return_value=_mock_runner(SAMPLE_NEGATIVE_KEYWORDS),
+        return_value=_mock_runner(SAMPLE_SETS),
     ):
-        result = negative_keywords_list(campaign_ids="12345")
+        result = negative_keywords_list(ids="1")
         assert len(result) == 1
         assert result[0]["Id"] == 1
-        assert result[0]["CampaignId"] == 12345
+
+
+def test_negative_keywords_list_no_ids():
+    """Test listing all negative keyword sets."""
+    with patch(
+        "server.tools.negative_keywords.get_runner",
+        return_value=_mock_runner(SAMPLE_SETS),
+    ):
+        result = negative_keywords_list()
+        assert len(result) == 1
 
 
 def test_negative_keywords_add():
-    """Test adding negative keywords."""
-    mock_result = {"success": True, "id": 1}
+    """Test adding a negative keyword set."""
+    mock_result = {"Id": 1}
     with patch(
         "server.tools.negative_keywords.get_runner",
         return_value=_mock_runner(mock_result),
     ):
-        result = negative_keywords_add(campaign_id="12345", keywords="bad, awful")
-        assert result["success"] is True
-        assert result["id"] == 1
+        result = negative_keywords_add(name="Bad words", keywords="bad, awful")
+        assert result["Id"] == 1
 
 
 def test_negative_keywords_update():
-    """Test updating negative keywords."""
-    mock_result = {"success": True, "id": 1}
+    """Test updating a negative keyword set."""
+    mock_result = {"success": True}
     with patch(
         "server.tools.negative_keywords.get_runner",
         return_value=_mock_runner(mock_result),
     ):
-        result = negative_keywords_update(id="1", keywords="new bad, worse")
+        result = negative_keywords_update(id="1", name="Updated")
         assert result["success"] is True
-        assert result["id"] == 1
 
 
 class TestNegativeKeywordsDelete:
     """Tests for negative keyword delete operations."""
 
     def test_negative_keywords_delete_success(self):
-        """Test deleting negative keywords successfully."""
         mock_result = {"success": True}
         with patch(
             "server.tools.negative_keywords.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = negative_keywords_delete(ids="1,2")
+            result = negative_keywords_delete(ids="1")
             assert result["success"] is True
 
     def test_negative_keywords_delete_batch_limit(self):
-        """Test batch limit validation for delete."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = negative_keywords_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -57,20 +57,36 @@ class TestRetargetingList:
             result = retargeting_list(ids="201,202")
             assert len(result) == 2
 
-    def test_list_retargeting_empty(self):
-        """Test listing retargeting lists with empty result."""
+    def test_list_retargeting_no_ids(self, mock_retargeting_lists):
+        """Test listing all retargeting lists."""
         with patch(
-            "server.tools.retargeting.get_runner", return_value=_mock_runner([])
+            "server.tools.retargeting.get_runner",
+            return_value=_mock_runner(mock_retargeting_lists),
         ):
-            result = retargeting_list(ids="201")
-            assert result == []
+            result = retargeting_list()
+            assert len(result) == 2
+
+    def test_list_retargeting_with_types(self):
+        """Test listing retargeting lists filtered by types."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch(
+            "server.tools.retargeting.get_runner",
+            return_value=runner,
+        ):
+            retargeting_list(types="REMARKETING")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--types" in call_args
 
     def test_list_retargeting_auth_error(self):
         """Test auth error during retargeting list."""
         runner = MagicMock()
         runner.run_json.side_effect = CliAuthError("Token expired")
         with (
-            patch("server.tools.retargeting.get_runner", return_value=runner),
+            patch(
+                "server.tools.retargeting.get_runner",
+                return_value=runner,
+            ),
             patch("server.tools._try_refresh_token", return_value=None),
         ):
             result = retargeting_list(ids="201")
@@ -85,27 +101,52 @@ class TestRetargetingAdd:
         mock_result = {
             "Id": 203,
             "Name": "Site visitors",
-            "Type": "REMARKETING",
+            "Type": "AUDIENCE_SEGMENT",
             "State": "ON",
         }
-        rule = '{"conditions": [{"operator": "AND", "operands": [{"type": "time_on_site", "time_on_site": 30}]}]}'
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
         with patch(
             "server.tools.retargeting.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=runner,
         ):
-            result = retargeting_add(name="Site visitors", rule=rule)
+            result = retargeting_add(
+                name="Site visitors",
+                list_type="AUDIENCE_SEGMENT",
+            )
             assert result["Id"] == 203
-            assert result["Name"] == "Site visitors"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--name" in call_args
+            assert "--type" in call_args
+
+    def test_add_retargeting_with_extra_json(self):
+        """Test adding with extra JSON parameters."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 204}
+        with patch(
+            "server.tools.retargeting.get_runner",
+            return_value=runner,
+        ):
+            retargeting_add(
+                name="Test",
+                list_type="AUDIENCE_SEGMENT",
+                extra_json='{"Description":"test"}',
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
     def test_add_retargeting_auth_error(self):
         """Test auth error during retargeting add."""
         runner = MagicMock()
         runner.run_json.side_effect = CliAuthError("Token expired")
         with (
-            patch("server.tools.retargeting.get_runner", return_value=runner),
+            patch(
+                "server.tools.retargeting.get_runner",
+                return_value=runner,
+            ),
             patch("server.tools._try_refresh_token", return_value=None),
         ):
-            result = retargeting_add(name="Test", rule="{}")
+            result = retargeting_add(name="Test", list_type="AUDIENCE_SEGMENT")
             assert result["error"] == "auth_expired"
 
 
@@ -119,7 +160,7 @@ class TestRetargetingDelete:
             "server.tools.retargeting.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = retargeting_delete(ids="201,202")
+            result = retargeting_delete(ids="201")
             assert result["success"] is True
 
     def test_delete_retargeting_batch_limit(self):
@@ -128,14 +169,3 @@ class TestRetargetingDelete:
         result = retargeting_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
-
-    def test_delete_retargeting_auth_error(self):
-        """Test auth error during retargeting delete."""
-        runner = MagicMock()
-        runner.run_json.side_effect = CliAuthError("Token expired")
-        with (
-            patch("server.tools.retargeting.get_runner", return_value=runner),
-            patch("server.tools._try_refresh_token", return_value=None),
-        ):
-            result = retargeting_delete(ids="201")
-            assert result["error"] == "auth_expired"

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -78,6 +78,26 @@ class TestRetargetingList:
             call_args = runner.run_json.call_args[0][0]
             assert "--types" in call_args
 
+    def test_list_retargeting_trims_filters(self):
+        """Test retargeting filters are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.retargeting.get_runner", return_value=runner):
+            retargeting_list(ids=" 201,202 ", types=" REMARKETING ")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "retargeting",
+                "get",
+                "--format",
+                "json",
+                "--ids",
+                "201,202",
+                "--types",
+                "REMARKETING",
+            ]
+        )
+
     def test_list_retargeting_auth_error(self):
         """Test auth error during retargeting list."""
         runner = MagicMock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -111,8 +111,9 @@ EXPECTED_TOOLS = {
     "smart_ad_targets_delete",
     # Businesses (1 tool)
     "businesses_list",
-    # Dictionaries (1 tool)
+    # Dictionaries (2 tools)
     "dictionaries_get",
+    "dictionaries_list_names",
     # Changes (3 tools)
     "changes_check",
     "changes_checkcamp",
@@ -136,8 +137,9 @@ EXPECTED_TOOLS = {
     "feeds_delete",
     # Creatives (1 tool)
     "creatives_list",
-    # Turbo Pages (1 tool)
+    # Turbo Pages (2 tools)
     "turbo_pages_list",
+    "turbo_pages_add",
     # Auth (3 tools)
     "auth_status",
     "auth_setup",

--- a/tests/test_sitelinks.py
+++ b/tests/test_sitelinks.py
@@ -20,18 +20,9 @@ def mock_sitelinks():
     return [
         {
             "Id": 1,
-            "Name": "Quick Links",
-            "Links": [
+            "Sitelinks": [
                 {"Title": "About", "Href": "https://example.com/about"},
                 {"Title": "Contact", "Href": "https://example.com/contact"},
-            ],
-        },
-        {
-            "Id": 2,
-            "Name": "Products",
-            "Links": [
-                {"Title": "Product A", "Href": "https://example.com/a"},
-                {"Title": "Product B", "Href": "https://example.com/b"},
             ],
         },
     ]
@@ -53,9 +44,18 @@ class TestSitelinksList:
             "server.tools.sitelinks.get_runner",
             return_value=_mock_runner(mock_sitelinks),
         ):
-            result = sitelinks_list(ids="1,2")
-            assert len(result) == 2
+            result = sitelinks_list(ids="1")
+            assert len(result) == 1
             assert result[0]["Id"] == 1
+
+    def test_list_sitelinks_no_ids(self, mock_sitelinks):
+        """Test listing sitelinks with no IDs returns all."""
+        with patch(
+            "server.tools.sitelinks.get_runner",
+            return_value=_mock_runner(mock_sitelinks),
+        ):
+            result = sitelinks_list()
+            assert len(result) == 1
 
     def test_list_sitelinks_batch_limit(self):
         """Test batch limit validation for list."""
@@ -64,27 +64,25 @@ class TestSitelinksList:
         assert "error" in result
         assert result["error"] == "batch_limit"
 
-    def test_list_sitelinks_empty_result(self):
-        """Test empty response returns empty list."""
-        with patch("server.tools.sitelinks.get_runner", return_value=_mock_runner([])):
-            result = sitelinks_list(ids="1")
-            assert result == []
-
 
 class TestSitelinksAdd:
     """Tests for sitelinks_add tool."""
 
     def test_add_sitelinks_success(self):
         """Test adding sitelinks successfully."""
-        mock_result = {"Id": 123, "Name": "New Sitelinks"}
-        sitelinks_data = '{"Name": "New Sitelinks", "Links": [{"Title": "Link", "Href": "https://example.com"}]}'
+        mock_result = {"Id": 123}
+        links = '[{"Title":"About","Href":"https://example.com/about"}]'
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
 
         with patch(
-            "server.tools.sitelinks.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.sitelinks.get_runner",
+            return_value=runner,
         ):
-            result = sitelinks_add(sitelinks_data=sitelinks_data)
+            result = sitelinks_add(links=links)
             assert result["Id"] == 123
-            assert result["Name"] == "New Sitelinks"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--links" in call_args
 
 
 class TestSitelinksDelete:
@@ -95,9 +93,10 @@ class TestSitelinksDelete:
         mock_result = {"success": True}
 
         with patch(
-            "server.tools.sitelinks.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.sitelinks.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = sitelinks_delete(ids="1,2")
+            result = sitelinks_delete(ids="1")
             assert result["success"] is True
 
     def test_delete_sitelinks_batch_limit(self):

--- a/tests/test_sitelinks.py
+++ b/tests/test_sitelinks.py
@@ -64,6 +64,17 @@ class TestSitelinksList:
         assert "error" in result
         assert result["error"] == "batch_limit"
 
+    def test_list_sitelinks_trims_ids_before_cli(self, mock_sitelinks):
+        """Test sitelink IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_sitelinks
+        with patch("server.tools.sitelinks.get_runner", return_value=runner):
+            sitelinks_list(ids=" 1 ")
+
+        runner.run_json.assert_called_once_with(
+            ["sitelinks", "get", "--format", "json", "--ids", "1"]
+        )
+
 
 class TestSitelinksAdd:
     """Tests for sitelinks_add tool."""

--- a/tests/test_smart_ad_targets.py
+++ b/tests/test_smart_ad_targets.py
@@ -44,6 +44,28 @@ def test_smart_ad_targets_list():
         assert len(result) == 1
 
 
+def test_smart_ad_targets_list_trims_ids():
+    runner = _mock_runner(SAMPLE_TARGETS)
+    with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
+        smart_ad_targets_list(ad_group_ids=" 200 ")
+
+    runner.run_json.assert_called_once_with(
+        [
+            "smartadtargets",
+            "get",
+            "--adgroup-ids",
+            "200",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_smart_ad_targets_list_requires_ids():
+    result = smart_ad_targets_list(ad_group_ids="   ")
+    assert result["error"] == "missing_ad_group_ids"
+
+
 def test_smart_ad_targets_list_empty():
     with patch(
         "server.tools.smart_ad_targets.get_runner", return_value=_mock_runner([])

--- a/tests/test_smart_targets.py
+++ b/tests/test_smart_targets.py
@@ -1,6 +1,6 @@
 """Tests for smart target MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -37,6 +37,17 @@ def test_smart_targets_list():
     ):
         result = smart_targets_list(ad_group_ids="100")
         assert len(result) == 1
+
+
+def test_smart_targets_list_ignores_blank_ids():
+    """Test blank ad group IDs behave like no filter."""
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_TARGETS
+    with patch("server.tools.smart_targets.get_runner", return_value=runner):
+        result = smart_targets_list(ad_group_ids="   ")
+        assert len(result) == 1
+        call_args = runner.run_json.call_args[0][0]
+        assert "--adgroup-ids" not in call_args
 
 
 def test_smart_targets_list_no_ids():
@@ -82,6 +93,19 @@ class TestSmartTargetsDelete:
         ):
             result = smart_targets_delete(ids="1")
             assert result["success"] is True
+
+    def test_smart_targets_delete_batches_multiple_ids(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.smart_targets.get_runner", return_value=runner):
+            result = smart_targets_delete(ids="1,2")
+
+        assert result["success"] is True
+        assert result["ids"] == ["1", "2"]
+        assert runner.run_json.call_args_list == [
+            call(["smarttargets", "delete", "--id", "1"]),
+            call(["smarttargets", "delete", "--id", "2"]),
+        ]
 
     def test_smart_targets_delete_batch_limit(self):
         ids = ",".join(str(i) for i in range(1, 12))

--- a/tests/test_smart_targets.py
+++ b/tests/test_smart_targets.py
@@ -98,6 +98,12 @@ def test_smart_targets_update():
         assert result["success"] is True
 
 
+def test_smart_targets_update_requires_fields():
+    """Test missing smart target update fields returns a local error."""
+    result = smart_targets_update(id="1")
+    assert result["error"] == "missing_update_fields"
+
+
 class TestSmartTargetsDelete:
     """Tests for smart target delete operations."""
 

--- a/tests/test_smart_targets.py
+++ b/tests/test_smart_targets.py
@@ -39,6 +39,22 @@ def test_smart_targets_list():
         assert len(result) == 1
 
 
+def test_smart_targets_use_canonical_cli_surface():
+    """Legacy wrapper should call canonical smartadtargets command."""
+    runner = MagicMock()
+    runner.run_json.return_value = {"success": True}
+    with patch("server.tools.smart_targets.get_runner", return_value=runner):
+        smart_targets_list(ad_group_ids="100")
+        smart_targets_add(ad_group_id="100", target_type="RETARGETING")
+        smart_targets_update(id="1", extra_json='{"Condition":"URL_CONTAINS"}')
+        smart_targets_delete(ids="1")
+
+    assert runner.run_json.call_args_list[0][0][0][0] == "smartadtargets"
+    assert runner.run_json.call_args_list[1][0][0][0] == "smartadtargets"
+    assert runner.run_json.call_args_list[2][0][0][0] == "smartadtargets"
+    assert runner.run_json.call_args_list[3][0][0][0] == "smartadtargets"
+
+
 def test_smart_targets_list_ignores_blank_ids():
     """Test blank ad group IDs behave like no filter."""
     runner = MagicMock()
@@ -103,8 +119,8 @@ class TestSmartTargetsDelete:
         assert result["success"] is True
         assert result["ids"] == ["1", "2"]
         assert runner.run_json.call_args_list == [
-            call(["smarttargets", "delete", "--id", "1"]),
-            call(["smarttargets", "delete", "--id", "2"]),
+            call(["smartadtargets", "delete", "--id", "1"]),
+            call(["smartadtargets", "delete", "--id", "2"]),
         ]
 
     def test_smart_targets_delete_batch_limit(self):

--- a/tests/test_smart_targets.py
+++ b/tests/test_smart_targets.py
@@ -1,6 +1,6 @@
 """Tests for smart target MCP tools."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,17 +18,12 @@ def setup():
     server.tools.set_token_getter(lambda: "test-token")
 
 
-SAMPLE_SMART_TARGETS = [
-    {
-        "Id": 1,
-        "AdGroupId": 100,
-        "Conditions": '{"RetargetingListId": "123"}',
-    },
+SAMPLE_TARGETS = [
+    {"Id": 1, "AdGroupId": 100, "Type": "RETARGETING"},
 ]
 
 
 def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
@@ -38,70 +33,58 @@ def test_smart_targets_list():
     """Test listing smart targets."""
     with patch(
         "server.tools.smart_targets.get_runner",
-        return_value=_mock_runner(SAMPLE_SMART_TARGETS),
+        return_value=_mock_runner(SAMPLE_TARGETS),
     ):
-        result = smart_targets_list(ad_group_ids="100,101")
+        result = smart_targets_list(ad_group_ids="100")
         assert len(result) == 1
-        assert result[0]["Id"] == 1
-        assert result[0]["AdGroupId"] == 100
+
+
+def test_smart_targets_list_no_ids():
+    """Test listing all smart targets."""
+    with patch(
+        "server.tools.smart_targets.get_runner",
+        return_value=_mock_runner(SAMPLE_TARGETS),
+    ):
+        result = smart_targets_list()
+        assert len(result) == 1
 
 
 def test_smart_targets_add():
     """Test adding smart target."""
-    conditions = '{"RetargetingListId": "123"}'
-    mock_result = {"success": True, "id": 1}
+    mock_result = {"Id": 1}
     with patch(
         "server.tools.smart_targets.get_runner",
         return_value=_mock_runner(mock_result),
     ):
-        result = smart_targets_add(ad_group_id="100", conditions=conditions)
-        assert result["success"] is True
-        assert result["id"] == 1
-
-
-def test_smart_targets_add_invalid_json():
-    """Test adding smart target with invalid JSON."""
-    result = smart_targets_add(ad_group_id="100", conditions="invalid json")
-    assert "error" in result
-    assert result["error"] == "invalid_json"
+        result = smart_targets_add(ad_group_id="100", target_type="RETARGETING")
+        assert result["Id"] == 1
 
 
 def test_smart_targets_update():
     """Test updating smart target."""
-    conditions = '{"RetargetingListId": "456"}'
-    mock_result = {"success": True, "id": 1}
+    mock_result = {"success": True}
     with patch(
         "server.tools.smart_targets.get_runner",
         return_value=_mock_runner(mock_result),
     ):
-        result = smart_targets_update(id="1", conditions=conditions)
+        result = smart_targets_update(id="1", extra_json='{"Condition":"URL_CONTAINS"}')
         assert result["success"] is True
-        assert result["id"] == 1
-
-
-def test_smart_targets_update_invalid_json():
-    """Test updating smart target with invalid JSON."""
-    result = smart_targets_update(id="1", conditions="not json")
-    assert "error" in result
-    assert result["error"] == "invalid_json"
 
 
 class TestSmartTargetsDelete:
     """Tests for smart target delete operations."""
 
     def test_smart_targets_delete_success(self):
-        """Test deleting smart targets successfully."""
         mock_result = {"success": True}
         with patch(
             "server.tools.smart_targets.get_runner",
             return_value=_mock_runner(mock_result),
         ):
-            result = smart_targets_delete(ids="1,2")
+            result = smart_targets_delete(ids="1")
             assert result["success"] is True
 
     def test_smart_targets_delete_batch_limit(self):
-        """Test batch limit validation for delete."""
-        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        ids = ",".join(str(i) for i in range(1, 12))
         result = smart_targets_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"

--- a/tests/test_turbo_pages.py
+++ b/tests/test_turbo_pages.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import server.tools
-from server.tools.turbo_pages import turbo_pages_list
+from server.tools.turbo_pages import turbo_pages_list, turbo_pages_add
 
 
 @pytest.fixture(autouse=True)
@@ -32,3 +32,48 @@ class TestTurboPagesList:
         ):
             result = turbo_pages_list(ids="1")
             assert "turboPages" in result
+
+    def test_turbo_pages_list_no_ids(self):
+        """Test listing all turbo pages."""
+        mock_result = {"turboPages": []}
+        with patch(
+            "server.tools.turbo_pages.get_runner",
+            return_value=_mock_runner(mock_result),
+        ):
+            result = turbo_pages_list()
+            assert "turboPages" in result
+
+
+class TestTurboPagesAdd:
+    """Tests for turbo_pages_add tool."""
+
+    def test_turbo_pages_add_basic(self):
+        """Test adding a turbo page."""
+        mock_result = {"id": 123, "name": "Test Page"}
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
+        with patch(
+            "server.tools.turbo_pages.get_runner",
+            return_value=runner,
+        ):
+            result = turbo_pages_add(name="Test Page", url="https://example.com/page")
+            assert result["id"] == 123
+            call_args = runner.run_json.call_args[0][0]
+            assert "--name" in call_args
+            assert "--url" in call_args
+
+    def test_turbo_pages_add_with_extra_json(self):
+        """Test adding turbo page with extra JSON."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"id": 124}
+        with patch(
+            "server.tools.turbo_pages.get_runner",
+            return_value=runner,
+        ):
+            turbo_pages_add(
+                name="Test",
+                url="https://example.com/page",
+                extra_json='{"Description":"test"}',
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args

--- a/tests/test_turbo_pages.py
+++ b/tests/test_turbo_pages.py
@@ -43,6 +43,17 @@ class TestTurboPagesList:
             result = turbo_pages_list()
             assert "turboPages" in result
 
+    def test_turbo_pages_list_trims_ids(self):
+        """Test turbo page IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"turboPages": []}
+        with patch("server.tools.turbo_pages.get_runner", return_value=runner):
+            turbo_pages_list(ids=" 1 ")
+
+        runner.run_json.assert_called_once_with(
+            ["turbopages", "get", "--format", "json", "--ids", "1"]
+        )
+
 
 class TestTurboPagesAdd:
     """Tests for turbo_pages_add tool."""

--- a/tests/test_vcards.py
+++ b/tests/test_vcards.py
@@ -53,18 +53,21 @@ class TestVcardsList:
             assert len(result) == 2
             assert result[0]["Id"] == 1
 
+    def test_list_vcards_no_ids(self, mock_vcards):
+        """Test listing all vCards with no IDs."""
+        with patch(
+            "server.tools.vcards.get_runner",
+            return_value=_mock_runner(mock_vcards),
+        ):
+            result = vcards_list()
+            assert len(result) == 2
+
     def test_list_vcards_batch_limit(self):
         """Test batch limit validation for list."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
         result = vcards_list(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
-
-    def test_list_vcards_empty_result(self):
-        """Test empty response returns empty list."""
-        with patch("server.tools.vcards.get_runner", return_value=_mock_runner([])):
-            result = vcards_list(ids="1")
-            assert result == []
 
 
 class TestVcardsAdd:
@@ -73,14 +76,15 @@ class TestVcardsAdd:
     def test_add_vcard_success(self):
         """Test adding vCard successfully."""
         mock_result = {"Id": 123, "CompanyAddress": "789 Pine Rd"}
-        vcard_data = '{"CompanyAddress": "789 Pine Rd", "ContactPhone": "+79991112233"}'
+        vcard_json = '{"CompanyAddress": "789 Pine Rd"}'
+        runner = MagicMock()
+        runner.run_json.return_value = mock_result
 
-        with patch(
-            "server.tools.vcards.get_runner", return_value=_mock_runner(mock_result)
-        ):
-            result = vcards_add(vcard_data=vcard_data)
+        with patch("server.tools.vcards.get_runner", return_value=runner):
+            result = vcards_add(vcard_json=vcard_json)
             assert result["Id"] == 123
-            assert result["CompanyAddress"] == "789 Pine Rd"
+            call_args = runner.run_json.call_args[0][0]
+            assert "--json" in call_args
 
 
 class TestVcardsDelete:
@@ -91,9 +95,10 @@ class TestVcardsDelete:
         mock_result = {"success": True}
 
         with patch(
-            "server.tools.vcards.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.vcards.get_runner",
+            return_value=_mock_runner(mock_result),
         ):
-            result = vcards_delete(ids="1,2")
+            result = vcards_delete(ids="1")
             assert result["success"] is True
 
     def test_delete_vcards_batch_limit(self):

--- a/tests/test_vcards.py
+++ b/tests/test_vcards.py
@@ -69,6 +69,17 @@ class TestVcardsList:
         assert "error" in result
         assert result["error"] == "batch_limit"
 
+    def test_list_vcards_trims_ids_before_cli(self, mock_vcards):
+        """Test vCard IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_vcards
+        with patch("server.tools.vcards.get_runner", return_value=runner):
+            vcards_list(ids=" 1,2 ")
+
+        runner.run_json.assert_called_once_with(
+            ["vcards", "get", "--format", "json", "--ids", "1,2"]
+        )
+
 
 class TestVcardsAdd:
     """Tests for vcards_add tool."""


### PR DESCRIPTION
## Summary

Closes #58. Full audit of all MCP tool wrappers against direct-cli command source code. Every CLI flag, parameter type, and subcommand was verified by reading the actual source at `direct_cli/commands/`.

## Categories fixed

### Category 1 — Non-existent CLI commands (3 tools documented)
- `negative_keywords.py` — CLI has no `negativekeywords` command (only `negativekeywordsharedsets`)
- `smart_targets.py` — CLI has no `smarttargets` command (only `smartadtargets`)
- `dynamic_targets.py` — CLI has no `dynamictargets` command (only `dynamicads`)
- Added docstring notes explaining the situation; tools kept as placeholders

### Category 2 — Incorrect CLI flags (10+ tools fixed)
- `dictionaries_get`: `--type` → `--names`, removed non-existent `--locale`
- `leads_list`: removed non-existent `--date-from`/`--date-to`
- `agency_clients_list/add/delete`: `--login` → `--ids`/`--json`/`--id`
- `clients_get/update`: `--login`/`--fields` → `--ids`/`--client-id` + `--json`
- `adextensions_add`: `--data` → `--json`; `delete`: `--ids` → `--id`
- `adimages_add`: `--data` → `--json`; `delete`: `--ids` → `--hash`
- `sitelinks_add`: `--data` → `--links`
- `vcards_add`: `--data` → `--json`
- `retargeting_add`: `--rule` → `--type` + `--json`
- `audience_targets_add`: `--campaign-id`/`--audience-id` → `--adgroup-id`/`--retargeting-list-id`/`--bid`/`--json`
- `bidmodifiers_set/toggle/delete`: fixed flag validation and command names
- `bids_set`: removed non-existent `--context-bid`, added `--json`
- `adgroups_delete`, `feeds_delete`: `--ids` → `--id` via `run_single_id_batch`

### Category 3 — Missing domain parameters (15 tools expanded)
- `ads_list`: added `ids`, `ad_group_ids`, `status`
- `adgroups_list/add/update`: added `ids`, `status`, `types`, `type`, `extra_json`
- `campaigns_list`: added `ids`, `status`, `types`
- `bidmodifiers_list/set`: added `ad_group_ids`, `extra_json`
- `bids_list/set`: added `ad_group_ids`, `keyword_ids`, `extra_json`
- `retargeting_list/add`: added `types`, `list_type`, `extra_json`
- `creatives_list`: added `campaign_ids`
- `audience_targets_list`: added `ids`, `ad_group_ids`
- `feeds_add/update`: added `extra_json`

### Category 4 — New tools
- `turbo_pages_add` (name, url, extra_json)
- `dictionaries_list_names` — lists available dictionary names

## Test plan

- [x] All 340 tests pass (`pytest tests/ -x -q`)
- [x] `ruff check server/tools/ tests/` passes
- [x] `ruff format server/tools/ tests/` applied
- [x] `EXPECTED_TOOLS` in `test_server.py` updated for new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)