### PR TITLE
refactor(auth): drop dead CLAUDE_PLUGIN_OPTION_* mapping (#98)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Core code lives in `server/`. Use `server/main.py` as the MCP entrypoint, `server/tools/` for tool handlers (`campaigns.py`, `ads.py`, `keywords.py`, `reports.py`), `server/auth/` for OAuth/PKCE and token storage, and `server/cli/` for `direct` execution (installed via the `direct-cli` package). Tests live in `tests/`, with cassette fixtures under `tests/recordings/` and shared setup in `tests/conftest.py` and `tests/cli_recorder.py`. Documentation is in `docs/`, and skill definitions are in `skills/`.
+Core code lives in `server/`. Use `server/main.py` as the MCP entrypoint, `server/tools/` for tool handlers (`campaigns.py`, `ads.py`, `keywords.py`, `reports.py`, `auth_tools.py`), and `server/cli/` for `direct` execution (installed via the `direct-cli` package). Authentication is delegated to direct-cli profiles rather than a plugin-local auth module. Tests live in `tests/`, with cassette fixtures under `tests/recordings/` and shared setup in `tests/conftest.py` and `tests/cli_recorder.py`. Documentation is in `docs/`, and skill definitions are in `skills/`.
 
 ## Build, Test, and Development Commands
 Install dev dependencies with `pip install -e '.[dev]'`. Run the server locally with `python -m server.main`. Use `pytest` for the default cassette-replay suite, `pytest --record` to refresh cassettes from the live CLI, `pytest -m mocks` for subprocess edge cases, and `pytest -m integration` for live-token checks. Run `ruff check .`, `ruff format .`, and `mypy .` before opening a PR. For docs, use `make -C docs html`.
@@ -16,7 +16,7 @@ The default test flow replays JSON cassettes instead of calling the API. Record 
 Recent history follows Conventional Commit style, for example `fix: ...`, `refactor(auth): ...`, and issue-linked subjects such as `(#40)`. Keep commits focused and imperative. PRs should describe user-visible behavior, note auth or cassette changes, link the issue when applicable, and include command results for `pytest`, `ruff`, and `mypy`. Add screenshots only when updating docs or plugin UX text that benefits from visual context.
 
 ## Security & Configuration Tips
-Keep local secrets in `.env` or generated test files such as `.env.test`, and never commit them. OAuth tokens are stored under `CLAUDE_PLUGIN_DATA`; tests already isolate this path via `tmp_path`, so preserve that pattern in new tests.
+Keep local secrets in `.env` or generated test files such as `.env.test`, and never commit them. OAuth tokens are stored by direct-cli profiles, normally in `~/.direct-cli/auth.json`; tests should isolate `HOME` or the auth store path via `tmp_path` when they inspect profile state.
 
 ## Publishing to the Marketplace
 Run `./scripts/update-version.sh VERSION` to update all plugin version fields (`pyproject.toml`, `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and the bundled Codex plugin manifest), then propagate that version into `~/Projects/plugin-marketplace/.claude-plugin/marketplace.json`, commit, and push the marketplace repo. The version argument is required.

--- a/server/cli/runner.py
+++ b/server/cli/runner.py
@@ -51,17 +51,8 @@ def _find_direct() -> str | None:
 
 
 def _direct_env() -> dict[str, str]:
-    """Build subprocess env, mapping plugin auth options to direct-cli vars."""
-    env = os.environ.copy()
-    if token := env.get("CLAUDE_PLUGIN_OPTION_token"):
-        env.setdefault("YANDEX_DIRECT_TOKEN", token)
-    if login := env.get("CLAUDE_PLUGIN_OPTION_login"):
-        env.setdefault("YANDEX_DIRECT_LOGIN", login)
-    if client_id := env.get("CLAUDE_PLUGIN_OPTION_client_id"):
-        env.setdefault("YANDEX_DIRECT_CLIENT_ID", client_id)
-    if client_secret := env.get("CLAUDE_PLUGIN_OPTION_client_secret"):
-        env.setdefault("YANDEX_DIRECT_CLIENT_SECRET", client_secret)
-    return env
+    """Build subprocess env for direct-cli."""
+    return os.environ.copy()
 
 
 class CliRunner(Protocol):

--- a/server/tools/auth_tools.py
+++ b/server/tools/auth_tools.py
@@ -140,8 +140,6 @@ def _setup_args(
         args.extend(["--code", code])
     if login:
         args.extend(["--login", login])
-    if client_id := os.environ.get("CLAUDE_PLUGIN_OPTION_client_id"):
-        args.extend(["--client-id", client_id])
     return args
 
 
@@ -158,8 +156,6 @@ def _login_process_args(
     args = ["auth", "login", "--profile", profile]
     if login:
         args.extend(["--login", login])
-    if client_id := os.environ.get("CLAUDE_PLUGIN_OPTION_client_id"):
-        args.extend(["--client-id", client_id])
     return args
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -159,9 +159,7 @@ class TestAuthSetup:
         assert "--client-secret" not in args
         assert "secret" not in args
 
-    def test_auth_command_args_ignore_plugin_client_options(
-        self, monkeypatch
-    ) -> None:
+    def test_auth_command_args_ignore_plugin_client_options(self, monkeypatch) -> None:
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_id", "cid")
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_secret", "secret")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -144,7 +144,7 @@ class TestAuthSetup:
             timeout=None,
         )
 
-    def test_auth_setup_passes_plugin_client_options(self, monkeypatch) -> None:
+    def test_auth_setup_ignores_plugin_client_options(self, monkeypatch) -> None:
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_id", "cid")
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_secret", "secret")
         with patch(
@@ -154,20 +154,24 @@ class TestAuthSetup:
             auth_setup("abc123")
 
         args = mock_run.call_args.args[0]
-        assert "--client-id" in args
-        assert "cid" in args
+        assert "--client-id" not in args
+        assert "cid" not in args
         assert "--client-secret" not in args
         assert "secret" not in args
 
-    def test_auth_command_args_do_not_expose_client_secret(self, monkeypatch) -> None:
+    def test_auth_command_args_ignore_plugin_client_options(
+        self, monkeypatch
+    ) -> None:
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_id", "cid")
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_secret", "secret")
 
         setup_args = _setup_args("abc123")
         login_args = _login_process_args()
 
-        assert "--client-id" in setup_args
-        assert "--client-id" in login_args
+        assert "--client-id" not in setup_args
+        assert "--client-id" not in login_args
+        assert "cid" not in setup_args
+        assert "cid" not in login_args
         assert "--client-secret" not in setup_args
         assert "--client-secret" not in login_args
         assert "secret" not in setup_args
@@ -346,8 +350,18 @@ class TestAuthLogin:
         return_value=("https://oauth.yandex.ru/authorize?x=1", "url"),
     )
     def test_auth_login_sends_code_to_same_process(
-        self, _mock_read_url, _mock_resolve, mock_popen, _mock_find, _mock_status
+        self,
+        _mock_read_url,
+        _mock_resolve,
+        mock_popen,
+        _mock_find,
+        _mock_status,
+        monkeypatch,
     ) -> None:
+        monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_id", "cid")
+        monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_secret", "secret")
+        monkeypatch.delenv("YANDEX_DIRECT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_CLIENT_SECRET", raising=False)
         proc = MagicMock()
         proc.poll.return_value = None
         proc.returncode = 0
@@ -375,6 +389,8 @@ class TestAuthLogin:
             "client",
         ]
         assert "env" in kwargs
+        assert "YANDEX_DIRECT_CLIENT_ID" not in kwargs["env"]
+        assert "YANDEX_DIRECT_CLIENT_SECRET" not in kwargs["env"]
         proc.communicate.assert_called_once_with(input="ABC123\n", timeout=60)
         assert result == {
             "success": True,

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -115,12 +115,21 @@ class TestRun:
             assert "--token" not in cmd
             assert "campaigns" in cmd
 
-    def test_plugin_token_option_is_mapped_to_direct_env(self, runner, monkeypatch):
+    def test_plugin_auth_options_are_not_mapped_to_direct_env(
+        self, runner, monkeypatch
+    ):
         mock_result = MagicMock()
         mock_result.stdout = "[]"
         mock_result.stderr = ""
         mock_result.returncode = 0
         monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_token", "plugin-token")
+        monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_login", "plugin-login")
+        monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_id", "plugin-client-id")
+        monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_client_secret", "plugin-secret")
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_CLIENT_SECRET", raising=False)
 
         with (
             patch("server.cli.runner.shutil.which", return_value="/usr/bin/direct"),
@@ -131,7 +140,10 @@ class TestRun:
             runner.run(["campaigns", "get"])
 
         env = mock_run.call_args.kwargs["env"]
-        assert env["YANDEX_DIRECT_TOKEN"] == "plugin-token"
+        assert "YANDEX_DIRECT_TOKEN" not in env
+        assert "YANDEX_DIRECT_LOGIN" not in env
+        assert "YANDEX_DIRECT_CLIENT_ID" not in env
+        assert "YANDEX_DIRECT_CLIENT_SECRET" not in env
 
     def test_cli_not_found(self, runner):
         """Test 17: direct-cli not in PATH."""


### PR DESCRIPTION
## Summary
- Closes #98 — removes the dead `CLAUDE_PLUGIN_OPTION_*` → `YANDEX_DIRECT_*` mapping in `server/cli/runner.py:_direct_env()` and the matching `--client-id` injection in `server/tools/auth_tools.py`. These options were never actually set by Claude Code, so the code path was unreachable after auth was delegated to direct-cli profiles in #97.
- Flips the now-misleading tests in `tests/test_auth.py` and `tests/test_cli_runner.py` to assert that plugin options are ignored, and updates `AGENTS.md` to reflect that tokens live in `~/.direct-cli/auth.json` and there is no `server/auth/` package anymore.
- The optional `tokens.json` migration from issue #98 is not included — it was explicitly marked optional, and `FileTokenStorage` is already gone.

## Test plan
- [ ] `pytest tests/test_auth.py tests/test_cli_runner.py -v`
- [ ] `ruff check . && ruff format --check .`
- [ ] `mypy .`
- [ ] `grep -rn "CLAUDE_PLUGIN_OPTION_" server/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)