### PR TITLE
feat(ads_list): forward fields/text_ad_fields to direct-cli

### DIFF
--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -45,6 +45,8 @@ def ads_list(
     ids: str | None = None,
     ad_group_ids: str | None = None,
     status: str | None = None,
+    fields: str | None = None,
+    text_ad_fields: str | None = None,
 ) -> list[dict] | dict:
     """List ads.
 
@@ -53,6 +55,8 @@ def ads_list(
         ids: Comma-separated ad IDs (optional, max 10).
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
         status: Filter by status (optional).
+        fields: Comma-separated top-level field names (optional).
+        text_ad_fields: Comma-separated TextAd field names (e.g. "Title,Text,Href"). Default: Title,Title2,Text,Href.
     """
     normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
@@ -85,6 +89,10 @@ def ads_list(
         args.extend(["--adgroup-ids", normalized_ad_group_ids])
     if status is not None:
         args.extend(["--status", status])
+    if fields is not None:
+        args.extend(["--fields", fields])
+    if text_ad_fields is not None:
+        args.extend(["--text-ad-fields", text_ad_fields])
 
     runner = get_runner()
     return runner.run_json(args)


### PR DESCRIPTION
## Summary

\`direct-cli\` **0.2.2** (released to PyPI yesterday) added a \`--text-ad-fields\` option on \`ads get\` so callers can actually retrieve TextAd sub-object content (\`Title\`, \`Title2\`, \`Text\`, \`Href\`) via the separate \`TextAdFieldNames\` API parameter. This PR plumbs that through the MCP tool layer so MCP clients can ask for ad body text directly via \`ads_list\`.

Before this PR, MCP callers had no way to get the text of an ad — they could only list IDs, statuses, and types. To read actual ad body they had to shell out to the CLI directly.

## Changes

\`server/tools/ads.py::ads_list\` — two new optional parameters:

- \`fields: str | None\` — comma-separated top-level field names (Id, Status, State, Type, …). Forwarded as \`--fields\`.
- \`text_ad_fields: str | None\` — comma-separated TextAd field names. Forwarded as \`--text-ad-fields\`. Defaults to \`Title,Title2,Text,Href\` when omitted (default comes from direct-cli, not from the MCP wrapper).

No schema munging, no conversion. direct-cli handles parsing and \`TextAdFieldNames\` assembly.

## Runtime requirement

Requires **\`direct-cli >= 0.2.2\`** at runtime. Already released:

- https://pypi.org/project/direct-cli/0.2.2/
- https://github.com/axisrow/direct-cli/releases/tag/v0.2.2

If an older direct-cli is installed, the \`--text-ad-fields\` flag will be rejected by Click before any HTTP call, producing a clear error message.

## Test plan

- [x] \`pytest -q\` — **385 passed, 8 skipped** (no existing tests broken)
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] Additive change — no existing callers affected, new params default to \`None\` (CLI default applies)
- [ ] Manual MCP smoke after merge + Claude Code restart: call \`ads_list(campaign_ids=\"<real>\", text_ad_fields=\"Title,Text\")\` and confirm TextAd content is in the response

## Related

- Refs axisrow/yandex-direct-mcp-plugin#61 (test-coverage tracking)
- Depends on axisrow/direct-cli#13 (merged, released as v0.2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)