### PR TITLE
fix(auth): finish login via --code -

### DIFF
--- a/server/tools/auth_tools.py
+++ b/server/tools/auth_tools.py
@@ -152,6 +152,10 @@ def _login_finish_args(*, profile: str = "default") -> list[str]:
     return ["auth", "login", "--profile", profile, "--code", "-"]
 
 
+def _login_finish_legacy_args(*, profile: str = "default") -> list[str]:
+    return ["auth", "login", "--profile", profile, "--code-stdin"]
+
+
 def _clean_cli_output(stdout: str = "", stderr: str = "") -> str:
     return _strip_ansi(stderr or stdout).strip()
 
@@ -165,6 +169,25 @@ def _parse_authorize_url(stdout: str) -> str | None:
         return None
     authorize_url = payload.get("authorize_url")
     return authorize_url if isinstance(authorize_url, str) and authorize_url else None
+
+
+def _complete_login_with_code(profile: str, code: str) -> dict:
+    stdin = f"{code}\n"
+    result = _run_auth_command(
+        _login_finish_args(profile=profile),
+        timeout=60,
+        input=stdin,
+    )
+    if result.get("success"):
+        return result
+    legacy_result = _run_auth_command(
+        _login_finish_legacy_args(profile=profile),
+        timeout=60,
+        input=stdin,
+    )
+    if legacy_result.get("success"):
+        return legacy_result
+    return result
 
 
 # --- MCP Tools ---
@@ -294,11 +317,7 @@ async def auth_login(
     if result.action != "accept" or not result.data:
         return {"cancelled": True, "message": "Авторизация отменена."}
 
-    finish_result = _run_auth_command(
-        _login_finish_args(profile=target_profile),
-        timeout=60,
-        input=f"{result.data.value}\n",
-    )
+    finish_result = _complete_login_with_code(target_profile, result.data.value)
     if not finish_result.get("success"):
         return {**finish_result, "auth_url": auth_url}
     return {

--- a/server/tools/auth_tools.py
+++ b/server/tools/auth_tools.py
@@ -149,7 +149,7 @@ def _login_start_args(login: str | None = None, profile: str = "default") -> lis
 
 
 def _login_finish_args(*, profile: str = "default") -> list[str]:
-    return ["auth", "login", "--profile", profile, "--code-stdin"]
+    return ["auth", "login", "--profile", profile, "--code", "-"]
 
 
 def _clean_cli_output(stdout: str = "", stderr: str = "") -> str:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -195,7 +195,8 @@ class TestAuthSetup:
             "login",
             "--profile",
             "default",
-            "--code-stdin",
+            "--code",
+            "-",
         ]
 
     def test_auth_setup_rejects_browser_oauth_code_without_cli_call(self) -> None:
@@ -423,7 +424,8 @@ class TestAuthLogin:
             "login",
             "--profile",
             "custom",
-            "--code-stdin",
+            "--code",
+            "-",
         ]
         assert mock_run.call_args_list[1].kwargs == {
             "timeout": 60,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ from server.cli.runner import CliError, CliNotFoundError, CliTimeoutError
 from server.tools.auth_tools import (
     _human_readable_time,
     _login_finish_args,
+    _login_finish_legacy_args,
     _login_start_args,
     _token_setup_args,
     auth_login,
@@ -197,6 +198,13 @@ class TestAuthSetup:
             "default",
             "--code",
             "-",
+        ]
+        assert _login_finish_legacy_args() == [
+            "auth",
+            "login",
+            "--profile",
+            "default",
+            "--code-stdin",
         ]
 
     def test_auth_setup_rejects_browser_oauth_code_without_cli_call(self) -> None:
@@ -449,6 +457,55 @@ class TestAuthLogin:
     @patch("server.tools.auth_tools._find_direct", return_value="/usr/bin/direct")
     @patch("server.tools.auth_tools._resolve_profile_name", return_value="custom")
     @patch("server.tools.auth_tools.DirectCliRunner.run")
+    def test_auth_login_falls_back_to_legacy_code_stdin(
+        self, mock_run, _mock_resolve, _mock_find, _mock_status
+    ) -> None:
+        mock_run.side_effect = [
+            _completed(
+                json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
+            ),
+            _completed(stderr="invalid authorization code", returncode=1),
+            _completed("saved"),
+        ]
+
+        result = asyncio.run(auth_login(self._accepted_ctx(), profile="custom"))
+
+        assert mock_run.call_args_list[1].args[0] == [
+            "auth",
+            "login",
+            "--profile",
+            "custom",
+            "--code",
+            "-",
+        ]
+        assert mock_run.call_args_list[2].args[0] == [
+            "auth",
+            "login",
+            "--profile",
+            "custom",
+            "--code-stdin",
+        ]
+        assert mock_run.call_args_list[1].kwargs == {
+            "timeout": 60,
+            "input": "ABC123\n",
+        }
+        assert mock_run.call_args_list[2].kwargs == {
+            "timeout": 60,
+            "input": "ABC123\n",
+        }
+        for call in mock_run.call_args_list:
+            assert "ABC123" not in call.args[0]
+        assert result == {
+            "success": True,
+            "method": "oauth_code",
+            "profile": "custom",
+            "login": "",
+        }
+
+    @patch("server.tools.auth_tools.auth_status", return_value={"valid": False})
+    @patch("server.tools.auth_tools._find_direct", return_value="/usr/bin/direct")
+    @patch("server.tools.auth_tools._resolve_profile_name", return_value="custom")
+    @patch("server.tools.auth_tools.DirectCliRunner.run")
     def test_auth_login_finish_cli_failure(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
@@ -456,6 +513,7 @@ class TestAuthLogin:
             _completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
+            _completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
             _completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
         ]
 
@@ -479,6 +537,7 @@ class TestAuthLogin:
             _completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
+            CliError("direct failed"),
             CliError("direct failed"),
         ]
 


### PR DESCRIPTION
## Summary
- change MCP auth_login finish step to call `direct auth login --code -`
- keep the OAuth code in subprocess stdin instead of argv
- update auth tests to assert the code is only passed through `input`

## Dependency
- Requires axisrow/direct-cli#169 to provide the `--code -` stdin sentinel contract.
- Dependency version remains `direct-cli>=0.3.5` per request.

## Tests
- `python3 -m pytest tests/test_auth.py tests/test_server.py tests/test_tool_helpers.py`
- `python3 -m ruff check server/tools/auth_tools.py tests/test_auth.py`