### PR TITLE
[codex] integrate direct-cli 0.3.1 v4 tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ direct (Python CLI)         — talks to Yandex.Direct API
        ↑
 server/main.py (MCP)        — FastMCP server (stdio transport)
        ↑
-server/contract.py          — machine-readable parity layer (121 tools)
+server/contract.py          — machine-readable parity layer (124 tools)
 server/auth/                — OAuth 2.0 module (httpx)
 server/cli/runner.py        — subprocess wrapper over `direct`
-server/tools/               — 121 MCP tools across 32 active modules
+server/tools/               — 124 MCP tools across 33 active modules
        ↑
 skills/                     — domain knowledge (SKILL.md files)
        ↑
@@ -205,13 +205,13 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (121 total) + 1 Prompt
+## MCP Tools (124 total) + 1 Prompt
 
 The canonical source of truth for tool names is `server/contract.py`.
 Naming follows `service_method` from `tapi-yandex-direct`/`direct-cli`;
 WSDL/reports spec wins when there is drift.
 
-### Direct API tools (115)
+### Direct API tools (118)
 
 | Tool | Purpose |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ OAuth-приложение само по себе не даёт доступ к 
 
 Или через переменные окружения `CLAUDE_PLUGIN_OPTION_client_id` / `CLAUDE_PLUGIN_OPTION_client_secret`.
 
-## MCP contract (111 tools)
+## MCP contract (124 tools)
 
 The public contract is now defined as:
 
@@ -151,9 +151,10 @@ The public contract is now defined as:
 
 - MCP never calls Yandex.Direct directly.
 - `direct` remains the only execution/transport boundary.
-- The package is still installed as `direct-cli`.
+- The package is still installed as `direct-cli` and must be `>=0.3.1`.
 - `tapi-yandex-direct` naming is the default source reused by the CLI.
 - WSDL / Reports spec wins when old CLI convenience names drift.
+- v4 Live methods are exposed only when `direct` has a typed public command.
 
 The machine-readable parity source lives in
 [`server/contract.py`](server/contract.py).
@@ -176,8 +177,8 @@ The machine-readable parity source lives in
 
 | Surface | Examples | Notes |
 |---|---|---|
-| Direct API tools | `campaigns_get`, `advideos_add`, `dictionaries_get_geo_regions`, `dynamicads_set_bids`, `smartadtargets_resume`, `retargeting_update` | Canonical CLI-mediated Direct contract |
-| CLI helper tools | `agencyclients_delete`, `bidmodifiers_toggle`, `dictionaries_list_names`, `reports_list_types` | Public, but explicitly not 1:1 Direct API methods |
+| Direct API tools | `campaigns_get`, `advideos_add`, `dictionaries_get_geo_regions`, `dynamicads_set_bids`, `balance_get`, `v4goals_get_stat_goals` | Canonical CLI-mediated Direct contract |
+| CLI helper tools | `agencyclients_delete`, `dictionaries_list_names`, `reports_list_types` | Public, but explicitly not 1:1 Direct API methods |
 | Plugin tools | `auth_status`, `auth_setup`, `auth_login` | Plugin-only auth flows, not Direct operations |
 
 ### Breaking-change migration highlights
@@ -216,6 +217,21 @@ The machine-readable parity source lives in
 - `audiencetargets_set_bids`
 - `dynamicads_suspend`, `dynamicads_resume`, `dynamicads_set_bids`
 - `smartadtargets_suspend`, `smartadtargets_resume`, `smartadtargets_set_bids`
+- `balance_get`
+- `v4goals_get_stat_goals`, `v4goals_get_retargeting_goals`
+
+### v4 Live coverage
+
+`direct-cli` 0.3.1 exposes v4 shell groups for future expansion, but only these
+typed public commands are registered as MCP tools today:
+
+- `direct balance` → `balance_get`
+- `direct v4goals get-stat-goals` → `v4goals_get_stat_goals`
+- `direct v4goals get-retargeting-goals` → `v4goals_get_retargeting_goals`
+
+Other methods from `direct_cli.v4_contracts` are tracked in
+`server/contract.py` as blocked/future metadata and are not exposed until the CLI
+publishes typed commands for them.
 
 ## Skills
 
@@ -244,6 +260,12 @@ Just ask in natural language — the plugin handles the rest:
 
 > статистика за последнюю неделю
   → reports_get(date_from="2026-03-30", date_to="2026-04-06")
+
+> баланс аккаунта
+  → balance_get()
+
+> цели Метрики для кампании 12345
+  → v4goals_get_stat_goals(campaign_ids="12345")
 
 > напиши объявление для доставки пиццы
   → /yandex-direct:direct-ads "доставка пиццы"

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -103,6 +103,15 @@ Research & Reporting
 .. automodule:: server.tools.reports
    :members:
 
+V4 Live
+-------
+
+.. automodule:: server.tools.balance
+   :members:
+
+.. automodule:: server.tools.v4goals
+   :members:
+
 Authentication
 --------------
 

--- a/hooks/setup.sh
+++ b/hooks/setup.sh
@@ -11,6 +11,10 @@ _pip_user() {
     true
 }
 
+_has_direct_cli_031() {
+    "$1" -c "import direct_cli; raise SystemExit(tuple(map(int, direct_cli.__version__.split('.')[:3])) < (0, 3, 1))" 2>/dev/null
+}
+
 # Try plugin venv first (Debian/Docker friendly)
 if [ ! -f "$VENV/bin/python3" ]; then
     python3 -m venv "$VENV" --quiet 2>/dev/null || true
@@ -18,16 +22,16 @@ fi
 
 if [ -f "$VENV/bin/python3" ]; then
     # Venv available — install into it
-    if ! "$VENV/bin/python3" -c "import direct" 2>/dev/null; then
-        "$VENV/bin/pip" install --quiet --disable-pip-version-check direct-cli 2>/dev/null || true
+    if ! _has_direct_cli_031 "$VENV/bin/python3"; then
+        "$VENV/bin/pip" install --quiet --disable-pip-version-check 'direct-cli>=0.3.1' 2>/dev/null || true
     fi
     if ! "$VENV/bin/python3" -c "import mcp, httpx" 2>/dev/null; then
         "$VENV/bin/pip" install --quiet --disable-pip-version-check mcp "httpx>=0.27" python-dotenv 2>/dev/null || true
     fi
 else
     # No venv — fallback to system install (macOS)
-    if ! command -v direct &>/dev/null; then
-        _pip_user direct-cli
+    if ! command -v direct &>/dev/null || ! _has_direct_cli_031 python3; then
+        _pip_user 'direct-cli>=0.3.1'
     fi
     if ! python3 -c "import mcp, httpx" 2>/dev/null; then
         _pip_user mcp "httpx>=0.27" python-dotenv

--- a/plugins/yandex-direct/server/main.py
+++ b/plugins/yandex-direct/server/main.py
@@ -16,9 +16,11 @@ mcp = FastMCP("yandex-direct-mcp", json_response=True)
 import server.tools.adextensions  # noqa: E402, F401
 import server.tools.adgroups  # noqa: E402, F401
 import server.tools.ads  # noqa: E402, F401
+import server.tools.advideos  # noqa: E402, F401
 import server.tools.agency  # noqa: E402, F401
 import server.tools.audience  # noqa: E402, F401
 import server.tools.auth_tools  # noqa: E402, F401
+import server.tools.balance  # noqa: E402, F401
 import server.tools.businesses  # noqa: E402, F401
 import server.tools.bidmodifiers  # noqa: E402, F401
 import server.tools.bids  # noqa: E402, F401
@@ -28,21 +30,21 @@ import server.tools.clients  # noqa: E402, F401
 import server.tools.creatives  # noqa: E402, F401
 import server.tools.dictionaries  # noqa: E402, F401
 import server.tools.dynamic_ads  # noqa: E402, F401
-import server.tools.dynamic_targets  # noqa: E402, F401
+import server.tools.dynamic_feed_ad_targets  # noqa: E402, F401
 import server.tools.feeds  # noqa: E402, F401
 import server.tools.images  # noqa: E402, F401
 import server.tools.keyword_bids  # noqa: E402, F401
 import server.tools.keywords  # noqa: E402, F401
 import server.tools.leads  # noqa: E402, F401
 import server.tools.negative_keyword_shared_sets  # noqa: E402, F401
-import server.tools.negative_keywords  # noqa: E402, F401
 import server.tools.reports  # noqa: E402, F401
 import server.tools.research  # noqa: E402, F401
 import server.tools.retargeting  # noqa: E402, F401
 import server.tools.sitelinks  # noqa: E402, F401
 import server.tools.smart_ad_targets  # noqa: E402, F401
-import server.tools.smart_targets  # noqa: E402, F401
+import server.tools.strategies  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
+import server.tools.v4goals  # noqa: E402, F401
 import server.tools.vcards  # noqa: E402, F401
 
 # Initialize token getter for production use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yandex-direct-mcp-plugin"
 version = "1.0.0"
 requires-python = ">=3.11"
-dependencies = ["mcp", "httpx>=0.27", "python-dotenv>=1.0"]
+dependencies = ["mcp", "httpx>=0.27", "python-dotenv>=1.0", "direct-cli>=0.3.1"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/contract.py
+++ b/server/contract.py
@@ -1,10 +1,10 @@
 """Public MCP contract metadata aligned to the `direct` CLI surface.
 
 Tool count (derived from the structures below):
-- Direct API tools: 115
+- Direct API tools: 118
 - CLI helper tools:   3
 - Plugin tools:       3
-Total:              121
+Total:              124
 """
 
 from __future__ import annotations
@@ -14,9 +14,10 @@ from typing import Literal
 
 # ``wsdl``: canonical SOAP/WSDL-backed Direct API operation.
 # ``reports-spec``: canonical Reports API operation validated against reports spec.
+# ``v4-live``: canonical Yandex Direct v4 Live operation exposed by direct-cli.
 # ``cli-extra``: public CLI helper intentionally outside the 1:1 API surface.
 # ``plugin``: plugin-only auth/utility tool, not a Direct API operation.
-ToolAuthority = Literal["wsdl", "reports-spec", "cli-extra", "plugin"]
+ToolAuthority = Literal["wsdl", "reports-spec", "v4-live", "cli-extra", "plugin"]
 
 # ``direct_api``: public Direct operation exposed through CLI transport.
 # ``cli_helper``: public helper kept separate from the Direct API contract.
@@ -68,12 +69,27 @@ class ContractTool:
         ``set_auto`` → ``setAuto``, ``has_search_volume`` → ``hasSearchVolume``.
         Returns ``None`` when there is no CLI method (plugin tools).
         """
+        if self.cli_method is None and self.tapi_name is not None:
+            return self.tapi_name
         if self.cli_method is None:
             return None
         if self.tapi_name is not None:
             return self.tapi_name
         parts = self.cli_method.split("_")
         return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+@dataclass(frozen=True)
+class BlockedV4Method:
+    """Known v4 Live method that direct-cli does not expose as a command yet."""
+
+    method: str
+    group: str
+    expected_cli_group: str | None
+    expected_cli_subcommand: str | None
+    reason: str = (
+        "direct 0.3.1 does not expose a typed CLI command for this v4 Live method."
+    )
 
 
 DIRECT_API_SERVICE_METHODS: dict[str, tuple[str, ...]] = {
@@ -163,6 +179,102 @@ CLI_HELPER_SERVICE_METHODS: dict[str, tuple[str, ...]] = {
     "dictionaries": ("list_names",),
     "reports": ("list_types",),
 }
+
+V4_LIVE_CLI_TOOLS: tuple[ContractTool, ...] = (
+    ContractTool(
+        public_name="balance_get",
+        cli_service="balance",
+        cli_method=None,
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="AccountManagement",
+    ),
+    ContractTool(
+        public_name="v4goals_get_stat_goals",
+        cli_service="v4goals",
+        cli_method="get_stat_goals",
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="GetStatGoals",
+    ),
+    ContractTool(
+        public_name="v4goals_get_retargeting_goals",
+        cli_service="v4goals",
+        cli_method="get_retargeting_goals",
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="GetRetargetingGoals",
+    ),
+)
+
+# Methods present in direct_cli.v4_contracts but intentionally not exposed as
+# MCP tools until direct-cli publishes typed commands for them.
+V4_LIVE_BLOCKED_METHODS: tuple[BlockedV4Method, ...] = (
+    BlockedV4Method("GetClientsUnits", "finance", "v4finance", "get-clients-units"),
+    BlockedV4Method("GetCreditLimits", "finance", "v4finance", "get-credit-limits"),
+    BlockedV4Method("TransferMoney", "finance", "v4finance", "transfer-money"),
+    BlockedV4Method("PayCampaigns", "finance", "v4finance", "pay-campaigns"),
+    BlockedV4Method(
+        "PayCampaignsByCard", "finance", "v4finance", "pay-campaigns-by-card"
+    ),
+    BlockedV4Method("CheckPayment", "finance", "v4finance", "check-payment"),
+    BlockedV4Method("CreateInvoice", "finance", "v4finance", "create-invoice"),
+    BlockedV4Method(
+        "EnableSharedAccount",
+        "shared_account",
+        "v4account",
+        "enable-shared-account",
+    ),
+    BlockedV4Method("GetEventsLog", "events", "v4events", "get-events-log"),
+    BlockedV4Method(
+        "CreateNewWordstatReport",
+        "wordstat",
+        "v4wordstat",
+        "create-new-wordstat-report",
+    ),
+    BlockedV4Method(
+        "GetWordstatReportList",
+        "wordstat",
+        "v4wordstat",
+        "get-wordstat-report-list",
+    ),
+    BlockedV4Method(
+        "GetWordstatReport", "wordstat", "v4wordstat", "get-wordstat-report"
+    ),
+    BlockedV4Method(
+        "DeleteWordstatReport",
+        "wordstat",
+        "v4wordstat",
+        "delete-wordstat-report",
+    ),
+    BlockedV4Method(
+        "CreateNewForecast", "forecast", "v4forecast", "create-new-forecast"
+    ),
+    BlockedV4Method("GetForecastList", "forecast", "v4forecast", "get-forecast-list"),
+    BlockedV4Method("GetForecast", "forecast", "v4forecast", "get-forecast"),
+    BlockedV4Method(
+        "DeleteForecastReport",
+        "forecast",
+        "v4forecast",
+        "delete-forecast-report",
+    ),
+    BlockedV4Method(
+        "DeleteOfflineReport", "offline_reports", None, "delete-offline-report"
+    ),
+    BlockedV4Method("DeleteReport", "offline_reports", None, "delete-report"),
+    BlockedV4Method("GetBannersTags", "tags", None, "get-banners-tags"),
+    BlockedV4Method("GetCampaignsTags", "tags", None, "get-campaigns-tags"),
+    BlockedV4Method("UpdateBannersTags", "tags", None, "update-banners-tags"),
+    BlockedV4Method("UpdateCampaignsTags", "tags", None, "update-campaigns-tags"),
+    BlockedV4Method("AdImageAssociation", "ad_image", None, "ad-image-association"),
+    BlockedV4Method(
+        "GetKeywordsSuggestion", "keywords", None, "get-keywords-suggestion"
+    ),
+    BlockedV4Method("PingAPI", "meta", "v4meta", "ping-api"),
+    BlockedV4Method("PingAPI_X", "meta", "v4meta", "ping-api-x"),
+    BlockedV4Method("GetVersion", "meta", "v4meta", "get-version"),
+    BlockedV4Method("GetAvailableVersions", "meta", "v4meta", "get-available-versions"),
+)
 
 PLUGIN_TOOL_NAMES = ("auth_status", "auth_setup", "auth_login")
 
@@ -294,6 +406,7 @@ PUBLIC_CONTRACT: tuple[ContractTool, ...] = tuple(
             for service, methods in CLI_HELPER_SERVICE_METHODS.items()
             for method in methods
         ),
+        *V4_LIVE_CLI_TOOLS,
         *(
             ContractTool(
                 public_name=name,
@@ -313,6 +426,10 @@ DIRECT_API_TOOL_NAMES = frozenset(
 )
 CLI_HELPER_TOOL_NAMES = frozenset(
     tool.public_name for tool in PUBLIC_CONTRACT if tool.classification == "cli_helper"
+)
+V4_LIVE_TOOL_NAMES = frozenset(tool.public_name for tool in V4_LIVE_CLI_TOOLS)
+V4_LIVE_BLOCKED_METHOD_NAMES = frozenset(
+    blocked.method for blocked in V4_LIVE_BLOCKED_METHODS
 )
 PLUGIN_ONLY_TOOL_NAMES = frozenset(
     tool.public_name for tool in PUBLIC_CONTRACT if tool.classification == "plugin"

--- a/server/contract.py
+++ b/server/contract.py
@@ -64,10 +64,11 @@ class ContractTool:
     def tapi_canonical(self) -> str | None:
         """tapi-yandex-direct canonical method name (camelCase).
 
-        Returns the explicit ``tapi_name`` when set; otherwise auto-derives it
-        from ``cli_method`` by converting snake_case to camelCase, e.g.
-        ``set_auto`` → ``setAuto``, ``has_search_volume`` → ``hasSearchVolume``.
-        Returns ``None`` when there is no CLI method (plugin tools).
+        Returns the explicit ``tapi_name`` when set, including CLI-backed v4
+        tools with no subcommand method stored in ``cli_method``. Otherwise
+        auto-derives it from ``cli_method`` by converting snake_case to
+        camelCase, e.g. ``set_auto`` → ``setAuto``. Returns ``None`` for
+        plugin tools with neither ``cli_method`` nor ``tapi_name``.
         """
         if self.cli_method is None and self.tapi_name is not None:
             return self.tapi_name

--- a/server/main.py
+++ b/server/main.py
@@ -20,6 +20,7 @@ import server.tools.advideos  # noqa: E402, F401
 import server.tools.agency  # noqa: E402, F401
 import server.tools.audience  # noqa: E402, F401
 import server.tools.auth_tools  # noqa: E402, F401
+import server.tools.balance  # noqa: E402, F401
 import server.tools.businesses  # noqa: E402, F401
 import server.tools.bidmodifiers  # noqa: E402, F401
 import server.tools.bids  # noqa: E402, F401
@@ -43,6 +44,7 @@ import server.tools.sitelinks  # noqa: E402, F401
 import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.strategies  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
+import server.tools.v4goals  # noqa: E402, F401
 import server.tools.vcards  # noqa: E402, F401
 
 # Initialize token getter for production use

--- a/server/tools/balance.py
+++ b/server/tools/balance.py
@@ -1,0 +1,19 @@
+"""MCP tools for Yandex Direct v4 Live account balance."""
+
+from server.main import mcp
+from server.tools import get_runner, handle_cli_errors
+
+
+@mcp.tool(name="balance_get")
+@handle_cli_errors
+def balance_get(logins: str | None = None) -> dict | list[dict]:
+    """Get account money balance via the v4 Live AccountManagement method.
+
+    Args:
+        logins: Optional comma-separated client logins.
+    """
+    args = ["balance", "--format", "json"]
+    normalized_logins = logins.strip() if logins is not None else None
+    if normalized_logins:
+        args.extend(["--logins", normalized_logins])
+    return get_runner().run_json(args)

--- a/server/tools/v4goals.py
+++ b/server/tools/v4goals.py
@@ -1,0 +1,38 @@
+"""MCP tools for Yandex Direct v4 Live goals commands."""
+
+from server.main import mcp
+from server.tools import ToolError, get_runner, handle_cli_errors
+
+
+def _run_goals_command(method: str, campaign_ids: str) -> dict | list[dict]:
+    normalized_ids = campaign_ids.strip()
+    if not normalized_ids:
+        return ToolError(
+            error="missing_campaign_ids",
+            message="Provide at least one campaign ID.",
+        ).__dict__
+    return get_runner().run_json(
+        ["v4goals", method, "--campaign-ids", normalized_ids, "--format", "json"]
+    )
+
+
+@mcp.tool(name="v4goals_get_stat_goals")
+@handle_cli_errors
+def v4goals_get_stat_goals(campaign_ids: str) -> dict | list[dict]:
+    """Get Yandex Metrica goals available for campaigns.
+
+    Args:
+        campaign_ids: Comma-separated campaign IDs.
+    """
+    return _run_goals_command("get-stat-goals", campaign_ids)
+
+
+@mcp.tool(name="v4goals_get_retargeting_goals")
+@handle_cli_errors
+def v4goals_get_retargeting_goals(campaign_ids: str) -> dict | list[dict]:
+    """Get retargeting goals for campaigns.
+
+    Args:
+        campaign_ids: Comma-separated campaign IDs.
+    """
+    return _run_goals_command("get-retargeting-goals", campaign_ids)

--- a/skills/yandex-direct/SKILL.md
+++ b/skills/yandex-direct/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 
 Не пытайся вызывать другие tools пока авторизация не пройдена — они вернут ошибку.
 
-## Доступный MCP-контракт (121 tools)
+## Доступный MCP-контракт (124 tools)
 
 Контракт теперь следует иерархии:
 
@@ -27,6 +27,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 - Используй только публичные MCP tools.
 - Не опирайся на старые alias-имена (`*_list`, `agency_clients_*`, `keyword_bids_*`, `smart_targets_*` и т.д.).
 - Для Direct-операций используй канонические имена `service_method`.
+- v4 Live методы вызывай только через публичные MCP tools; shell-группы без CLI-команд не используются.
 
 ### Правила именования
 
@@ -53,6 +54,7 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Стратегии | `strategies_get/add/update/archive/unarchive` |
 | Медиа и расширения | `adimages_get/add/delete`, `advideos_get/add`, `adextensions_get/add/delete`, `sitelinks_get/add/delete`, `vcards_get/add/delete`, `creatives_get/add` |
 | Справочники / изменения / отчёты | `dictionaries_get`, `dictionaries_get_geo_regions`, `changes_check`, `changes_check_campaigns`, `changes_check_dictionaries`, `reports_get` |
+| v4 Live | `balance_get`, `v4goals_get_stat_goals`, `v4goals_get_retargeting_goals` |
 | Прочее | `clients_get/update`, `agencyclients_get/add/update/add_passport_organization/add_passport_organization_member`, `businesses_get`, `feeds_get/add/update/delete`, `leads_get`, `negativekeywordsharedsets_get/add/update/delete`, `keywordsresearch_has_search_volume`, `keywordsresearch_deduplicate`, `turbopages_get` |
 
 ### Явно helper-only tools
@@ -86,6 +88,9 @@ argument-hint: "[вопрос или команда по Яндекс.Дирек
 | Ставка показа на dynamic-target | `dynamic_ads_set_bids(id=42, bid=5000000)` |
 | Средняя CPC для smart-таргета | `smart_ad_targets_set_bids(id=42, average_cpc=8000000)` |
 | Статистика за последнюю неделю | `reports_get(date_from="...", date_to="...")` |
+| Баланс аккаунта | `balance_get()` |
+| Цели Метрики для кампаний | `v4goals_get_stat_goals(campaign_ids="123")` |
+| Ретаргетинговые цели для кампаний | `v4goals_get_retargeting_goals(campaign_ids="123")` |
 | Проверить есть ли изменения в кампаниях | `changes_check_campaigns(campaign_ids="123", timestamp="...")` |
 | Показать группы объявлений | `adgroups_get(campaign_ids="123")` |
 | Токен живой? | `auth_status()` |

--- a/tests/test_codex_plugin_packaging.py
+++ b/tests/test_codex_plugin_packaging.py
@@ -52,3 +52,16 @@ def test_plugin_manifest_matches_bundle_layout() -> None:
     server = mcp["mcpServers"]["yandex-direct-mcp"]
     assert server["command"] == "python3"
     assert server["args"] == ["${CLAUDE_PLUGIN_ROOT}/server/main.py"]
+
+
+def test_plugin_entrypoint_imports_same_tools_as_repo_entrypoint() -> None:
+    def tool_imports(path: Path) -> set[str]:
+        return {
+            line.strip()
+            for line in path.read_text().splitlines()
+            if line.startswith("import server.tools.")
+        }
+
+    assert tool_imports(SERVER_ENTRYPOINT) == tool_imports(
+        REPO_ROOT / "server" / "main.py"
+    )

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -89,6 +89,11 @@ def test_v4goals_requires_campaign_ids():
     assert result["error"] == "missing_campaign_ids"
 
 
+def test_v4goals_retargeting_requires_campaign_ids():
+    result = v4goals_get_retargeting_goals(campaign_ids="   ")
+    assert result["error"] == "missing_campaign_ids"
+
+
 def test_v4_contract_exposes_only_cli_backed_tools():
     assert V4_LIVE_TOOL_NAMES == {
         "balance_get",

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -1,0 +1,103 @@
+"""Tests for v4 Live MCP tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server.tools
+from server.contract import (
+    PUBLIC_TOOL_NAMES,
+    V4_LIVE_BLOCKED_METHOD_NAMES,
+    V4_LIVE_TOOL_NAMES,
+)
+from server.tools.balance import balance_get
+from server.tools.v4goals import (
+    v4goals_get_retargeting_goals,
+    v4goals_get_stat_goals,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_token_getter():
+    server.tools.set_token_getter(lambda: "test-token")
+
+
+def _mock_runner(return_value):
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    return runner
+
+
+def test_balance_get_without_logins():
+    runner = _mock_runner({"Accounts": []})
+    with patch("server.tools.balance.get_runner", return_value=runner):
+        result = balance_get()
+
+    assert result == {"Accounts": []}
+    runner.run_json.assert_called_once_with(["balance", "--format", "json"])
+
+
+def test_balance_get_with_logins():
+    runner = _mock_runner({"Accounts": []})
+    with patch("server.tools.balance.get_runner", return_value=runner):
+        result = balance_get(logins=" client-a,client-b ")
+
+    assert result == {"Accounts": []}
+    runner.run_json.assert_called_once_with(
+        ["balance", "--format", "json", "--logins", "client-a,client-b"]
+    )
+
+
+def test_v4goals_get_stat_goals():
+    runner = _mock_runner({"Goals": []})
+    with patch("server.tools.v4goals.get_runner", return_value=runner):
+        result = v4goals_get_stat_goals(campaign_ids=" 123,456 ")
+
+    assert result == {"Goals": []}
+    runner.run_json.assert_called_once_with(
+        [
+            "v4goals",
+            "get-stat-goals",
+            "--campaign-ids",
+            "123,456",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_v4goals_get_retargeting_goals():
+    runner = _mock_runner({"RetargetingGoals": []})
+    with patch("server.tools.v4goals.get_runner", return_value=runner):
+        result = v4goals_get_retargeting_goals(campaign_ids="123,456")
+
+    assert result == {"RetargetingGoals": []}
+    runner.run_json.assert_called_once_with(
+        [
+            "v4goals",
+            "get-retargeting-goals",
+            "--campaign-ids",
+            "123,456",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_v4goals_requires_campaign_ids():
+    result = v4goals_get_stat_goals(campaign_ids="   ")
+    assert result["error"] == "missing_campaign_ids"
+
+
+def test_v4_contract_exposes_only_cli_backed_tools():
+    assert V4_LIVE_TOOL_NAMES == {
+        "balance_get",
+        "v4goals_get_stat_goals",
+        "v4goals_get_retargeting_goals",
+    }
+    assert V4_LIVE_TOOL_NAMES <= PUBLIC_TOOL_NAMES
+    assert {"GetClientsUnits", "PingAPI", "CreateNewForecast"} <= (
+        V4_LIVE_BLOCKED_METHOD_NAMES
+    )
+    assert "v4finance_get_clients_units" not in PUBLIC_TOOL_NAMES
+    assert "v4meta_ping_api" not in PUBLIC_TOOL_NAMES


### PR DESCRIPTION
## Summary

- Add MCP wrappers for the v4 commands that exist in `direct-cli` 0.3.1: `balance_get`, `v4goals_get_stat_goals`, and `v4goals_get_retargeting_goals`.
- Update the public contract to 124 tools and track missing v4 methods as blocked/future metadata without registering tools for absent CLI commands.
- Require `direct-cli>=0.3.1`, sync the plugin entrypoint, and update docs/skill guidance.

## Validation

- `pytest` -> 450 passed, 8 skipped
- `ruff check .` -> passed
- `mypy .` -> passed
- `bash -n hooks/setup.sh` -> passed
- `git diff --check` -> passed