### PR TITLE
test: expand coverage with 31 new tests across 14 modules

### DIFF
--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -112,6 +112,17 @@ class TestAgencyClientsAdd:
             result = agency_clients_add(client_json=client_json)
             assert result == mock_result
 
+    def test_add_client_argv_composition(self):
+        """Test add passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Login": "client"}
+        with patch("server.tools.agency.get_runner", return_value=runner):
+            agency_clients_add(client_json='{"Login":"test"}')
+
+        runner.run_json.assert_called_once_with(
+            ["agencyclients", "add", "--json", '{"Login":"test"}']
+        )
+
 
 class TestAgencyClientsDelete:
     """Test scenarios for agency_clients_delete."""

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -108,6 +108,30 @@ class TestBidModifiersSet:
             call_args = runner.run_json.call_args[0][0]
             assert "--json" in call_args
 
+    def test_bidmodifiers_set_argv_composition(self):
+        """Test set passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
+            bidmodifiers_set(
+                campaign_id="12345",
+                modifier_type="MOBILE",
+                value="1.2",
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "bidmodifiers",
+                "set",
+                "--campaign-id",
+                "12345",
+                "--type",
+                "MOBILE",
+                "--value",
+                "1.2",
+            ]
+        )
+
 
 class TestBidModifiersToggle:
     """Tests for bidmodifiers_toggle tool."""

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -128,3 +128,34 @@ class TestBidsSet:
 
         assert result["error"] == "missing_update_fields"
         runner.run_json.assert_not_called()
+
+    def test_bids_set_only_extra_json(self):
+        """Test setting bid with only extra_json (no bid)."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch(
+            "server.tools.bids.get_runner",
+            return_value=runner,
+        ):
+            result = bids_set(
+                campaign_id="12345",
+                extra_json='{"ContextBid":12000000}',
+            )
+            assert result["success"] is True
+            call_args = runner.run_json.call_args[0][0]
+            assert "--bid" not in call_args
+            assert "--json" in call_args
+
+    def test_bids_list_ad_group_batch_limit(self):
+        """Test batch limit validation for ad_group_ids."""
+        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        result = bids_list(ad_group_ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
+    def test_bids_list_keyword_batch_limit(self):
+        """Test batch limit validation for keyword_ids."""
+        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        result = bids_list(keyword_ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -62,3 +62,26 @@ def test_businesses_list_empty():
     ):
         result = businesses_list()
         assert result == []
+
+
+def test_businesses_list_ignores_blank_ids():
+    """Test blank ids behave like no filter."""
+    runner = MagicMock()
+    runner.run_json.return_value = SAMPLE_BUSINESSES
+    with patch("server.tools.businesses.get_runner", return_value=runner):
+        result = businesses_list(ids="   ")
+        assert len(result) == 1
+        call_args = runner.run_json.call_args[0][0]
+        assert "--ids" not in call_args
+
+
+def test_businesses_list_empty_ids():
+    """Test empty ids string treated like no filter."""
+    runner = MagicMock()
+    runner.run_json.return_value = []
+    with patch("server.tools.businesses.get_runner", return_value=runner):
+        businesses_list(ids="")
+
+    runner.run_json.assert_called_once_with(
+        ["businesses", "get", "--format", "json"]
+    )

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -82,6 +82,4 @@ def test_businesses_list_empty_ids():
     with patch("server.tools.businesses.get_runner", return_value=runner):
         businesses_list(ids="")
 
-    runner.run_json.assert_called_once_with(
-        ["businesses", "get", "--format", "json"]
-    )
+    runner.run_json.assert_called_once_with(["businesses", "get", "--format", "json"])

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -110,3 +110,30 @@ class TestClientsUpdate:
             extra_json = '{"Grants": ["CampaignManagement"]}'
             result = clients_update(client_id="123", extra_json=extra_json)
             assert result == mock_result
+
+    def test_update_client_argv_composition(self):
+        """Test update passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Login": "client1"}
+        with patch("server.tools.clients.get_runner", return_value=runner):
+            clients_update(client_id="123", extra_json='{"FirstName":"Bob"}')
+
+        runner.run_json.assert_called_once_with(
+            [
+                "clients",
+                "update",
+                "--client-id",
+                "123",
+                "--json",
+                '{"FirstName":"Bob"}',
+            ]
+        )
+
+    def test_get_client_ignores_blank_ids(self):
+        """Test blank ids behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Clients": []}
+        with patch("server.tools.clients.get_runner", return_value=runner):
+            clients_get(ids="   ")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" not in call_args

--- a/tests/test_creatives.py
+++ b/tests/test_creatives.py
@@ -65,3 +65,22 @@ class TestCreativesList:
                 "12345",
             ]
         )
+
+    def test_creatives_list_empty_result(self):
+        """Test empty response returns empty list."""
+        with patch(
+            "server.tools.creatives.get_runner",
+            return_value=_mock_runner([]),
+        ):
+            result = creatives_list()
+            assert result == []
+
+    def test_creatives_list_ignores_blank_ids(self):
+        """Test blank ids behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.creatives.get_runner", return_value=runner):
+            creatives_list(ids="   ", campaign_ids="   ")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" not in call_args
+            assert "--campaign-ids" not in call_args

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -142,9 +142,7 @@ class TestDynamicAdsAuthErrors:
             patch("server.tools.dynamic_ads.get_runner", return_value=runner),
             patch("server.tools._try_refresh_token", return_value=None),
         ):
-            result = dynamic_ads_add(
-                ad_group_id="200", target_data='{"Name": "Test"}'
-            )
+            result = dynamic_ads_add(ad_group_id="200", target_data='{"Name": "Test"}')
             assert result["error"] == "auth_expired"
 
     def test_dynamic_ads_update_auth_error(self):

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -114,3 +114,61 @@ def test_dynamic_ads_delete():
         mock.return_value.run_json.assert_called_once_with(
             ["dynamicads", "delete", "--id", "100"]
         )
+
+
+class TestDynamicAdsAuthErrors:
+    """Auth error scenarios for dynamic ads."""
+
+    def test_dynamic_ads_list_auth_error(self):
+        """Test auth error during list."""
+        from server.cli.runner import CliAuthError
+
+        runner = MagicMock()
+        runner.run_json.side_effect = CliAuthError("Token expired")
+        with (
+            patch("server.tools.dynamic_ads.get_runner", return_value=runner),
+            patch("server.tools._try_refresh_token", return_value=None),
+        ):
+            result = dynamic_ads_list(ad_group_ids="200")
+            assert result["error"] == "auth_expired"
+
+    def test_dynamic_ads_add_auth_error(self):
+        """Test auth error during add."""
+        from server.cli.runner import CliAuthError
+
+        runner = MagicMock()
+        runner.run_json.side_effect = CliAuthError("Token expired")
+        with (
+            patch("server.tools.dynamic_ads.get_runner", return_value=runner),
+            patch("server.tools._try_refresh_token", return_value=None),
+        ):
+            result = dynamic_ads_add(
+                ad_group_id="200", target_data='{"Name": "Test"}'
+            )
+            assert result["error"] == "auth_expired"
+
+    def test_dynamic_ads_update_auth_error(self):
+        """Test auth error during update."""
+        from server.cli.runner import CliAuthError
+
+        runner = MagicMock()
+        runner.run_json.side_effect = CliAuthError("Token expired")
+        with (
+            patch("server.tools.dynamic_ads.get_runner", return_value=runner),
+            patch("server.tools._try_refresh_token", return_value=None),
+        ):
+            result = dynamic_ads_update(id="100", extra_json='{"Name": "Test"}')
+            assert result["error"] == "auth_expired"
+
+    def test_dynamic_ads_delete_auth_error(self):
+        """Test auth error during delete."""
+        from server.cli.runner import CliAuthError
+
+        runner = MagicMock()
+        runner.run_json.side_effect = CliAuthError("Token expired")
+        with (
+            patch("server.tools.dynamic_ads.get_runner", return_value=runner),
+            patch("server.tools._try_refresh_token", return_value=None),
+        ):
+            result = dynamic_ads_delete(id="100")
+            assert result["error"] == "auth_expired"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -119,6 +119,13 @@ class TestAdextensionsList:
             result = adextensions_list(ids="999")
             assert result == []
 
+    def test_list_extensions_batch_limit(self):
+        """Test batch limit validation for adextensions_list."""
+        ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
+        result = adextensions_list(ids=ids)
+        assert "error" in result
+        assert result["error"] == "batch_limit"
+
 
 class TestAdextensionsAdd:
     """Tests for adextensions_add tool."""

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -108,6 +108,17 @@ class TestAdimagesAdd:
             call_args = runner.run_json.call_args[0][0]
             assert "--json" in call_args
 
+    def test_add_image_argv_composition(self):
+        """Test add passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 124}
+        with patch("server.tools.images.get_runner", return_value=runner):
+            adimages_add(image_json='{"Data":"abc"}')
+
+        runner.run_json.assert_called_once_with(
+            ["adimages", "add", "--json", '{"Data":"abc"}']
+        )
+
 
 class TestAdimagesDelete:
     """Tests for adimages_delete tool."""

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -172,3 +172,32 @@ class TestKeywordBidsSet:
             result = keyword_bids_set(keyword_id="111")
             assert result["error"] == "missing_update_fields"
             runner.run_json.assert_not_called()
+
+    def test_keyword_bids_set_network_bid_invalid(self):
+        """Test that non-integer network bid is rejected."""
+        result = keyword_bids_set(keyword_id="111", network_bid="abc")
+        assert result["error"] == "invalid_value"
+
+    def test_keyword_bids_set_argv_with_search_bid(self):
+        """Test argv composition for search bid."""
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.keyword_bids.get_runner", return_value=runner):
+            keyword_bids_set(keyword_id="111", search_bid="10")
+
+        runner.run_json.assert_called_once_with(
+            ["keywordbids", "set", "--keyword-id", "111", "--search-bid", "10"]
+        )
+
+    def test_keyword_bids_list_ignores_blank_filters(self):
+        """Test blank filters behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = SAMPLE_BIDS
+        with patch("server.tools.keyword_bids.get_runner", return_value=runner):
+            result = keyword_bids_list(
+                campaign_ids="   ", ad_group_ids="   ", keyword_ids="   "
+            )
+            assert len(result) == 1
+            call_args = runner.run_json.call_args[0][0]
+            assert "--campaign-ids" not in call_args
+            assert "--adgroup-ids" not in call_args
+            assert "--keyword-ids" not in call_args

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -67,3 +67,22 @@ class TestLeadsList:
             call_args = runner.run_json.call_args[0][0]
             assert "--campaign-ids" in call_args
             assert "123,456" in call_args
+
+    def test_leads_list_trims_ids(self):
+        """Test campaign IDs are normalized before argv construction."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"leads": []}
+        with patch("server.tools.leads.get_runner", return_value=runner):
+            leads_list(campaign_ids=" 123,456 ")
+
+        runner.run_json.assert_called_once_with(
+            ["leads", "get", "--format", "json", "--campaign-ids", "123,456"]
+        )
+
+    def test_leads_list_empty_result(self):
+        """Test empty leads response."""
+        with patch(
+            "server.tools.leads.get_runner", return_value=_mock_runner({"leads": []})
+        ):
+            result = leads_list()
+            assert result == {"leads": []}

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -160,3 +160,24 @@ def test_reports_list_types():
         assert len(result) == 7
         assert "CAMPAIGN_PERFORMANCE_REPORT" in result
         runner.run_json.assert_called_once_with(["reports", "list-types"])
+
+
+def test_reports_get_empty():
+    """Test report with empty result."""
+    with patch("server.tools.reports.get_runner", return_value=_mock_runner([])):
+        result = reports_get(date_from="2026-03-30", date_to="2026-04-06")
+        assert result == []
+
+
+def test_reports_get_auth_error():
+    """Test auth error during report retrieval."""
+    from server.cli.runner import CliAuthError
+
+    runner = MagicMock()
+    runner.run_json.side_effect = CliAuthError("Token expired")
+    with (
+        patch("server.tools.reports.get_runner", return_value=runner),
+        patch("server.tools._try_refresh_token", return_value=None),
+    ):
+        result = reports_get(date_from="2026-03-30", date_to="2026-04-06")
+        assert result["error"] == "auth_expired"

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -57,3 +57,64 @@ class TestKeywordsDeduplicate:
         ):
             result = keywords_deduplicate(keywords="keyword1,keyword2,keyword1")
             assert result["deduplicated"] == ["keyword1", "keyword2"]
+
+    def test_keywords_deduplicate_no_dupes(self):
+        """Test deduplicating keywords with no duplicates."""
+        mock_result = {
+            "original": ["keyword1", "keyword2"],
+            "deduplicated": ["keyword1", "keyword2"],
+        }
+        with patch(
+            "server.tools.research.get_runner", return_value=_mock_runner(mock_result)
+        ):
+            result = keywords_deduplicate(keywords="keyword1,keyword2")
+            assert len(result["deduplicated"]) == 2
+
+    def test_keywords_has_volume_argv_composition(self):
+        """Test has_volume passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"k1": True}
+        with patch("server.tools.research.get_runner", return_value=runner):
+            keywords_has_volume(keywords="k1,k2")
+
+        runner.run_json.assert_called_once_with(
+            ["keywordsresearch", "has-volume", "--keywords", "k1,k2", "--format", "json"]
+        )
+
+    def test_keywords_has_volume_with_region_argv(self):
+        """Test has_volume with region passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"k1": True}
+        with patch("server.tools.research.get_runner", return_value=runner):
+            keywords_has_volume(keywords="k1", region_id="225")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "keywordsresearch",
+                "has-volume",
+                "--keywords",
+                "k1",
+                "--format",
+                "json",
+                "--region-id",
+                "225",
+            ]
+        )
+
+    def test_keywords_deduplicate_argv_composition(self):
+        """Test deduplicate passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"original": [], "deduplicated": []}
+        with patch("server.tools.research.get_runner", return_value=runner):
+            keywords_deduplicate(keywords="k1,k2")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "keywordsresearch",
+                "deduplicate",
+                "--keywords",
+                "k1,k2",
+                "--format",
+                "json",
+            ]
+        )

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -78,7 +78,14 @@ class TestKeywordsDeduplicate:
             keywords_has_volume(keywords="k1,k2")
 
         runner.run_json.assert_called_once_with(
-            ["keywordsresearch", "has-volume", "--keywords", "k1,k2", "--format", "json"]
+            [
+                "keywordsresearch",
+                "has-volume",
+                "--keywords",
+                "k1,k2",
+                "--format",
+                "json",
+            ]
         )
 
     def test_keywords_has_volume_with_region_argv(self):

--- a/tests/test_turbo_pages.py
+++ b/tests/test_turbo_pages.py
@@ -88,3 +88,45 @@ class TestTurboPagesAdd:
             )
             call_args = runner.run_json.call_args[0][0]
             assert "--json" in call_args
+
+    def test_turbo_pages_add_argv_composition(self):
+        """Test add passes correct argv to CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"id": 125}
+        with patch("server.tools.turbo_pages.get_runner", return_value=runner):
+            turbo_pages_add(
+                name="My Page",
+                url="https://example.com",
+                extra_json='{"Description":"desc"}',
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "turbopages",
+                "add",
+                "--name",
+                "My Page",
+                "--url",
+                "https://example.com",
+                "--json",
+                '{"Description":"desc"}',
+            ]
+        )
+
+    def test_turbo_pages_list_empty_result(self):
+        """Test empty response returns empty dict."""
+        with patch(
+            "server.tools.turbo_pages.get_runner",
+            return_value=_mock_runner({"turboPages": []}),
+        ):
+            result = turbo_pages_list()
+            assert result == {"turboPages": []}
+
+    def test_turbo_pages_list_ignores_blank_ids(self):
+        """Test blank ids behave like no filter."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"turboPages": []}
+        with patch("server.tools.turbo_pages.get_runner", return_value=runner):
+            turbo_pages_list(ids="   ")
+            call_args = runner.run_json.call_args[0][0]
+            assert "--ids" not in call_args


### PR DESCRIPTION
## Summary
- Add 31 new tests covering argv composition, blank filter handling, batch limit validation, auth error scenarios, and empty result edge cases
- Tests added across 14 modules: agency, bidmodifiers, bids, businesses, clients, creatives, dynamic_ads, extensions, images, keyword_bids, leads, reports, research, turbo_pages
- Total test count: 385 → 416

## Test plan
- [x] All 416 tests pass, 8 skipped (unchanged)
- [x] No changes to production code — only test files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)