### PR TITLE
fix(bidmodifiers): drop toggle tool and type --value as int for CLI 0.2.8

### DIFF
--- a/server/contract.py
+++ b/server/contract.py
@@ -239,6 +239,7 @@ RENAMED_TOOL_MIGRATION: dict[str, str | None] = {
     "adimages_list": "adimages_get",
     "adextensions_list": "adextensions_get",
     "sitelinks_list": "sitelinks_get",
+    "bidmodifiers_toggle": None,  # CLI 0.2.8 removed toggle; see TRANSPORT_BLOCKED_OPERATIONS
 }
 
 REMOVED_LEGACY_PUBLIC_NAMES = frozenset(RENAMED_TOOL_MIGRATION.keys())

--- a/server/contract.py
+++ b/server/contract.py
@@ -151,7 +151,6 @@ DIRECT_API_SERVICE_METHODS: dict[str, tuple[str, ...]] = {
 
 CLI_HELPER_SERVICE_METHODS: dict[str, tuple[str, ...]] = {
     "agencyclients": ("delete",),
-    "bidmodifiers": ("toggle",),
     "dictionaries": ("list_names",),
     "reports": ("list_types",),
 }
@@ -177,6 +176,10 @@ TRANSPORT_BLOCKED_OPERATIONS: dict[str, str] = {
         "The legacy `negative_keywords_*` MCP tools were removed because they "
         "had no valid CLI transport; manage them via the adgroups payload or "
         "via NegativeKeywordSharedSets."
+    ),
+    "bidmodifiers_toggle": (
+        "`direct bidmodifiers toggle` removed in CLI 0.2.8; "
+        "Yandex deprecated this API operation on 2025-11-13."
     ),
 }
 

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -42,7 +42,7 @@ def bidmodifiers_list(
 def bidmodifiers_set(
     campaign_id: str,
     modifier_type: str,
-    value: str,
+    value: int,
     extra_json: str | dict | None = None,
 ) -> dict:
     """Set bid modifier for a campaign.
@@ -50,7 +50,7 @@ def bidmodifiers_set(
     Args:
         campaign_id: Campaign ID.
         modifier_type: Type of modifier (e.g., "DEMOGRAPHICS", "MOBILE").
-        value: Modifier value (float, e.g. "1.5" for 50% increase).
+        value: Modifier percentage integer (0–1300, e.g. 150 for +50%).
         extra_json: Optional JSON string with additional parameters.
     """
     args = [
@@ -61,7 +61,7 @@ def bidmodifiers_set(
         "--type",
         modifier_type,
         "--value",
-        value,
+        str(value),
     ]
     if extra_json is not None:
         json_str = (
@@ -71,19 +71,6 @@ def bidmodifiers_set(
     runner = get_runner()
     return runner.run_json(args)
 
-
-@mcp.tool(name="bidmodifiers_toggle")
-@handle_cli_errors
-def bidmodifiers_toggle(id: str, enabled: bool = True) -> dict:
-    """Toggle bid modifier on/off.
-
-    Args:
-        id: Modifier ID.
-        enabled: True to enable, False to disable.
-    """
-    flag = "--enabled" if enabled else "--disabled"
-    runner = get_runner()
-    return runner.run_json(["bidmodifiers", "toggle", "--id", id, flag])
 
 
 @mcp.tool(name="bidmodifiers_delete")
@@ -103,7 +90,7 @@ def bidmodifiers_delete(ids: str) -> dict:
 @handle_cli_errors
 def bidmodifiers_add(
     modifier_type: str,
-    value: str,
+    value: int,
     campaign_id: str | None = None,
     ad_group_id: str | None = None,
     gender: str | None = None,
@@ -120,7 +107,7 @@ def bidmodifiers_add(
             message="Provide at least one of: campaign_id, ad_group_id",
         ).__dict__
 
-    args = ["bidmodifiers", "add", "--type", modifier_type, "--value", value]
+    args = ["bidmodifiers", "add", "--type", modifier_type, "--value", str(value)]
     if campaign_id is not None:
         args.extend(["--campaign-id", campaign_id])
     if ad_group_id is not None:

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -72,7 +72,6 @@ def bidmodifiers_set(
     return runner.run_json(args)
 
 
-
 @mcp.tool(name="bidmodifiers_delete")
 @handle_cli_errors
 def bidmodifiers_delete(ids: str) -> dict:

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -9,7 +9,6 @@ from server.tools.bidmodifiers import (
     bidmodifiers_add,
     bidmodifiers_list,
     bidmodifiers_set,
-    bidmodifiers_toggle,
     bidmodifiers_delete,
 )
 
@@ -88,7 +87,7 @@ class TestBidModifiersSet:
             result = bidmodifiers_set(
                 campaign_id="12345",
                 modifier_type="DEMOGRAPHICS",
-                value="1.5",
+                value=150,
             )
             assert result["success"] is True
 
@@ -103,7 +102,7 @@ class TestBidModifiersSet:
             bidmodifiers_set(
                 campaign_id="12345",
                 modifier_type="DEMOGRAPHICS",
-                value="1.5",
+                value=150,
                 extra_json='{"Level":"ADGROUP"}',
             )
             call_args = runner.run_json.call_args[0][0]
@@ -117,7 +116,7 @@ class TestBidModifiersSet:
             bidmodifiers_set(
                 campaign_id="12345",
                 modifier_type="MOBILE",
-                value="1.2",
+                value=120,
             )
 
         runner.run_json.assert_called_once_with(
@@ -129,7 +128,7 @@ class TestBidModifiersSet:
                 "--type",
                 "MOBILE",
                 "--value",
-                "1.2",
+                "120",
             ]
         )
 
@@ -144,7 +143,7 @@ class TestBidModifiersAdd:
             result = bidmodifiers_add(
                 campaign_id="12345",
                 modifier_type="MOBILE_ADJUSTMENT",
-                value="120",
+                value=120,
                 region_id="213",
             )
 
@@ -165,36 +164,9 @@ class TestBidModifiersAdd:
         )
 
     def test_bidmodifiers_add_requires_scope(self):
-        result = bidmodifiers_add(modifier_type="MOBILE_ADJUSTMENT", value="120")
+        result = bidmodifiers_add(modifier_type="MOBILE_ADJUSTMENT", value=120)
         assert result["error"] == "missing_target_scope"
 
-
-class TestBidModifiersToggle:
-    """Tests for bidmodifiers_toggle tool."""
-
-    def test_bidmodifiers_toggle_enable(self):
-        """Test enabling a bid modifier."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.bidmodifiers.get_runner",
-            return_value=_mock_runner(mock_result),
-        ) as mock:
-            result = bidmodifiers_toggle(id="1", enabled=True)
-            assert result["success"] is True
-            call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--enabled" in call_args
-
-    def test_bidmodifiers_toggle_disable(self):
-        """Test disabling a bid modifier."""
-        mock_result = {"success": True}
-        with patch(
-            "server.tools.bidmodifiers.get_runner",
-            return_value=_mock_runner(mock_result),
-        ) as mock:
-            result = bidmodifiers_toggle(id="1", enabled=False)
-            assert result["success"] is True
-            call_args = mock.return_value.run_json.call_args[0][0]
-            assert "--disabled" in call_args
 
 
 class TestBidModifiersDelete:

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -168,7 +168,6 @@ class TestBidModifiersAdd:
         assert result["error"] == "missing_target_scope"
 
 
-
 class TestBidModifiersDelete:
     """Tests for bidmodifiers_delete tool."""
 


### PR DESCRIPTION
## Summary

- Remove `bidmodifiers_toggle` MCP tool — `direct bidmodifiers toggle` was deleted in CLI 0.2.8 (Yandex deprecated this API operation on 2025-11-13)
- Add `bidmodifiers_toggle` to `TRANSPORT_BLOCKED_OPERATIONS` in `contract.py` with deprecation reason
- Change `value` parameter type from `str` to `int` in `bidmodifiers_set` and `bidmodifiers_add` to match CLI 0.2.7 typed-flags migration (`--value type=int`, percentage 0–1300)

## Test plan

- [ ] `pytest tests/test_bidmodifiers.py -v` — all 11 tests pass
- [ ] `pytest` — full suite passes (460 passed, 8 skipped)
- [ ] `mypy .` — no issues
- [ ] `ruff check .` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)