### PR TITLE
fix(issue-60): accept dict for JSON params, serialize before CLI

### DIFF
--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -1,5 +1,7 @@
 """MCP tools for ad extensions management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
@@ -33,7 +35,7 @@ def adextensions_list(
 
 @mcp.tool()
 @handle_cli_errors
-def adextensions_add(extension_type: str, extra_json: str) -> dict:
+def adextensions_add(extension_type: str, extra_json: str | dict) -> dict:
     """Add an ad extension.
 
     Args:
@@ -41,6 +43,7 @@ def adextensions_add(extension_type: str, extra_json: str) -> dict:
         extra_json: JSON string describing the extension content.
     """
     runner = get_runner()
+    json_str = json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
     result = runner.run_json(
         [
             "adextensions",
@@ -48,7 +51,7 @@ def adextensions_add(extension_type: str, extra_json: str) -> dict:
             "--type",
             extension_type,
             "--json",
-            extra_json,
+            json_str,
         ]
     )
     return result

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -1,5 +1,7 @@
 """MCP tools for ad group management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
@@ -57,7 +59,7 @@ def adgroups_add(
     name: str,
     region_ids: str | None = None,
     type: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Create a new ad group.
 
@@ -81,7 +83,10 @@ def adgroups_add(
     if region_ids is not None:
         args.extend(["--region-ids", region_ids])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -92,7 +97,7 @@ def adgroups_update(
     id: str,
     name: str | None = None,
     status: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Update an ad group.
 
@@ -114,7 +119,10 @@ def adgroups_update(
     if status is not None:
         args.extend(["--status", status])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -1,5 +1,7 @@
 """MCP tool for listing ads."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -96,7 +98,7 @@ def ads_add(
     title: str | None = None,
     text: str | None = None,
     href: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Create a new ad.
 
@@ -118,7 +120,10 @@ def ads_add(
     if href:
         args.extend(["--href", href])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -126,7 +131,7 @@ def ads_add(
 @mcp.tool()
 @handle_cli_errors
 def ads_update(
-    id: str, status: str | None = None, extra_json: str | None = None
+    id: str, status: str | None = None, extra_json: str | dict | None = None
 ) -> dict:
     """Update an ad.
 
@@ -145,7 +150,10 @@ def ads_update(
     if status:
         args.extend(["--status", status])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -1,5 +1,7 @@
 """MCP tools for audience target management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
@@ -49,7 +51,7 @@ def audience_targets_add(
     ad_group_id: str,
     retargeting_list_id: str,
     bid: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Add an audience target to an ad group.
 
@@ -70,7 +72,10 @@ def audience_targets_add(
     if bid is not None:
         args.extend(["--bid", bid])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -1,5 +1,7 @@
 """MCP tools for bid modifier management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
@@ -41,7 +43,7 @@ def bidmodifiers_set(
     campaign_id: str,
     modifier_type: str,
     value: str,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Set bid modifier for a campaign.
 
@@ -62,7 +64,10 @@ def bidmodifiers_set(
         value,
     ]
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -1,5 +1,7 @@
 """MCP tools for bid management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
@@ -48,7 +50,7 @@ def bids_list(
 def bids_set(
     campaign_id: str,
     bid: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Set bid for a campaign.
 
@@ -68,6 +70,9 @@ def bids_set(
     if bid is not None:
         args.extend(["--bid", bid])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -1,5 +1,7 @@
 """MCP tools for campaign management."""
 
+import json
+
 from server.cli.runner import CliAuthError, CliNotFoundError
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
@@ -57,7 +59,7 @@ def campaigns_update(
     name: str | None = None,
     status: str | None = None,
     budget: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Update campaign fields.
 
@@ -96,7 +98,10 @@ def campaigns_update(
         if budget_value is not None:
             args.extend(["--budget", budget_value])
         if extra_json:
-            args.extend(["--json", extra_json])
+            json_str = (
+                json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+            )
+            args.extend(["--json", json_str])
         runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
         raise
@@ -126,7 +131,7 @@ def campaigns_add(
     campaign_type: str | None = None,
     budget: str | None = None,
     end_date: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Create a new campaign.
 
@@ -159,7 +164,10 @@ def campaigns_add(
     if end_date:
         args.extend(["--end-date", end_date])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     result = runner.run_json(args)
     return result
 

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -1,5 +1,7 @@
 """MCP tools for client management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
@@ -24,7 +26,7 @@ def clients_get(ids: str | None = None) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def clients_update(client_id: str, extra_json: str) -> dict:
+def clients_update(client_id: str, extra_json: str | dict) -> dict:
     """Update client information.
 
     Args:
@@ -32,6 +34,7 @@ def clients_update(client_id: str, extra_json: str) -> dict:
         extra_json: JSON string containing fields to update.
     """
     runner = get_runner()
+    json_str = json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
     result = runner.run_json(
         [
             "clients",
@@ -39,7 +42,7 @@ def clients_update(client_id: str, extra_json: str) -> dict:
             "--client-id",
             client_id,
             "--json",
-            extra_json,
+            json_str,
         ]
     )
     return result

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -1,5 +1,7 @@
 """MCP tools for dynamic ad (webpage) management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -33,7 +35,7 @@ def dynamic_ads_list(ad_group_ids: str) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_ads_add(ad_group_id: str, target_data: str) -> dict:
+def dynamic_ads_add(ad_group_id: str, target_data: str | dict) -> dict:
     """Add a dynamic ad target (webpage).
 
     Args:
@@ -41,6 +43,7 @@ def dynamic_ads_add(ad_group_id: str, target_data: str) -> dict:
         target_data: JSON string with target data (must include Name and Conditions).
     """
     runner = get_runner()
+    json_str = json.dumps(target_data) if isinstance(target_data, dict) else target_data
     return runner.run_json(
         [
             "dynamicads",
@@ -48,14 +51,14 @@ def dynamic_ads_add(ad_group_id: str, target_data: str) -> dict:
             "--adgroup-id",
             ad_group_id,
             "--json",
-            target_data,
+            json_str,
         ]
     )
 
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_ads_update(id: str, extra_json: str) -> dict:
+def dynamic_ads_update(id: str, extra_json: str | dict) -> dict:
     """Update a dynamic ad target (webpage).
 
     Args:
@@ -63,7 +66,8 @@ def dynamic_ads_update(id: str, extra_json: str) -> dict:
         extra_json: JSON string with fields to update.
     """
     runner = get_runner()
-    return runner.run_json(["dynamicads", "update", "--id", id, "--json", extra_json])
+    json_str = json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+    return runner.run_json(["dynamicads", "update", "--id", id, "--json", json_str])
 
 
 @mcp.tool()

--- a/server/tools/dynamic_targets.py
+++ b/server/tools/dynamic_targets.py
@@ -6,6 +6,8 @@ The audited direct-cli surface does not guarantee a working
 wrappers in ``dynamic_ads.py``.
 """
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
@@ -35,7 +37,7 @@ def dynamic_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
+def dynamic_targets_add(ad_group_id: str, target_data: str | dict) -> dict:
     """Add a dynamic ad target.
 
     Args:
@@ -43,6 +45,7 @@ def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
         target_data: JSON string with target data (must include Name and Conditions).
     """
     runner = get_runner()
+    json_str = json.dumps(target_data) if isinstance(target_data, dict) else target_data
     return runner.run_json(
         [
             "dynamicads",
@@ -50,7 +53,7 @@ def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
             "--adgroup-id",
             ad_group_id,
             "--json",
-            target_data,
+            json_str,
             "--format",
             "json",
         ]
@@ -59,7 +62,7 @@ def dynamic_targets_add(ad_group_id: str, target_data: str) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def dynamic_targets_update(id: str, extra_json: str) -> dict:
+def dynamic_targets_update(id: str, extra_json: str | dict) -> dict:
     """Update a dynamic ad target.
 
     Args:
@@ -67,6 +70,7 @@ def dynamic_targets_update(id: str, extra_json: str) -> dict:
         extra_json: JSON string with fields to update.
     """
     runner = get_runner()
+    json_str = json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
     return runner.run_json(
         [
             "dynamicads",
@@ -74,7 +78,7 @@ def dynamic_targets_update(id: str, extra_json: str) -> dict:
             "--id",
             id,
             "--json",
-            extra_json,
+            json_str,
             "--format",
             "json",
         ]

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -1,5 +1,7 @@
 """MCP tools for feed management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -22,7 +24,7 @@ def feeds_list(ids: str | None = None) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def feeds_add(name: str, url: str, extra_json: str | None = None) -> dict:
+def feeds_add(name: str, url: str, extra_json: str | dict | None = None) -> dict:
     """Add a new feed.
 
     Args:
@@ -32,7 +34,10 @@ def feeds_add(name: str, url: str, extra_json: str | None = None) -> dict:
     """
     args = ["feeds", "add", "--name", name, "--url", url]
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -43,7 +48,7 @@ def feeds_update(
     id: str,
     name: str | None = None,
     url: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Update an existing feed.
 
@@ -65,7 +70,10 @@ def feeds_update(
     if url is not None:
         args.extend(["--url", url])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -1,5 +1,7 @@
 """MCP tools for ad images management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
@@ -23,14 +25,15 @@ def adimages_list(ids: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def adimages_add(image_json: str) -> dict:
+def adimages_add(image_json: str | dict) -> dict:
     """Add an ad image.
 
     Args:
         image_json: JSON string with image data (e.g. base64-encoded).
     """
     runner = get_runner()
-    result = runner.run_json(["adimages", "add", "--json", image_json])
+    json_str = json.dumps(image_json) if isinstance(image_json, dict) else image_json
+    result = runner.run_json(["adimages", "add", "--json", json_str])
     return result
 
 

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -1,5 +1,7 @@
 """MCP tools for keyword bid management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -38,7 +40,7 @@ def keyword_bids_set(
     keyword_id: str,
     search_bid: str | None = None,
     network_bid: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Set keyword bids.
 
@@ -76,6 +78,9 @@ def keyword_bids_set(
     if network_bid_value is not None:
         args.extend(["--network-bid", str(network_bid_value)])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -1,5 +1,7 @@
 """MCP tools for keyword management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -55,7 +57,7 @@ def keywords_update(
     bid: str | None = None,
     context_bid: str | None = None,
     status: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Update keyword fields.
 
@@ -100,7 +102,10 @@ def keywords_update(
     if status:
         args.extend(["--status", status])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner.run_json(args)
 
     result: dict[str, object] = {"success": True, "id": id}
@@ -124,7 +129,7 @@ def keywords_add(
     context_bid: str | None = None,
     user_param_1: str | None = None,
     user_param_2: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Add a keyword to an ad group.
 
@@ -147,7 +152,10 @@ def keywords_add(
     if user_param_2 is not None:
         args.extend(["--user-param-2", user_param_2])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -1,5 +1,7 @@
 """MCP tools for negative keyword shared sets management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -48,7 +50,7 @@ def negative_keyword_shared_sets_update(
     id: str,
     name: str | None = None,
     keywords: str | None = None,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Update a negative keyword shared set.
 
@@ -70,7 +72,10 @@ def negative_keyword_shared_sets_update(
     if keywords is not None:
         args.extend(["--keywords", keywords])
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -1,5 +1,7 @@
 """MCP tools for retargeting list management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import run_single_id_batch
@@ -32,7 +34,7 @@ def retargeting_list(
 def retargeting_add(
     name: str,
     list_type: str,
-    extra_json: str | None = None,
+    extra_json: str | dict | None = None,
 ) -> dict:
     """Add a retargeting list.
 
@@ -50,7 +52,10 @@ def retargeting_add(
         list_type,
     ]
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -1,5 +1,7 @@
 """MCP tools for sitelinks management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
@@ -27,7 +29,7 @@ def sitelinks_list(ids: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def sitelinks_add(links: str) -> dict:
+def sitelinks_add(links: str | list) -> dict:
     """Add a sitelinks set.
 
     Args:
@@ -35,7 +37,8 @@ def sitelinks_add(links: str) -> dict:
             Example: '[{"Title":"About","Href":"https://example.com/about"}]'
     """
     runner = get_runner()
-    result = runner.run_json(["sitelinks", "add", "--links", links])
+    links_str = json.dumps(links) if isinstance(links, list) else links
+    result = runner.run_json(["sitelinks", "add", "--links", links_str])
     return result
 
 

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -1,5 +1,7 @@
 """MCP tools for smart ad target management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -34,7 +36,7 @@ def smart_ad_targets_list(ad_group_ids: str) -> list[dict] | dict:
 @mcp.tool()
 @handle_cli_errors
 def smart_ad_targets_add(
-    ad_group_id: str, target_type: str, extra_json: str | None = None
+    ad_group_id: str, target_type: str, extra_json: str | dict | None = None
 ) -> dict:
     """Add a smart ad target.
 
@@ -45,7 +47,10 @@ def smart_ad_targets_add(
     """
     args = ["smartadtargets", "add", "--adgroup-id", ad_group_id, "--type", target_type]
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -53,7 +58,7 @@ def smart_ad_targets_add(
 @mcp.tool()
 @handle_cli_errors
 def smart_ad_targets_update(
-    id: str, target_type: str | None = None, extra_json: str | None = None
+    id: str, target_type: str | None = None, extra_json: str | dict | None = None
 ) -> dict:
     """Update a smart ad target.
 
@@ -72,7 +77,10 @@ def smart_ad_targets_update(
     if target_type:
         args.extend(["--type", target_type])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/smart_targets.py
+++ b/server/tools/smart_targets.py
@@ -6,6 +6,8 @@ The audited direct-cli surface does not guarantee a working
 wrappers in ``smart_ad_targets.py``.
 """
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -36,7 +38,7 @@ def smart_targets_list(ad_group_ids: str | None = None) -> list[dict] | dict:
 @mcp.tool()
 @handle_cli_errors
 def smart_targets_add(
-    ad_group_id: str, target_type: str, extra_json: str | None = None
+    ad_group_id: str, target_type: str, extra_json: str | dict | None = None
 ) -> dict:
     """Add a smart ad target.
 
@@ -54,7 +56,10 @@ def smart_targets_add(
         target_type,
     ]
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     args.extend(["--format", "json"])
     runner = get_runner()
     return runner.run_json(args)
@@ -63,7 +68,7 @@ def smart_targets_add(
 @mcp.tool()
 @handle_cli_errors
 def smart_targets_update(
-    id: str, target_type: str | None = None, extra_json: str | None = None
+    id: str, target_type: str | None = None, extra_json: str | dict | None = None
 ) -> dict:
     """Update a smart ad target.
 
@@ -82,7 +87,10 @@ def smart_targets_update(
     if target_type:
         args.extend(["--type", target_type])
     if extra_json:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     args.extend(["--format", "json"])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/turbo_pages.py
+++ b/server/tools/turbo_pages.py
@@ -1,5 +1,7 @@
 """MCP tools for turbo pages management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
@@ -22,7 +24,7 @@ def turbo_pages_list(ids: str | None = None) -> dict:
 
 @mcp.tool()
 @handle_cli_errors
-def turbo_pages_add(name: str, url: str, extra_json: str | None = None) -> dict:
+def turbo_pages_add(name: str, url: str, extra_json: str | dict | None = None) -> dict:
     """Add a turbo page.
 
     Args:
@@ -32,6 +34,9 @@ def turbo_pages_add(name: str, url: str, extra_json: str | None = None) -> dict:
     """
     args = ["turbopages", "add", "--name", name, "--url", url]
     if extra_json is not None:
-        args.extend(["--json", extra_json])
+        json_str = (
+            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        )
+        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -1,5 +1,7 @@
 """MCP tools for vCard management."""
 
+import json
+
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
@@ -27,14 +29,15 @@ def vcards_list(ids: str | None = None) -> list[dict] | dict:
 
 @mcp.tool()
 @handle_cli_errors
-def vcards_add(vcard_json: str) -> dict:
+def vcards_add(vcard_json: str | dict) -> dict:
     """Add a vCard.
 
     Args:
         vcard_json: JSON string describing the vCard.
     """
     runner = get_runner()
-    result = runner.run_json(["vcards", "add", "--json", vcard_json])
+    json_str = json.dumps(vcard_json) if isinstance(vcard_json, dict) else vcard_json
+    result = runner.run_json(["vcards", "add", "--json", json_str])
     return result
 
 


### PR DESCRIPTION
## Summary

Claude Code (the MCP host) auto-parses JSON-looking string arguments into `dict`/`list` before passing them to MCP tools. Tool functions that declared their JSON-shaped parameters as `str | None` rejected those calls with a Pydantic validation error before the CLI was even invoked:

\`\`\`
Input should be a valid string [type=string_type, input_value={'TextAd': {'Title': '...'}}, input_type=dict]
\`\`\`

This PR widens the type of every JSON-shaped parameter to accept `str | dict` (or `str | list` for `sitelinks_add`, which expects a JSON array) and serializes back to a string with `json.dumps` before forwarding to \`direct-cli\`. The CLI invocation is unchanged on the wire — recorded cassettes still match.

## Scope

- 21 functions across 20 modules touched (1 already fixed in working tree before this PR: \`ads_add\`/\`ads_update\` in \`server/tools/ads.py\`).
- Audit found **6 functions missed by the original issue #60**:
  - \`dynamic_targets_update\` (extra_json, required)
  - \`adextensions_add\` (extra_json, required)
  - \`clients_update\` (extra_json, required)
  - \`vcards_add\` (\`vcard_json\`, required)
  - \`adimages_add\` (\`image_json\`, required)
  - \`sitelinks_add\` (\`links\`, required, JSON array)
  - Plus \`dynamic_ads_add\` and \`dynamic_targets_add\` use \`target_data\` instead of \`extra_json\` — also missed.

## Test plan

- [x] \`ruff check .\` — clean
- [x] \`ruff format --check .\` — clean
- [x] \`mypy server/\` — \`Success: no issues found in 41 source files\`
- [x] \`pytest -q\` — \`385 passed, 8 skipped\` (cassettes unchanged because serialized arg list is identical)
- [ ] Manual MCP smoke: call \`ads_update\` from Claude Code with an inline dict argument and confirm Pydantic no longer rejects (requires direct-cli #61 to land before \`ads_add\` actually succeeds against the API)

## Related

- Closes #60
- Sub-issue under tracking #18
- direct-cli side of the same Phase 2 cleanup is tracked in #61 (\`Type\` field bug in \`ads add\` + write-command test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)