### PR TITLE
test(auth): align auth_login tests with single-step elicit flow

### DIFF
--- a/server/auth/storage.py
+++ b/server/auth/storage.py
@@ -29,7 +29,9 @@ class FileTokenStorage:
                 self._path = Path(plugin_data) / "tokens.json"
             else:
                 # Fallback: store relative to plugin root (predictable for manual runs)
-                self._path = Path(__file__).parent.parent.parent / "data" / "tokens.json"
+                self._path = (
+                    Path(__file__).parent.parent.parent / "data" / "tokens.json"
+                )
 
     @property
     def path(self) -> Path:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -404,21 +404,6 @@ class TestAuthTools:
         assert "просроченный" in result["message"]
 
     @patch("server.tools.auth_tools._oauth")
-    def test_auth_login_invalid_method(self, mock_oauth) -> None:
-        mock_oauth.get_status.return_value = {"valid": False}
-
-        mock_ctx = MagicMock()
-        mock_choice = MagicMock()
-        mock_choice.action = "accept"
-        mock_choice.data.method = "invalid"
-        mock_ctx.elicit = AsyncMock(return_value=mock_choice)
-
-        from server.tools.auth_tools import auth_login
-
-        result = asyncio.run(auth_login(mock_ctx))
-        assert result["error"] == "invalid_method"
-
-    @patch("server.tools.auth_tools._oauth")
     def test_auth_login_already_authenticated(self, mock_oauth) -> None:
         mock_oauth.get_status.return_value = {
             "valid": True,
@@ -431,14 +416,17 @@ class TestAuthTools:
         assert result.get("already_authenticated") is True
 
     @patch("server.tools.auth_tools._oauth")
-    def test_auth_login_cancelled_on_method_choice(self, mock_oauth) -> None:
+    def test_auth_login_cancelled(self, mock_oauth) -> None:
         mock_oauth.get_status.return_value = {"valid": False}
+        mock_oauth.start_auth_flow.return_value = (
+            "https://oauth.yandex.ru/authorize?x=1"
+        )
 
         mock_ctx = MagicMock()
-        mock_choice = MagicMock()
-        mock_choice.action = "decline"
-        mock_choice.data = None
-        mock_ctx.elicit = AsyncMock(return_value=mock_choice)
+        mock_result = MagicMock()
+        mock_result.action = "decline"
+        mock_result.data = None
+        mock_ctx.elicit = AsyncMock(return_value=mock_result)
 
         from server.tools.auth_tools import auth_login
 
@@ -449,41 +437,23 @@ class TestAuthTools:
     @patch("server.tools.auth_tools._oauth")
     def test_auth_login_token_flow(self, mock_oauth, mock_exchange) -> None:
         mock_oauth.get_status.return_value = {"valid": False}
+        mock_oauth.start_auth_flow.return_value = (
+            "https://oauth.yandex.ru/authorize?x=1"
+        )
         mock_exchange.return_value = {"success": True, "method": "direct_token"}
 
         mock_ctx = MagicMock()
-        method_choice = MagicMock()
-        method_choice.action = "accept"
-        method_choice.data.method = "token"
-        token_input = MagicMock()
-        token_input.action = "accept"
-        token_input.data.value = "y0_live_token"
-        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, token_input])
+        credential = MagicMock()
+        credential.action = "accept"
+        credential.data.value = "y0_live_token"
+        mock_ctx.elicit = AsyncMock(return_value=credential)
 
         from server.tools.auth_tools import auth_login
 
         result = asyncio.run(auth_login(mock_ctx))
         assert result["success"] is True
         mock_exchange.assert_called_once_with("y0_live_token")
-        assert mock_ctx.elicit.await_count == 2
-
-    @patch("server.tools.auth_tools._oauth")
-    def test_auth_login_token_input_cancelled(self, mock_oauth) -> None:
-        mock_oauth.get_status.return_value = {"valid": False}
-
-        mock_ctx = MagicMock()
-        method_choice = MagicMock()
-        method_choice.action = "accept"
-        method_choice.data.method = "token"
-        token_input = MagicMock()
-        token_input.action = "decline"
-        token_input.data = None
-        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, token_input])
-
-        from server.tools.auth_tools import auth_login
-
-        result = asyncio.run(auth_login(mock_ctx))
-        assert result == {"cancelled": True, "message": "Ввод токена отменён."}
+        assert mock_ctx.elicit.await_count == 1
 
     @patch("server.tools.auth_tools._exchange_or_set_token")
     @patch("server.tools.auth_tools._oauth")
@@ -495,13 +465,10 @@ class TestAuthTools:
         mock_exchange.return_value = {"success": True, "method": "oauth_code"}
 
         mock_ctx = MagicMock()
-        method_choice = MagicMock()
-        method_choice.action = "accept"
-        method_choice.data.method = "pkce"
-        code_input = MagicMock()
-        code_input.action = "accept"
-        code_input.data.value = "ABC1234"
-        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, code_input])
+        credential = MagicMock()
+        credential.action = "accept"
+        credential.data.value = "ABC1234"
+        mock_ctx.elicit = AsyncMock(return_value=credential)
 
         from server.tools.auth_tools import auth_login
 
@@ -509,27 +476,6 @@ class TestAuthTools:
         assert result["success"] is True
         mock_oauth.start_auth_flow.assert_called_once()
         mock_exchange.assert_called_once_with("ABC1234")
-
-    @patch("server.tools.auth_tools._oauth")
-    def test_auth_login_pkce_code_cancelled(self, mock_oauth) -> None:
-        mock_oauth.get_status.return_value = {"valid": False}
-        mock_oauth.start_auth_flow.return_value = (
-            "https://oauth.yandex.ru/authorize?x=1"
-        )
-
-        mock_ctx = MagicMock()
-        method_choice = MagicMock()
-        method_choice.action = "accept"
-        method_choice.data.method = "pkce"
-        code_input = MagicMock()
-        code_input.action = "decline"
-        code_input.data = None
-        mock_ctx.elicit = AsyncMock(side_effect=[method_choice, code_input])
-
-        from server.tools.auth_tools import auth_login
-
-        result = asyncio.run(auth_login(mock_ctx))
-        assert result == {"cancelled": True, "message": "Ввод кода отменён."}
 
     @patch("server.tools.auth_tools._oauth")
     def test_oauth_login_prompt_embeds_authorize_url(self, mock_oauth) -> None:

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -62,14 +62,22 @@ class TestFindDirect:
         local_bin.parent.mkdir(parents=True)
         local_bin.touch()
         with (
-            patch.dict(os.environ, {"HOME": str(tmp_path), "CLAUDE_PLUGIN_DATA": ""}, clear=False),
+            patch.dict(
+                os.environ,
+                {"HOME": str(tmp_path), "CLAUDE_PLUGIN_DATA": ""},
+                clear=False,
+            ),
             patch("server.cli.runner.shutil.which", return_value=None),
         ):
             assert _find_direct() == str(local_bin)
 
     def test_not_found(self, tmp_path):
         with (
-            patch.dict(os.environ, {"HOME": str(tmp_path), "CLAUDE_PLUGIN_DATA": ""}, clear=False),
+            patch.dict(
+                os.environ,
+                {"HOME": str(tmp_path), "CLAUDE_PLUGIN_DATA": ""},
+                clear=False,
+            ),
             patch("server.cli.runner.shutil.which", return_value=None),
         ):
             assert _find_direct() is None
@@ -113,9 +121,7 @@ class TestRun:
         with patch("server.cli.runner.shutil.which", return_value=None):
             with pytest.raises(CliNotFoundError) as exc_info:
                 runner.run(["campaigns", "get"])
-            assert "Install package direct-cli and run `direct`" in str(
-                exc_info.value
-            )
+            assert "Install package direct-cli and run `direct`" in str(exc_info.value)
 
     def test_cli_not_found_file_not_found(self, runner):
         """Test 17: FileNotFoundError from subprocess."""


### PR DESCRIPTION
## Summary

- Приводит `tests/test_auth.py::TestAuthTools::test_auth_login_*` к реальному контракту `auth_login` (одношаговый elicit через `AuthCredential`), установленному в коммите `2b03a02` (closes #71).
- Было `5 failed, 460 passed` → стало `0 failed, 462 passed, 8 skipped`.

## Root cause

Коммит `2b03a02` намеренно удалил двухшаговый flow `AuthMethodChoice → AuthCredential` — `Literal` не поддерживался `ctx.elicit` на проде. Тесты остались на старом контракте: дергали `mock_ctx.elicit = AsyncMock(side_effect=[method_choice, credential])` и проверяли `_exchange_or_set_token(MagicMock…)` вместо реального токена.

## Изменения

- Удалены `test_auth_login_invalid_method`, `test_auth_login_token_input_cancelled`, `test_auth_login_pkce_code_cancelled` — соответствующих веток в реализации больше нет.
- `test_auth_login_cancelled_on_method_choice` → `test_auth_login_cancelled`: один elicit с `action="decline"`.
- `test_auth_login_token_flow` / `test_auth_login_pkce_flow`: один elicit возвращает `AuthCredential(value=...)`; assert `elicit.await_count == 1`.

## Test plan

- [x] `pytest tests/test_auth.py -k auth_login` — 4 passed
- [x] `pytest -q` — 462 passed, 8 skipped, 0 failed
- [x] `ruff check tests/test_auth.py` — passed

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)