### PR TITLE
breaking: canonicalize payload shapes for campaigns, keywordbids, retargeting, ads (#68)

### DIFF
--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -53,8 +53,8 @@ def ads_list(
         ids: Comma-separated ad IDs (optional, max 10).
         ad_group_ids: Comma-separated ad group IDs (optional, max 10).
         status: Filter by status (optional).
-        fields: Comma-separated top-level field names (optional).
-        text_ad_fields: Comma-separated TextAd field names (e.g. "Title,Text,Href"). Default: Title,Title2,Text,Href.
+        fields: Comma-separated WSDL FieldNames selectors (optional).
+        text_ad_fields: Comma-separated WSDL TextAdFieldNames selectors (e.g. "Title,Text,Href"). Default: Title,Title2,Text,Href.
     """
     normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
@@ -142,7 +142,7 @@ def ads_update(
     if not status:
         return ToolError(
             error="missing_update_fields",
-            message="Provide status",
+            message="Provide at least one of: status",
         ).__dict__
 
     args = ["ads", "update", "--id", id, "--status", status]

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -142,7 +142,7 @@ def ads_update(
     if not status:
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: status",
+            message="Provide: status",
         ).__dict__
 
     args = ["ads", "update", "--id", id, "--status", status]

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -145,9 +145,7 @@ def ads_update(
             message="Provide status",
         ).__dict__
 
-    args = ["ads", "update", "--id", id]
-    if status:
-        args.extend(["--status", status])
+    args = ["ads", "update", "--id", id, "--status", status]
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -1,7 +1,5 @@
 """MCP tool for listing ads."""
 
-import json
-
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -106,7 +104,6 @@ def ads_add(
     title: str | None = None,
     text: str | None = None,
     href: str | None = None,
-    extra_json: str | dict | None = None,
 ) -> dict:
     """Create a new ad.
 
@@ -116,7 +113,6 @@ def ads_add(
         title: Ad title (optional).
         text: Ad text content (optional).
         href: Ad URL (optional).
-        extra_json: JSON string with additional parameters (optional).
     """
     args = ["ads", "add", "--adgroup-id", ad_group_id]
     if ad_type:
@@ -127,11 +123,6 @@ def ads_add(
         args.extend(["--text", text])
     if href:
         args.extend(["--href", href])
-    if extra_json:
-        json_str = (
-            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
-        )
-        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 
@@ -139,29 +130,24 @@ def ads_add(
 @mcp.tool()
 @handle_cli_errors
 def ads_update(
-    id: str, status: str | None = None, extra_json: str | dict | None = None
+    id: str,
+    status: str | None = None,
 ) -> dict:
     """Update an ad.
 
     Args:
         id: Ad ID to update.
         status: Optional new ad status.
-        extra_json: JSON string with fields to update (e.g. '{"TextAd": {"Title": "New"}}').
     """
-    if not status and not extra_json:
+    if not status:
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: status, extra_json",
+            message="Provide status",
         ).__dict__
 
     args = ["ads", "update", "--id", id]
     if status:
         args.extend(["--status", status])
-    if extra_json:
-        json_str = (
-            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
-        )
-        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -88,28 +88,36 @@ def campaigns_update(
                 message=f"Budget must be a positive integer. Got: '{budget}'",
             ).__dict__
 
-    runner = get_runner()
     notification_val: dict | None = None
+    if notification is not None:
+        if isinstance(notification, dict):
+            notification_val = notification
+        else:
+            try:
+                notification_val = json.loads(notification)
+            except json.JSONDecodeError:
+                return ToolError(
+                    error="invalid_json",
+                    message=f"notification is not valid JSON: '{notification}'",
+                ).__dict__
+            if not isinstance(notification_val, dict):
+                return ToolError(
+                    error="invalid_json",
+                    message="notification must be a JSON object",
+                ).__dict__
+
+    args = ["campaigns", "update", "--id", id]
+    if name:
+        args.extend(["--name", name])
+    if status:
+        args.extend(["--status", status])
+    if budget_value is not None:
+        args.extend(["--budget", budget_value])
+    if notification_val is not None:
+        args.extend(["--json", json.dumps({"Notification": notification_val})])
+
+    runner = get_runner()
     try:
-        args = ["campaigns", "update", "--id", id]
-        if name:
-            args.extend(["--name", name])
-        if status:
-            args.extend(["--status", status])
-        if budget_value is not None:
-            args.extend(["--budget", budget_value])
-        if notification is not None:
-            if isinstance(notification, dict):
-                notification_val = notification
-            else:
-                try:
-                    notification_val = json.loads(notification)
-                except json.JSONDecodeError:
-                    return ToolError(
-                        error="invalid_json",
-                        message=f"notification is not valid JSON: '{notification}'",
-                    ).__dict__
-            args.extend(["--json", json.dumps({"Notification": notification_val})])
         runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
         raise
@@ -163,14 +171,7 @@ def campaigns_add(
                 message=f"Budget must be a positive integer. Got: '{budget}'",
             ).__dict__
 
-    runner = get_runner()
-    args = ["campaigns", "add", "--name", name, "--start-date", start_date]
-    if campaign_type:
-        args.extend(["--type", campaign_type])
-    if budget_value is not None:
-        args.extend(["--budget", budget_value])
-    if end_date:
-        args.extend(["--end-date", end_date])
+    bs_val: dict | None = None
     if bidding_strategy is not None:
         if isinstance(bidding_strategy, dict):
             bs_val = bidding_strategy
@@ -182,9 +183,23 @@ def campaigns_add(
                     error="invalid_json",
                     message=f"bidding_strategy is not valid JSON: '{bidding_strategy}'",
                 ).__dict__
+            if not isinstance(bs_val, dict):
+                return ToolError(
+                    error="invalid_json",
+                    message="bidding_strategy must be a JSON object",
+                ).__dict__
+
+    args = ["campaigns", "add", "--name", name, "--start-date", start_date]
+    if campaign_type:
+        args.extend(["--type", campaign_type])
+    if budget_value is not None:
+        args.extend(["--budget", budget_value])
+    if end_date:
+        args.extend(["--end-date", end_date])
+    if bs_val is not None:
         args.extend(["--json", json.dumps({"BiddingStrategy": bs_val})])
-    result = runner.run_json(args)
-    return result
+    runner = get_runner()
+    return runner.run_json(args)
 
 
 @mcp.tool()

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -59,7 +59,7 @@ def campaigns_update(
     name: str | None = None,
     status: str | None = None,
     budget: str | None = None,
-    extra_json: str | dict | None = None,
+    notification: str | dict | None = None,
 ) -> dict:
     """Update campaign fields.
 
@@ -68,12 +68,12 @@ def campaigns_update(
         name: Optional new campaign name.
         status: Optional new campaign status.
         budget: Optional new daily budget.
-        extra_json: Optional JSON string forwarded to direct-cli --json.
+        notification: Optional notification settings (e.g. {"SmsSettings": {"Events": ["MONITORING"]}}).
     """
-    if not any((name, status, budget, extra_json)):
+    if not any((name, status, budget, notification)):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, status, budget, extra_json",
+            message="Provide at least one of: name, status, budget, notification",
         ).__dict__
 
     budget_value: str | None = None
@@ -97,11 +97,13 @@ def campaigns_update(
             args.extend(["--status", status])
         if budget_value is not None:
             args.extend(["--budget", budget_value])
-        if extra_json:
-            json_str = (
-                json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+        if notification is not None:
+            notification_val = (
+                notification
+                if isinstance(notification, dict)
+                else json.loads(notification)
             )
-            args.extend(["--json", json_str])
+            args.extend(["--json", json.dumps({"Notification": notification_val})])
         runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
         raise
@@ -118,8 +120,6 @@ def campaigns_update(
         result["status"] = status
     if budget_value is not None:
         result["budget"] = int(budget_value)
-    if extra_json:
-        result["extra_json"] = extra_json
     return result
 
 
@@ -131,7 +131,7 @@ def campaigns_add(
     campaign_type: str | None = None,
     budget: str | None = None,
     end_date: str | None = None,
-    extra_json: str | dict | None = None,
+    bidding_strategy: str | dict | None = None,
 ) -> dict:
     """Create a new campaign.
 
@@ -141,7 +141,7 @@ def campaigns_add(
         campaign_type: Campaign type (optional).
         budget: Optional daily budget.
         end_date: Optional campaign end date in YYYY-MM-DD format.
-        extra_json: Optional JSON string forwarded to direct-cli --json.
+        bidding_strategy: Optional bidding strategy (e.g. {"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}}).
     """
     budget_value: str | None = None
     if budget is not None:
@@ -163,11 +163,13 @@ def campaigns_add(
         args.extend(["--budget", budget_value])
     if end_date:
         args.extend(["--end-date", end_date])
-    if extra_json:
-        json_str = (
-            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
+    if bidding_strategy is not None:
+        bs_val = (
+            bidding_strategy
+            if isinstance(bidding_strategy, dict)
+            else json.loads(bidding_strategy)
         )
-        args.extend(["--json", json_str])
+        args.extend(["--json", json.dumps({"BiddingStrategy": bs_val})])
     result = runner.run_json(args)
     return result
 

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -98,11 +98,16 @@ def campaigns_update(
         if budget_value is not None:
             args.extend(["--budget", budget_value])
         if notification is not None:
-            notification_val = (
-                notification
-                if isinstance(notification, dict)
-                else json.loads(notification)
-            )
+            if isinstance(notification, dict):
+                notification_val = notification
+            else:
+                try:
+                    notification_val = json.loads(notification)
+                except json.JSONDecodeError:
+                    return ToolError(
+                        error="invalid_json",
+                        message=f"notification is not valid JSON: '{notification}'",
+                    ).__dict__
             args.extend(["--json", json.dumps({"Notification": notification_val})])
         runner.run_json(args)
     except (CliAuthError, CliNotFoundError):
@@ -120,6 +125,8 @@ def campaigns_update(
         result["status"] = status
     if budget_value is not None:
         result["budget"] = int(budget_value)
+    if notification is not None:
+        result["notification"] = notification
     return result
 
 
@@ -164,11 +171,16 @@ def campaigns_add(
     if end_date:
         args.extend(["--end-date", end_date])
     if bidding_strategy is not None:
-        bs_val = (
-            bidding_strategy
-            if isinstance(bidding_strategy, dict)
-            else json.loads(bidding_strategy)
-        )
+        if isinstance(bidding_strategy, dict):
+            bs_val = bidding_strategy
+        else:
+            try:
+                bs_val = json.loads(bidding_strategy)
+            except json.JSONDecodeError:
+                return ToolError(
+                    error="invalid_json",
+                    message=f"bidding_strategy is not valid JSON: '{bidding_strategy}'",
+                ).__dict__
         args.extend(["--json", json.dumps({"BiddingStrategy": bs_val})])
     result = runner.run_json(args)
     return result

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -89,6 +89,7 @@ def campaigns_update(
             ).__dict__
 
     runner = get_runner()
+    notification_val: dict | None = None
     try:
         args = ["campaigns", "update", "--id", id]
         if name:
@@ -125,8 +126,8 @@ def campaigns_update(
         result["status"] = status
     if budget_value is not None:
         result["budget"] = int(budget_value)
-    if notification is not None:
-        result["notification"] = notification
+    if notification_val is not None:
+        result["notification"] = notification_val
     return result
 
 

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -1,7 +1,5 @@
 """MCP tools for keyword bid management."""
 
-import json
-
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
@@ -40,7 +38,6 @@ def keyword_bids_set(
     keyword_id: str,
     search_bid: str | None = None,
     network_bid: str | None = None,
-    extra_json: str | dict | None = None,
 ) -> dict:
     """Set keyword bids.
 
@@ -48,12 +45,11 @@ def keyword_bids_set(
         keyword_id: Keyword ID.
         search_bid: Search bid amount (optional).
         network_bid: Network bid amount (optional).
-        extra_json: JSON string with additional parameters (optional).
     """
-    if not any((search_bid, network_bid, extra_json)):
+    if not any((search_bid, network_bid)):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: search_bid, network_bid, extra_json",
+            message="Provide at least one of: search_bid, network_bid",
         ).__dict__
 
     from server.tools.helpers import validate_positive_int
@@ -77,11 +73,6 @@ def keyword_bids_set(
         args.extend(["--search-bid", str(search_bid_value)])
     if network_bid_value is not None:
         args.extend(["--network-bid", str(network_bid_value)])
-    if extra_json:
-        json_str = (
-            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
-        )
-        args.extend(["--json", json_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -1,5 +1,7 @@
 """MCP tools for retargeting list management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import run_single_id_batch
@@ -32,14 +34,14 @@ def retargeting_list(
 def retargeting_add(
     name: str,
     list_type: str,
-    rule: str | None = None,
+    rule: str | dict | None = None,
 ) -> dict:
     """Add a retargeting list.
 
     Args:
         name: Name for the retargeting list.
         list_type: List type (e.g. "AUDIENCE_SEGMENT").
-        rule: JSON string with targeting rule conditions (e.g. {"conditions": [...]}).
+        rule: Targeting rule conditions as a dict or JSON string (e.g. {"conditions": [...]}).
     """
     args = [
         "retargeting",
@@ -50,7 +52,18 @@ def retargeting_add(
         list_type,
     ]
     if rule is not None:
-        args.extend(["--rule", rule])
+        if isinstance(rule, dict):
+            rule_str = json.dumps(rule)
+        else:
+            try:
+                json.loads(rule)
+            except json.JSONDecodeError:
+                return ToolError(
+                    error="invalid_json",
+                    message=f"rule is not valid JSON: '{rule}'",
+                ).__dict__
+            rule_str = rule
+        args.extend(["--rule", rule_str])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -1,7 +1,5 @@
 """MCP tools for retargeting list management."""
 
-import json
-
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import run_single_id_batch
@@ -34,14 +32,14 @@ def retargeting_list(
 def retargeting_add(
     name: str,
     list_type: str,
-    extra_json: str | dict | None = None,
+    rule: str | None = None,
 ) -> dict:
     """Add a retargeting list.
 
     Args:
         name: Name for the retargeting list.
         list_type: List type (e.g. "AUDIENCE_SEGMENT").
-        extra_json: Optional JSON string with additional parameters.
+        rule: Optional JSON string with targeting rule conditions (optional).
     """
     args = [
         "retargeting",
@@ -51,11 +49,8 @@ def retargeting_add(
         "--type",
         list_type,
     ]
-    if extra_json is not None:
-        json_str = (
-            json.dumps(extra_json) if isinstance(extra_json, dict) else extra_json
-        )
-        args.extend(["--json", json_str])
+    if rule is not None:
+        args.extend(["--rule", rule])
     runner = get_runner()
     return runner.run_json(args)
 

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -85,7 +85,7 @@ def retargeting_update(
     id: str,
     name: str | None = None,
     list_type: str | None = None,
-    rule: str | None = None,
+    rule: str | dict | None = None,
 ) -> dict:
     """Update a retargeting list.
 
@@ -93,7 +93,7 @@ def retargeting_update(
         id: Retargeting list ID to update.
         name: New name for the list (optional).
         list_type: New list type, e.g. "AUDIENCE_SEGMENT" (optional).
-        rule: JSON string with updated targeting rule conditions (optional).
+        rule: Targeting rule conditions as a dict or JSON string (optional).
     """
     if not any((name, list_type, rule)):
         return ToolError(
@@ -101,13 +101,27 @@ def retargeting_update(
             message="Provide at least one of: name, list_type, rule",
         ).__dict__
 
+    rule_str: str | None = None
+    if rule is not None:
+        if isinstance(rule, dict):
+            rule_str = json.dumps(rule)
+        else:
+            try:
+                json.loads(rule)
+            except json.JSONDecodeError:
+                return ToolError(
+                    error="invalid_json",
+                    message=f"rule is not valid JSON: '{rule}'",
+                ).__dict__
+            rule_str = rule
+
     args = ["retargeting", "update", "--id", id]
     if name is not None:
         args.extend(["--name", name])
     if list_type is not None:
         args.extend(["--type", list_type])
-    if rule is not None:
-        args.extend(["--rule", rule])
+    if rule_str is not None:
+        args.extend(["--rule", rule_str])
 
     runner = get_runner()
     return runner.run_json(args)

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -39,7 +39,7 @@ def retargeting_add(
     Args:
         name: Name for the retargeting list.
         list_type: List type (e.g. "AUDIENCE_SEGMENT").
-        rule: Optional JSON string with targeting rule conditions (optional).
+        rule: JSON string with targeting rule conditions (e.g. {"conditions": [...]}).
     """
     args = [
         "retargeting",

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -97,7 +97,6 @@ class TestAdsCrudOperations:
                 title="Title",
                 text="New ad text",
                 href="https://example.com",
-                extra_json='{"Mobile":"YES"}',
             )
             assert result["Id"] == 999
             runner.run_json.assert_called_once_with(
@@ -114,8 +113,6 @@ class TestAdsCrudOperations:
                     "New ad text",
                     "--href",
                     "https://example.com",
-                    "--json",
-                    '{"Mobile":"YES"}',
                 ]
             )
 
@@ -135,7 +132,6 @@ class TestAdsCrudOperations:
             ads_update(
                 id="111",
                 status="SUSPENDED",
-                extra_json='{"TextAd": {"Title": "New"}}',
             )
             runner.run_json.assert_called_once_with(
                 [
@@ -145,8 +141,6 @@ class TestAdsCrudOperations:
                     "111",
                     "--status",
                     "SUSPENDED",
-                    "--json",
-                    '{"TextAd": {"Title": "New"}}',
                 ]
             )
 

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -160,7 +160,7 @@ class TestCampaignsUpdate:
                 name="Renamed",
                 status="SUSPENDED",
                 budget="5000",
-                extra_json='{"Notification": {"SmsSettings": {"Events": ["MONITORING"]}}}',
+                notification={"SmsSettings": {"Events": ["MONITORING"]}},
             )
 
         runner.run_json.assert_called_once_with(
@@ -205,7 +205,7 @@ class TestCampaignsCrudOperations:
                 campaign_type="TEXT_CAMPAIGN",
                 budget="5000",
                 end_date="2026-12-31",
-                extra_json='{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"}}}',
+                bidding_strategy={"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}},
             )
             assert result["Id"] == 99999
             runner.run_json.assert_called_once_with(
@@ -223,7 +223,7 @@ class TestCampaignsCrudOperations:
                     "--end-date",
                     "2026-12-31",
                     "--json",
-                    '{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"}}}',
+                    '{"BiddingStrategy": {"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}}}',
                 ]
             )
 

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -191,7 +191,7 @@ class TestCampaignsUpdate:
                 notification='{"SmsSettings": {"Events": ["MONITORING"]}}',
             )
         assert result["success"] is True
-        assert result["notification"] == '{"SmsSettings": {"Events": ["MONITORING"]}}'
+        assert result["notification"] == {"SmsSettings": {"Events": ["MONITORING"]}}
         runner.run_json.assert_called_once_with(
             [
                 "campaigns",
@@ -233,7 +233,9 @@ class TestCampaignsCrudOperations:
                 campaign_type="TEXT_CAMPAIGN",
                 budget="5000",
                 end_date="2026-12-31",
-                bidding_strategy={"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}},
+                bidding_strategy={
+                    "Search": {"BiddingStrategyType": "HIGHEST_POSITION"}
+                },
             )
             assert result["Id"] == 99999
             runner.run_json.assert_called_once_with(

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -209,6 +209,12 @@ class TestCampaignsUpdate:
         assert result["error"] == "invalid_json"
         assert "notification" in result["message"]
 
+    def test_campaigns_update_notification_non_dict_json(self):
+        """Test that a non-object JSON value for notification returns a clear error."""
+        result = campaigns_update(id="12345", notification="[1, 2, 3]")
+        assert result["error"] == "invalid_json"
+        assert "JSON object" in result["message"]
+
     def test_campaigns_update_requires_changes(self):
         """Test that empty updates are rejected before CLI call."""
         runner = _mock_runner({"Id": 12345})
@@ -280,6 +286,16 @@ class TestCampaignsCrudOperations:
         )
         assert result["error"] == "invalid_json"
         assert "bidding_strategy" in result["message"]
+
+    def test_campaigns_add_bidding_strategy_non_dict_json(self):
+        """Test that a non-object JSON value for bidding_strategy returns a clear error."""
+        result = campaigns_add(
+            name="New Campaign",
+            start_date="2026-01-01",
+            bidding_strategy="123",
+        )
+        assert result["error"] == "invalid_json"
+        assert "JSON object" in result["message"]
 
     def test_campaigns_delete_success(self):
         """Test deleting campaigns successfully."""

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -180,6 +180,34 @@ class TestCampaignsUpdate:
             ]
         )
         assert result["budget"] == 5000
+        assert result["notification"] == {"SmsSettings": {"Events": ["MONITORING"]}}
+
+    def test_campaigns_update_notification_as_string(self):
+        """Test that notification accepts a JSON string and wraps it correctly."""
+        runner = _mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(
+                id="12345",
+                notification='{"SmsSettings": {"Events": ["MONITORING"]}}',
+            )
+        assert result["success"] is True
+        assert result["notification"] == '{"SmsSettings": {"Events": ["MONITORING"]}}'
+        runner.run_json.assert_called_once_with(
+            [
+                "campaigns",
+                "update",
+                "--id",
+                "12345",
+                "--json",
+                '{"Notification": {"SmsSettings": {"Events": ["MONITORING"]}}}',
+            ]
+        )
+
+    def test_campaigns_update_notification_invalid_json(self):
+        """Test that an invalid JSON string for notification returns a clear error."""
+        result = campaigns_update(id="12345", notification="not-valid-json")
+        assert result["error"] == "invalid_json"
+        assert "notification" in result["message"]
 
     def test_campaigns_update_requires_changes(self):
         """Test that empty updates are rejected before CLI call."""
@@ -226,6 +254,30 @@ class TestCampaignsCrudOperations:
                     '{"BiddingStrategy": {"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}}}',
                 ]
             )
+
+    def test_campaigns_add_bidding_strategy_as_string(self):
+        """Test that bidding_strategy accepts a JSON string."""
+        mock_result = {"Id": 99999}
+        runner = _mock_runner(mock_result)
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_add(
+                name="New Campaign",
+                start_date="2026-01-01",
+                bidding_strategy='{"Search": {"BiddingStrategyType": "HIGHEST_POSITION"}}',
+            )
+        assert result["Id"] == 99999
+        call_args = runner.run_json.call_args[0][0]
+        assert "--json" in call_args
+
+    def test_campaigns_add_bidding_strategy_invalid_json(self):
+        """Test that an invalid JSON string for bidding_strategy returns a clear error."""
+        result = campaigns_add(
+            name="New Campaign",
+            start_date="2026-01-01",
+            bidding_strategy="not-valid-json",
+        )
+        assert result["error"] == "invalid_json"
+        assert "bidding_strategy" in result["message"]
 
     def test_campaigns_delete_success(self):
         """Test deleting campaigns successfully."""

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -154,21 +154,6 @@ class TestKeywordBidsSet:
             assert "5" in call_args
             assert "--format" not in call_args
 
-    def test_keyword_bids_set_with_json(self):
-        """Test setting keyword bids with additional JSON."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(mock_result),
-        ) as mock:
-            result = keyword_bids_set(
-                keyword_id="111", extra_json='{"AutoBudget":"YES"}'
-            )
-            assert result["success"] is True
-            call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--json" in call_args
-            assert '{"AutoBudget":"YES"}' in call_args
-
     def test_keyword_bids_set_requires_changes(self):
         """Reject no-op updates before calling CLI."""
         runner = _mock_runner({"success": True})

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -248,3 +248,19 @@ class TestRetargetingUpdate:
     def test_update_retargeting_requires_changes(self):
         result = retargeting_update(id="201")
         assert result["error"] == "missing_update_fields"
+
+    def test_update_retargeting_rule_as_dict(self):
+        """Test that retargeting_update accepts rule as a dict."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.retargeting.get_runner", return_value=runner):
+            retargeting_update(id="201", rule={"Goal": {"Id": 123}})
+            call_args = runner.run_json.call_args[0][0]
+            assert "--rule" in call_args
+            assert '{"Goal": {"Id": 123}}' in call_args
+
+    def test_update_retargeting_rule_invalid_json(self):
+        """Test that an invalid JSON string for rule returns a clear error."""
+        result = retargeting_update(id="201", rule="not-valid-json")
+        assert result["error"] == "invalid_json"
+        assert "rule" in result["message"]

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -157,6 +157,31 @@ class TestRetargetingAdd:
             assert "--rule" in call_args
             assert '{"Goal":{"Id":123}}' in call_args
 
+    def test_add_retargeting_with_rule_as_dict(self):
+        """Test adding with rule passed as a dict (serialized to JSON string)."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 205}
+        with patch(
+            "server.tools.retargeting.get_runner",
+            return_value=runner,
+        ):
+            retargeting_add(
+                name="Test",
+                list_type="AUDIENCE_SEGMENT",
+                rule={"Goal": {"Id": 123}},
+            )
+            call_args = runner.run_json.call_args[0][0]
+            assert "--rule" in call_args
+            assert '{"Goal": {"Id": 123}}' in call_args
+
+    def test_add_retargeting_with_rule_invalid_json(self):
+        """Test that an invalid JSON string for rule returns a clear error."""
+        result = retargeting_add(
+            name="Test", list_type="AUDIENCE_SEGMENT", rule="not-valid-json"
+        )
+        assert result["error"] == "invalid_json"
+        assert "rule" in result["message"]
+
     def test_add_retargeting_auth_error(self):
         """Test auth error during retargeting add."""
         runner = MagicMock()

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -140,8 +140,8 @@ class TestRetargetingAdd:
             assert "--name" in call_args
             assert "--type" in call_args
 
-    def test_add_retargeting_with_extra_json(self):
-        """Test adding with extra JSON parameters."""
+    def test_add_retargeting_with_rule(self):
+        """Test adding with targeting rule conditions."""
         runner = MagicMock()
         runner.run_json.return_value = {"Id": 204}
         with patch(
@@ -151,10 +151,11 @@ class TestRetargetingAdd:
             retargeting_add(
                 name="Test",
                 list_type="AUDIENCE_SEGMENT",
-                extra_json='{"Description":"test"}',
+                rule='{"Goal":{"Id":123}}',
             )
             call_args = runner.run_json.call_args[0][0]
-            assert "--json" in call_args
+            assert "--rule" in call_args
+            assert '{"Goal":{"Id":123}}' in call_args
 
     def test_add_retargeting_auth_error(self):
         """Test auth error during retargeting add."""


### PR DESCRIPTION
Replace the CLI-specific `extra_json` escape hatch with explicitly-named
WSDL-canonical parameters for the four tools identified in issue #68:

- `campaigns_update`: `extra_json` → `notification` (WSDL Notification field)
- `campaigns_add`: `extra_json` → `bidding_strategy` (WSDL BiddingStrategy)
- `keywordbids_set`: `extra_json` removed (`search_bid`/`network_bid` are sufficient)
- `retargeting_add`: `extra_json` → `rule` (matching `retargeting_update` pattern)
- `ads_add`: `extra_json` removed (explicit `title`/`text`/`href`/`type` cover main fields)
- `ads_update`: `extra_json` removed (status-only update; guard simplified)

**Scope:** This PR covers the four `extra_json` bearers and `ads_get` review
explicitly listed in issue #68. Other tools that still carry `extra_json`
(e.g. `adgroups`, `bids`, `feeds`) are **out of scope** for this PR and
tracked separately.

Also removes unused `import json` from `keyword_bids.py`, `retargeting.py`, `ads.py`.
Tests updated to reflect new signatures; `test_keyword_bids_set_with_json` deleted.
`ads_get` `fields`/`text_ad_fields` documented as WSDL `FieldNames`/`TextAdFieldNames` selectors.

Closes #68.

https://claude.ai/code/session_01D3jDhbYppabhHK6BWAtNfE