### PR TITLE
feat(campaigns): expose campaign get selector fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yandex-direct-mcp-plugin"
 version = "0.1.10"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.3.5"]
+dependencies = ["mcp", "direct-cli>=0.3.6"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -7,6 +7,31 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
 
+CAMPAIGN_GET_SELECTOR_FLAGS = (
+    ("text_campaign_fields", "--text-campaign-fields"),
+    (
+        "text_campaign_search_strategy_placement_types_fields",
+        "--text-campaign-search-strategy-placement-types-fields",
+    ),
+    ("mobile_app_campaign_fields", "--mobile-app-campaign-fields"),
+    ("dynamic_text_campaign_fields", "--dynamic-text-campaign-fields"),
+    (
+        "dynamic_text_campaign_search_strategy_placement_types_fields",
+        "--dynamic-text-campaign-search-strategy-placement-types-fields",
+    ),
+    ("cpm_banner_campaign_fields", "--cpm-banner-campaign-fields"),
+    ("smart_campaign_fields", "--smart-campaign-fields"),
+    ("unified_campaign_fields", "--unified-campaign-fields"),
+    (
+        "unified_campaign_search_strategy_placement_types_fields",
+        "--unified-campaign-search-strategy-placement-types-fields",
+    ),
+    (
+        "unified_campaign_package_bidding_strategy_platforms_fields",
+        "--unified-campaign-package-bidding-strategy-platforms-fields",
+    ),
+)
+
 
 @mcp.tool(name="campaigns_get")
 @handle_cli_errors
@@ -15,6 +40,17 @@ def campaigns_list(
     ids: str | None = None,
     status: str | None = None,
     types: str | None = None,
+    fields: str | None = None,
+    text_campaign_fields: str | None = None,
+    text_campaign_search_strategy_placement_types_fields: str | None = None,
+    mobile_app_campaign_fields: str | None = None,
+    dynamic_text_campaign_fields: str | None = None,
+    dynamic_text_campaign_search_strategy_placement_types_fields: str | None = None,
+    cpm_banner_campaign_fields: str | None = None,
+    smart_campaign_fields: str | None = None,
+    unified_campaign_fields: str | None = None,
+    unified_campaign_search_strategy_placement_types_fields: str | None = None,
+    unified_campaign_package_bidding_strategy_platforms_fields: str | None = None,
 ) -> list[dict] | dict:
     """List advertising campaigns, optionally filtered.
 
@@ -24,6 +60,21 @@ def campaigns_list(
         ids: Comma-separated campaign IDs (optional, max 10).
         status: Filter by status, e.g. "ACTIVE", "SUSPENDED" (optional).
         types: Filter by types, e.g. "TEXT_CAMPAIGN" (optional).
+        fields: Comma-separated common campaign FieldNames (optional).
+        text_campaign_fields: Comma-separated TextCampaignFieldNames (optional).
+        text_campaign_search_strategy_placement_types_fields: Comma-separated
+            TextCampaignSearchStrategyPlacementTypesFieldNames (optional).
+        mobile_app_campaign_fields: Comma-separated MobileAppCampaignFieldNames (optional).
+        dynamic_text_campaign_fields: Comma-separated DynamicTextCampaignFieldNames (optional).
+        dynamic_text_campaign_search_strategy_placement_types_fields: Comma-separated
+            DynamicTextCampaignSearchStrategyPlacementTypesFieldNames (optional).
+        cpm_banner_campaign_fields: Comma-separated CpmBannerCampaignFieldNames (optional).
+        smart_campaign_fields: Comma-separated SmartCampaignFieldNames (optional).
+        unified_campaign_fields: Comma-separated UnifiedCampaignFieldNames (optional).
+        unified_campaign_search_strategy_placement_types_fields: Comma-separated
+            UnifiedCampaignSearchStrategyPlacementTypesFieldNames (optional).
+        unified_campaign_package_bidding_strategy_platforms_fields: Comma-separated
+            UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames (optional).
     """
     if state is not None and state not in ("ON", "OFF"):
         return ToolError(
@@ -42,6 +93,13 @@ def campaigns_list(
         args.extend(["--status", status])
     if types is not None:
         args.extend(["--types", types])
+    if fields is not None:
+        args.extend(["--fields", fields])
+    local_values = locals()
+    for option_name, cli_flag in CAMPAIGN_GET_SELECTOR_FLAGS:
+        value = local_values[option_name]
+        if value is not None:
+            args.extend([cli_flag, value])
 
     runner = get_runner()
     result = runner.run_json(args)

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -177,7 +177,9 @@ class TestCampaignsList:
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_list()
 
-        runner.run_json.assert_called_once_with(["campaigns", "get", "--format", "json"])
+        runner.run_json.assert_called_once_with(
+            ["campaigns", "get", "--format", "json"]
+        )
 
 
 class TestCampaignsUpdate:

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -79,6 +79,106 @@ class TestCampaignsList:
             ["campaigns", "get", "--format", "json", "--ids", "12345,67890"]
         )
 
+    def test_list_campaigns_text_campaign_fields_argv(self, mock_campaigns):
+        """Test campaign type-specific fields are forwarded to the CLI."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_campaigns
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_list(
+                ids="103258204",
+                fields="Id,Name,State",
+                text_campaign_fields="BiddingStrategy",
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "campaigns",
+                "get",
+                "--format",
+                "json",
+                "--ids",
+                "103258204",
+                "--fields",
+                "Id,Name,State",
+                "--text-campaign-fields",
+                "BiddingStrategy",
+            ]
+        )
+
+    def test_list_campaigns_filters_and_campaign_specific_fields_argv(
+        self, mock_campaigns
+    ):
+        """Test filters and campaign-specific selectors compose in CLI argv."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_campaigns
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_list(
+                ids="12345,67890",
+                fields="Id,Name,State",
+                status="ACCEPTED",
+                types="TEXT_CAMPAIGN",
+                state="ON",
+                text_campaign_fields="BiddingStrategy,PriorityGoals",
+                mobile_app_campaign_fields="Settings",
+                dynamic_text_campaign_fields="BiddingStrategy",
+                dynamic_text_campaign_search_strategy_placement_types_fields=(
+                    "SearchResults,DynamicPlaces"
+                ),
+                cpm_banner_campaign_fields="BiddingStrategy",
+                smart_campaign_fields="Settings",
+                unified_campaign_fields="BiddingStrategy",
+                unified_campaign_search_strategy_placement_types_fields=(
+                    "SearchResults,Maps"
+                ),
+                unified_campaign_package_bidding_strategy_platforms_fields=(
+                    "SearchResult,Network"
+                ),
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "campaigns",
+                "get",
+                "--format",
+                "json",
+                "--ids",
+                "12345,67890",
+                "--status",
+                "ACCEPTED",
+                "--types",
+                "TEXT_CAMPAIGN",
+                "--fields",
+                "Id,Name,State",
+                "--text-campaign-fields",
+                "BiddingStrategy,PriorityGoals",
+                "--mobile-app-campaign-fields",
+                "Settings",
+                "--dynamic-text-campaign-fields",
+                "BiddingStrategy",
+                "--dynamic-text-campaign-search-strategy-placement-types-fields",
+                "SearchResults,DynamicPlaces",
+                "--cpm-banner-campaign-fields",
+                "BiddingStrategy",
+                "--smart-campaign-fields",
+                "Settings",
+                "--unified-campaign-fields",
+                "BiddingStrategy",
+                "--unified-campaign-search-strategy-placement-types-fields",
+                "SearchResults,Maps",
+                "--unified-campaign-package-bidding-strategy-platforms-fields",
+                "SearchResult,Network",
+            ]
+        )
+
+    def test_list_campaigns_legacy_argv_unchanged(self, mock_campaigns):
+        """Test old campaigns_get() calls do not add selector flags."""
+        runner = MagicMock()
+        runner.run_json.return_value = mock_campaigns
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_list()
+
+        runner.run_json.assert_called_once_with(["campaigns", "get", "--format", "json"])
+
 
 class TestCampaignsUpdate:
     """Test scenarios 9-10."""


### PR DESCRIPTION
## Summary
- add `campaigns_get` parameters for campaign-specific field selectors
- forward the new parameters to matching `direct campaigns get` flags
- require `direct-cli>=0.3.6` for the selector contract

Closes #80.

## Tests
- `python3 -m pytest tests/test_campaigns.py tests/test_server.py`
- `python3 -m ruff check server/tools/campaigns.py tests/test_campaigns.py`