### PR TITLE
feat(reports): wire goal_ids to direct-cli native --goals (0.3.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {"name": "axisrow"},
   "keywords": ["yandex", "direct", "advertising", "oauth"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - Campaign IDs ~73-77M range belong to a second account (foreign_campaign error)
 - OAuth tokens stored in `${CLAUDE_PLUGIN_DATA}/tokens.json` (gitignored)
 - CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.2` (adds `reports get --goals` / `--attribution-models`, fixes Goals Filter rejection by Reports API).
-- `reports_custom(goal_ids=...)` maps to `direct reports get --goals ...` (top-level `ReportDefinition.Goals`). Yandex splits `Conversions` and `CostPerConversion` into per-goal columns: `Conversions_<goal_id>_<attribution>` (e.g. `Conversions_319910463_LSC`). `Goals` is NOT a valid Filter field, NOR a valid FieldName — passing it in either is rejected (locally for filters, by API for FieldNames with `error_code=8000`).
+- `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
 
 ## Breaking Changes (v1 → v2 migration)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,8 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - API batch limit: max 10 IDs per request
 - Campaign IDs ~73-77M range belong to a second account (foreign_campaign error)
 - OAuth tokens stored in `${CLAUDE_PLUGIN_DATA}/tokens.json` (gitignored)
-- CLI binary: `direct` (installed via `pip install direct-cli`)
+- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.2` (adds `reports get --goals` / `--attribution-models`, fixes Goals Filter rejection by Reports API).
+- `reports_custom(goal_ids=...)` maps to `direct reports get --goals ...` (top-level `ReportDefinition.Goals`). `Goals` is NOT a valid Filter field — passing it via `filters=["Goals:IN:..."]` is rejected locally before the call.
 - Language: project docs in Russian, code identifiers in English
 
 ## Breaking Changes (v1 → v2 migration)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - Campaign IDs ~73-77M range belong to a second account (foreign_campaign error)
 - OAuth tokens stored in `${CLAUDE_PLUGIN_DATA}/tokens.json` (gitignored)
 - CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.2` (adds `reports get --goals` / `--attribution-models`, fixes Goals Filter rejection by Reports API).
-- `reports_custom(goal_ids=...)` maps to `direct reports get --goals ...` (top-level `ReportDefinition.Goals`). `Goals` is NOT a valid Filter field — passing it via `filters=["Goals:IN:..."]` is rejected locally before the call.
+- `reports_custom(goal_ids=...)` maps to `direct reports get --goals ...` (top-level `ReportDefinition.Goals`). Yandex splits `Conversions` and `CostPerConversion` into per-goal columns: `Conversions_<goal_id>_<attribution>` (e.g. `Conversions_319910463_LSC`). `Goals` is NOT a valid Filter field, NOR a valid FieldName — passing it in either is rejected (locally for filters, by API for FieldNames with `error_code=8000`).
 - Language: project docs in Russian, code identifiers in English
 
 ## Breaking Changes (v1 → v2 migration)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "yandex-direct-mcp-plugin"
-version = "0.1.6"
+version = "0.1.7"
 requires-python = ">=3.11"
-dependencies = ["mcp", "httpx>=0.27", "python-dotenv>=1.0", "direct-cli>=0.3.1"]
+dependencies = ["mcp", "httpx>=0.27", "python-dotenv>=1.0", "direct-cli>=0.3.2"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -44,11 +44,10 @@ _INVALID_REQUEST_HINT_SORTORDER = (
 )
 
 _INVALID_REQUEST_HINT_FILTER = (
-    "A Filter entry has an invalid Field or Operator. Operator must be one "
-    "of EQUALS, NOT_EQUALS, IN, NOT_IN, LESS_THAN, GREATER_THAN, "
+    "A Filter entry has an invalid Field or Operator. Operators are usually "
+    "one of EQUALS, NOT_EQUALS, IN, NOT_IN, LESS_THAN, GREATER_THAN, "
     "STARTS_WITH_IGNORE_CASE, DOES_NOT_START_WITH_IGNORE_CASE. "
-    "Note: `Goals` is NOT a Filter field — pass `goal_ids` to `reports_custom` "
-    "instead, which maps to top-level `ReportDefinition.Goals`."
+    "For goal-based slicing use `goal_ids`, not a Filter."
 )
 
 # Targeted hints by error_code, per Yandex.Direct API errors-list reference.

--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -47,8 +47,8 @@ _INVALID_REQUEST_HINT_FILTER = (
     "A Filter entry has an invalid Field or Operator. Operator must be one "
     "of EQUALS, NOT_EQUALS, IN, NOT_IN, LESS_THAN, GREATER_THAN, "
     "STARTS_WITH_IGNORE_CASE, DOES_NOT_START_WITH_IGNORE_CASE. "
-    "Note: Goals filter is only valid for some report_types — pass dry_run=True "
-    "to confirm the body shape."
+    "Note: `Goals` is NOT a Filter field — pass `goal_ids` to `reports_custom` "
+    "instead, which maps to top-level `ReportDefinition.Goals`."
 )
 
 # Targeted hints by error_code, per Yandex.Direct API errors-list reference.

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -309,12 +309,12 @@ def reports_custom(
             last_7_days, this_week_mon_today, this_week_mon_sun, last_week,
             last_business_week, last_3_months, last_5_years, auto. Cannot be
             combined with explicit dates.
-        goal_ids: Convenience shortcut. Comma-separated Metrika goal IDs.
-            Internally translates to --filter Goals:IN:<ids>. Note: in
-            CUSTOM_REPORT the field is named `Goals` (NOT `GoalsIds`).
-            Find goal IDs via `v4goals_get_stat_goals(campaign_ids=...)`.
-            When `Goals` is also in field_names, each row reports per-goal
-            conversions for those goal IDs.
+        goal_ids: Comma-separated Metrika goal IDs (max 10). Maps to direct
+            CLI's `--goals` flag, which emits top-level `ReportDefinition.Goals`
+            in the request body — NOT a Filter entry. Find goal IDs via
+            `v4goals_get_stat_goals(campaign_ids=...)`. When `Goals` is also
+            in field_names, each row reports per-goal conversions for these
+            goal IDs.
         campaign_ids: Comma-separated campaign IDs (max 10). Maps to
             --campaign-ids.
         adgroup_ids: Comma-separated ad group IDs (max 10). Maps to
@@ -323,7 +323,7 @@ def reports_custom(
             Operators: EQUALS, NOT_EQUALS, IN, NOT_IN, LESS_THAN, GREATER_THAN,
             STARTS_WITH_IGNORE_CASE, DOES_NOT_START_WITH_IGNORE_CASE.
             Example: ["Impressions:GREATER_THAN:0", "Device:IN:DESKTOP,MOBILE"].
-            Cannot include a `Goals:` filter when `goal_ids` is also passed.
+            `Goals` is NOT a valid Filter field — use `goal_ids` instead.
         order_by: Repeatable `FIELD[:ASC|DESC]`. Example: ["Month:ASC"].
         page_limit: For paginated retrieval of large reports.
         page_offset: For paginated retrieval of large reports.
@@ -392,13 +392,11 @@ def reports_custom(
         )
 
     effective_filters: list[str] = list(filters) if filters else []
-    if goal_ids:
-        if any(_filter_field(f).lower() == "goals" for f in effective_filters):
-            raise ValueError(
-                "conflicting goal filter: pass either goal_ids or "
-                "filters with a 'Goals:' entry, not both"
-            )
-        effective_filters.append(f"Goals:IN:{goal_ids}")
+    if any(_filter_field(f).lower() == "goals" for f in effective_filters):
+        raise ValueError(
+            "Goals is not a valid Filter field — Reports API expects goals "
+            "at top-level ReportDefinition.Goals. Pass goal_ids instead."
+        )
 
     name = report_name or f"mcp_custom_{int(time.time() * 1000)}"
 
@@ -416,6 +414,8 @@ def reports_custom(
         args.extend(["--campaign-ids", campaign_ids])
     if adgroup_ids:
         args.extend(["--adgroup-ids", adgroup_ids])
+    if goal_ids:
+        args.extend(["--goals", goal_ids])
 
     for f in effective_filters:
         args.extend(["--filter", f])

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -130,11 +130,6 @@ def reports_list_types() -> list[str] | dict:
     return runner.run_json(["reports", "list-types"])
 
 
-def _filter_field(filter_str: str) -> str:
-    """Extract FIELD from a 'FIELD:OPERATOR:VALUES' filter string."""
-    return filter_str.split(":", 1)[0] if ":" in filter_str else filter_str
-
-
 def _allowed_output_roots() -> tuple[Path, ...]:
     roots = [
         Path(tempfile.gettempdir()),
@@ -284,15 +279,11 @@ def reports_custom(
     with an opaque `error_code=8000`, so a local dry run saves a round-trip.
 
     Args:
-        field_names: Comma-separated list of report fields (dimensions + metrics).
-            Common dimensions for grouping: Date, Week, Month, Quarter, Year,
-            CampaignName, CampaignId, AdGroupName, AdGroupId, AdId, Criterion,
-            Device, Placement, Gender, Age, Slot, TargetingLocationName.
-            Common metrics: Impressions, Clicks, Cost, Ctr, AvgCpc,
-            AvgClickPosition, AvgImpressionPosition, BounceRate, AvgPageviews,
-            Conversions, CostPerConversion, ConversionRate, Goals, Revenue.
-            Example for "stats by month with goals":
-              "Month,Impressions,Clicks,Cost,Goals,Conversions"
+        field_names: Comma-separated FieldNames per Yandex.Direct Reports API
+            spec (case-sensitive enum, scoped to `report_type`). When unsure,
+            pass `dry_run=True` to inspect the request body, or check the
+            spec at https://yandex.com/dev/direct/doc/reports/spec.html.
+            See Examples below for working combinations.
         date_from: Start date (YYYY-MM-DD). Required unless date_range_type is set.
         date_to: End date (YYYY-MM-DD). Required unless date_range_type is set.
             For "last 2 years" pass explicit dates — date_range_type does NOT
@@ -309,22 +300,18 @@ def reports_custom(
             last_7_days, this_week_mon_today, this_week_mon_sun, last_week,
             last_business_week, last_3_months, last_5_years, auto. Cannot be
             combined with explicit dates.
-        goal_ids: Comma-separated Metrika goal IDs (max 10). Maps to direct
-            CLI's `--goals` flag, which emits top-level `ReportDefinition.Goals`
-            in the request body — NOT a Filter entry. Find goal IDs via
-            `v4goals_get_stat_goals(campaign_ids=...)`. The API splits
-            conversion metrics into per-goal output columns automatically
-            (see Returns). NOTE: `Goals` itself is NOT a valid FieldName for
-            CUSTOM_REPORT — do not put it in field_names.
+        goal_ids: Comma-separated Metrika goal IDs (max 10). When set,
+            conversion metrics in the output are split per goal — see Returns.
+            Find goal IDs via `v4goals_get_stat_goals(campaign_ids=...)`.
         campaign_ids: Comma-separated campaign IDs (max 10). Maps to
             --campaign-ids.
         adgroup_ids: Comma-separated ad group IDs (max 10). Maps to
             --adgroup-ids.
-        filters: Repeatable raw filters in `FIELD:OPERATOR:VALUES` form.
-            Operators: EQUALS, NOT_EQUALS, IN, NOT_IN, LESS_THAN, GREATER_THAN,
-            STARTS_WITH_IGNORE_CASE, DOES_NOT_START_WITH_IGNORE_CASE.
+        filters: Repeatable raw filters in `FIELD:OPERATOR:VALUES` form. The
+            set of valid Field/Operator values is owned by the Reports API
+            spec. For goal-based slicing use `goal_ids` (see above). When in
+            doubt, run with `dry_run=True`.
             Example: ["Impressions:GREATER_THAN:0", "Device:IN:DESKTOP,MOBILE"].
-            `Goals` is NOT a valid Filter field — use `goal_ids` instead.
         order_by: Repeatable `FIELD[:ASC|DESC]`. Example: ["Month:ASC"].
         page_limit: For paginated retrieval of large reports.
         page_offset: For paginated retrieval of large reports.
@@ -347,11 +334,7 @@ def reports_custom(
 
     Examples:
 
-        # "Stats for 2 years, group by months, broken down by 2 goals"
-        # NOTE: `Goals` is not a valid FieldName for CUSTOM_REPORT — putting
-        # it in field_names returns error_code=8000. Use goal_ids instead;
-        # the API splits Conversions and CostPerConversion into per-goal
-        # columns automatically.
+        # "Stats for 2 years, by months, broken down by 2 goals"
         reports_custom(
             field_names="Month,CampaignName,Impressions,Clicks,Cost,Conversions,CostPerConversion",
             date_from="2024-04-29", date_to="2026-04-29",
@@ -359,9 +342,8 @@ def reports_custom(
             order_by=["Month:ASC", "CampaignName:ASC"],
             output_path="/tmp/direct_2y_by_goals.json",
         )
-        # → Output columns include Conversions_12345_LSC,
-        #   Conversions_67890_LSC, CostPerConversion_12345_LSC,
-        #   CostPerConversion_67890_LSC.
+        # Output adds per-goal columns: Conversions_12345_LSC,
+        # Conversions_67890_LSC, CostPerConversion_12345_LSC, etc.
 
         # "Top 50 keywords by cost last month"
         reports_custom(
@@ -387,9 +369,8 @@ def reports_custom(
 
         With `goal_ids` set, Yandex splits conversion metrics into per-goal
         columns: `Conversions_<goal_id>_<attribution>`, and same for
-        `CostPerConversion`. Default attribution suffix is `LSC`
-        (last-significant-click). To inspect this in advance, run with
-        `dry_run=True`.
+        `CostPerConversion`. Default attribution code is `LSC`. To inspect
+        this in advance, run with `dry_run=True`.
     """
     if response_format not in VALID_RESPONSE_FORMATS:
         raise ValueError(
@@ -406,11 +387,6 @@ def reports_custom(
         )
 
     effective_filters: list[str] = list(filters) if filters else []
-    if any(_filter_field(f).lower() == "goals" for f in effective_filters):
-        raise ValueError(
-            "Goals is not a valid Filter field — Reports API expects goals "
-            "at top-level ReportDefinition.Goals. Pass goal_ids instead."
-        )
 
     name = report_name or f"mcp_custom_{int(time.time() * 1000)}"
 

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -30,6 +30,11 @@ CUSTOM_REPORT_TIMEOUT_SECONDS = 120
 VALID_RESPONSE_FORMATS = frozenset({"json", "tsv", "csv", "table"})
 
 
+def _is_goals_filter(filter_expr: str) -> bool:
+    """Return whether a raw report filter targets the API's Goals field."""
+    return filter_expr.lstrip().lower().startswith("goals:")
+
+
 def _resolve_report_dates(
     date_from: str | None, date_to: str | None
 ) -> tuple[str, str]:
@@ -387,6 +392,11 @@ def reports_custom(
         )
 
     effective_filters: list[str] = list(filters) if filters else []
+    if any(_is_goals_filter(f) for f in effective_filters):
+        raise ValueError(
+            "Goals filters are not supported by Reports API Filter.Field; "
+            "pass goal IDs via goal_ids instead"
+        )
 
     name = report_name or f"mcp_custom_{int(time.time() * 1000)}"
 

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -312,9 +312,10 @@ def reports_custom(
         goal_ids: Comma-separated Metrika goal IDs (max 10). Maps to direct
             CLI's `--goals` flag, which emits top-level `ReportDefinition.Goals`
             in the request body — NOT a Filter entry. Find goal IDs via
-            `v4goals_get_stat_goals(campaign_ids=...)`. When `Goals` is also
-            in field_names, each row reports per-goal conversions for these
-            goal IDs.
+            `v4goals_get_stat_goals(campaign_ids=...)`. The API splits
+            conversion metrics into per-goal output columns automatically
+            (see Returns). NOTE: `Goals` itself is NOT a valid FieldName for
+            CUSTOM_REPORT — do not put it in field_names.
         campaign_ids: Comma-separated campaign IDs (max 10). Maps to
             --campaign-ids.
         adgroup_ids: Comma-separated ad group IDs (max 10). Maps to
@@ -346,14 +347,21 @@ def reports_custom(
 
     Examples:
 
-        # "Stats for 2 years, group by months, goals 12345 and 67890"
+        # "Stats for 2 years, group by months, broken down by 2 goals"
+        # NOTE: `Goals` is not a valid FieldName for CUSTOM_REPORT — putting
+        # it in field_names returns error_code=8000. Use goal_ids instead;
+        # the API splits Conversions and CostPerConversion into per-goal
+        # columns automatically.
         reports_custom(
-            field_names="Month,CampaignName,Impressions,Clicks,Cost,Goals,Conversions",
+            field_names="Month,CampaignName,Impressions,Clicks,Cost,Conversions,CostPerConversion",
             date_from="2024-04-29", date_to="2026-04-29",
             goal_ids="12345,67890",
             order_by=["Month:ASC", "CampaignName:ASC"],
-            output_path="/tmp/direct_2y_by_month.json",
+            output_path="/tmp/direct_2y_by_goals.json",
         )
+        # → Output columns include Conversions_12345_LSC,
+        #   Conversions_67890_LSC, CostPerConversion_12345_LSC,
+        #   CostPerConversion_67890_LSC.
 
         # "Top 50 keywords by cost last month"
         reports_custom(
@@ -376,6 +384,12 @@ def reports_custom(
         list[dict] of report rows by default; OR
         {output_path, rows_written, report_type, format} when output_path is
         set; OR a ToolError dict on failure.
+
+        With `goal_ids` set, Yandex splits conversion metrics into per-goal
+        columns: `Conversions_<goal_id>_<attribution>`, and same for
+        `CostPerConversion`. Default attribution suffix is `LSC`
+        (last-significant-click). To inspect this in advance, run with
+        `dry_run=True`.
     """
     if response_format not in VALID_RESPONSE_FORMATS:
         raise ValueError(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -272,19 +272,6 @@ def test_reports_custom_goal_ids_with_other_filters_pass_through():
     assert args[args.index("--filter") + 1] == "Device:IN:DESKTOP"
 
 
-def test_reports_custom_rejects_goals_filter_field():
-    """A user-supplied `Goals:IN:...` filter is still rejected — Goals is not
-    a valid Filter field per API spec, regardless of whether `goal_ids` is set."""
-    result = reports_custom(
-        field_names="Month,Goals,Conversions",
-        date_from="2024-01-01",
-        date_to="2024-02-01",
-        filters=["Goals:IN:222"],
-    )
-    assert result["error"] == "unknown"
-    assert "Goals is not a valid Filter field" in result["message"]
-
-
 def test_reports_custom_output_path(tmp_path):
     """output_path returns metadata, not the data array."""
     out = tmp_path / "report.json"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -196,7 +196,13 @@ def _custom_args(call):
 
 
 def test_reports_custom_month_with_goals():
-    """User scenario: 2 years, by months, filter by goal IDs."""
+    """User scenario: 2 years, by months, by goal IDs.
+
+    `goal_ids` must thread to direct CLI's native `--goals` flag (added in
+    direct-cli 0.3.2). The CLI emits it as top-level `ReportDefinition.Goals`,
+    NOT as a `Filter[Goals:IN:...]` entry — Reports API rejects the latter
+    with `error_code=8000`.
+    """
     runner = _mock_runner([{"Month": "2024-05", "Goals": "12345", "Conversions": 4}])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
@@ -211,44 +217,72 @@ def test_reports_custom_month_with_goals():
     runner.run_json.assert_called_once()
     args = _custom_args(runner.run_json.call_args)
     assert args[:4] == ["reports", "get", "--type", "CUSTOM_REPORT"]
-    # Date arguments
     i_from = args.index("--from")
     assert args[i_from + 1] == "2024-04-29"
     i_to = args.index("--to")
     assert args[i_to + 1] == "2026-04-29"
-    # Fields
     i_fields = args.index("--fields")
     assert (
         args[i_fields + 1]
         == "Month,CampaignName,Impressions,Clicks,Cost,Goals,Conversions"
     )
-    # Goal filter materialised
-    assert "--filter" in args
-    i_filter = args.index("--filter")
-    assert args[i_filter + 1] == "Goals:IN:12345,67890"
-    # Order-by passed through
+    # goal_ids → native --goals, NOT --filter Goals:IN:...
+    i_goals = args.index("--goals")
+    assert args[i_goals + 1] == "12345,67890"
+    assert not any(isinstance(a, str) and a.startswith("Goals:") for a in args), (
+        "goal_ids must not produce a Filter entry; got args=" + repr(args)
+    )
     i_order = args.index("--order-by")
     assert args[i_order + 1] == "Month:ASC"
-    # Auto-name with prefix
     i_name = args.index("--name")
     assert args[i_name + 1].startswith("mcp_custom_")
-    # Default in-memory format
     assert args[-2:] == ["--format", "json"]
-    # Higher timeout for long-period custom reports
     assert runner.run_json.call_args.kwargs["timeout"] == CUSTOM_REPORT_TIMEOUT_SECONDS
 
 
-def test_reports_custom_conflicting_goal_filter():
-    """Cannot pass both goal_ids and an explicit Goals: filter."""
+def test_reports_custom_goal_ids_only_no_filter_arg():
+    """`goal_ids` without other filters must not introduce any --filter."""
+    runner = _mock_runner([])
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        reports_custom(
+            field_names="Date,Goals,Conversions",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            goal_ids="111",
+        )
+    args = _custom_args(runner.run_json.call_args)
+    assert "--goals" in args
+    assert args[args.index("--goals") + 1] == "111"
+    assert "--filter" not in args
+
+
+def test_reports_custom_goal_ids_with_other_filters_pass_through():
+    """`goal_ids` and unrelated filters must coexist: --goals AND --filter both emit."""
+    runner = _mock_runner([])
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        reports_custom(
+            field_names="Date,Device,Goals,Conversions",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            goal_ids="111",
+            filters=["Device:IN:DESKTOP"],
+        )
+    args = _custom_args(runner.run_json.call_args)
+    assert args[args.index("--goals") + 1] == "111"
+    assert args[args.index("--filter") + 1] == "Device:IN:DESKTOP"
+
+
+def test_reports_custom_rejects_goals_filter_field():
+    """A user-supplied `Goals:IN:...` filter is still rejected — Goals is not
+    a valid Filter field per API spec, regardless of whether `goal_ids` is set."""
     result = reports_custom(
         field_names="Month,Goals,Conversions",
         date_from="2024-01-01",
         date_to="2024-02-01",
-        goal_ids="111",
         filters=["Goals:IN:222"],
     )
     assert result["error"] == "unknown"
-    assert "conflicting goal filter" in result["message"]
+    assert "Goals is not a valid Filter field" in result["message"]
 
 
 def test_reports_custom_output_path(tmp_path):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -272,6 +272,39 @@ def test_reports_custom_goal_ids_with_other_filters_pass_through():
     assert args[args.index("--filter") + 1] == "Device:IN:DESKTOP"
 
 
+def test_reports_custom_rejects_goals_filter_with_goal_ids():
+    """Raw Goals filters must not combine with native goal_ids routing."""
+    runner = _mock_runner([])
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        result = reports_custom(
+            field_names="Date,Goals,Conversions",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            goal_ids="111",
+            filters=["Goals:IN:222"],
+        )
+
+    assert result["error"] == "unknown"
+    assert "pass goal IDs via goal_ids instead" in result["message"]
+    runner.run_json.assert_not_called()
+
+
+def test_reports_custom_rejects_goals_filter_without_goal_ids():
+    """Goal-based slicing must use goal_ids, not Reports API filters."""
+    runner = _mock_runner([])
+    with patch("server.tools.reports.get_runner", return_value=runner):
+        result = reports_custom(
+            field_names="Date,Goals,Conversions",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            filters=[" goals:IN:111"],
+        )
+
+    assert result["error"] == "unknown"
+    assert "Goals filters are not supported" in result["message"]
+    runner.run_json.assert_not_called()
+
+
 def test_reports_custom_output_path(tmp_path):
     """output_path returns metadata, not the data array."""
     out = tmp_path / "report.json"

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -163,7 +163,7 @@ def test_handle_cli_errors_targeted_hint_8000_filter_falls_back_to_filter_hint()
         stderr="error_code=8000, error_detail=Filter Field contains an invalid enumeration value",
     )()
     assert result["error"] == "invalid_request"
-    assert "Operator must be one of" in result["hint"]
+    assert "Operators are usually one of" in result["hint"]
 
 
 def test_handle_cli_errors_filter_hint_matches_only_whole_word() -> None:


### PR DESCRIPTION
## Summary

- `goal_ids` теперь маршрутизируется в `direct reports get --goals ...` (новый флаг в direct-cli 0.3.2). CLI эмитит его как top-level `ReportDefinition.Goals`, а не как `Filter[Goals:IN:...]`, который Yandex Reports API отвергал с `error_code=8000`.
- Минимум `direct-cli` поднят до `>=0.3.2` — это единственная защита от того, чтобы пользователь обновил плагин, но не CLI, и упёрся в `unknown option --goals`.
- `Goals` как Filter.Field блокируется локально — соответствует API spec (Goals не входит в `FilterFieldEnum`).
- Версия плагина 0.1.6 → 0.1.7.

Связанные изменения в direct-cli:
- closed: axisrow/direct-cli#146 (issue с описанием проблемы)
- merged: axisrow/direct-cli#147 (`--goals` + `--attribution-models` + валидация Filter operator/SortOrder)

## Test plan

- [x] `pytest` — 483 passed / 8 skipped
- [x] `ruff check`, `ruff format --check` — clean
- [x] `mypy server/` — clean
- [x] Mocked dry-run smoke: argv содержит `["--goals", "319910463,409434840"]`, никакого `Filter[Goals:...]`
- [ ] Реальный e2e (требует токен): `reports_custom(goal_ids="319910463,409434840", ...)` за 2 года, разбивка по месяцам — изначальный сценарий пользователя

🤖 Generated with [Claude Code](https://claude.com/claude-code)