### PR TITLE
Align plugin with direct-cli 0.3.9 (typed ads/keywords/campaigns flags)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,7 +371,7 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - API batch limit: max 10 IDs per request
 - Campaign IDs ~73-77M range belong to a second account (foreign_campaign error)
 - OAuth tokens are stored by `direct-cli` profiles, normally in `~/.direct-cli/auth.json`.
-- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.8`.
+- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.9`.
 - `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
 
@@ -459,3 +459,42 @@ were updated accordingly:
   for diagnosing API warning 10165 ("parameter will not be applied").
 - **New tools**: 4 `v4forecast_*` (create / list / get / delete) for V4 Live
   budget forecasts.
+
+## Breaking Changes (CLI 0.3.9 alignment)
+
+CLI 0.3.9 added typed flags for the three mutating commands previously
+flagged as gaps in the 0.3.8 section. All three upstream issues
+(`axisrow/direct-cli#202`, `#203`, `#204`) are now closed. The plugin
+exposes these flags without any breaking change to existing callers —
+all new parameters are optional.
+
+- **`ads_add`** / **`ads_update`**: 7 new optional fields covering the
+  rest of `TextAdAddItem` / `TextAdUpdateItem`: `title2`,
+  `display_url_path`, `mobile` (YES / NO), `vcard_id`,
+  `sitelink_set_id`, `turbo_page_id`, `ad_extensions` (comma-separated
+  IDs). The plugin validates `mobile ∈ {YES, NO}` before invoking the
+  CLI; every other field/type compatibility check stays on the CLI side.
+  `image_hash` is now valid for `TEXT_AD` (was previously documented as
+  TEXT_IMAGE_AD / MOBILE_APP_AD only).
+- **`keywords_add`**: batch mode through `from_file` (path to a JSONL
+  file) or `keywords_json` (inline JSON array). Mutex with the single
+  `keyword` form — passing zero or more than one of the three returns
+  `ToolError(error="missing_mode" | "conflicting_modes")` without
+  invoking the CLI. Per-row WSDL CamelCase keys
+  (`AdGroupId`, `Keyword`, `Bid`, `ContextBid`, `UserParam1`,
+  `UserParam2`); top-level `ad_group_id` acts as a default that each row
+  can override. CLI 0.3.9 forwards the array as a single Yandex Direct
+  API request (up to 1000 keywords per call). The plugin does not read
+  `from_file` itself — CLI opens the path.
+- **`campaigns_add`**: 8 new optional fields for CPA strategies and
+  cross-cutting `CampaignAddItem` configuration: `counter_ids`
+  (csv for TextCampaign / DynamicText), `goal_id`, `priority_goals`
+  (csv `goal_id:value`), `average_cpa`, `crr`, `bid_ceiling`,
+  `notification_json`, `time_targeting_json`. Strategy-subtype
+  compatibility (`--crr` only on `PAY_FOR_CONVERSION_CRR`,
+  `--priority-goals` only on `*_MULTIPLE_GOALS`, `--counter-ids` not for
+  Smart, etc.) is enforced by CLI `UsageError` and propagates through
+  `handle_cli_errors` — the plugin does not duplicate cross-field
+  validation.
+
+Closes plugin issues `#110`, `#111`, `#112`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yandex-direct-mcp-plugin"
 version = "0.1.11"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.3.8"]
+dependencies = ["mcp", "direct-cli>=0.3.9"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -6,6 +6,7 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 MAX_BATCH_SIZE = 10
 FOREIGN_CAMPAIGN_MIN = 73_000_000
 FOREIGN_CAMPAIGN_MAX = 77_999_999
+MOBILE_VALUES = ("YES", "NO")
 
 
 def _parse_ids(ids_str: str) -> list[str]:
@@ -165,21 +166,25 @@ def ads_add(
     tracking_url: str | None = None,
     action: str | None = None,
     age_label: str | None = None,
+    title2: str | None = None,
+    display_url_path: str | None = None,
+    mobile: str | None = None,
+    vcard_id: int | None = None,
+    sitelink_set_id: int | None = None,
+    turbo_page_id: int | None = None,
+    ad_extensions: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Create a new ad.
 
-    CLI 0.3.8 enforces strict WSDL parity — invalid field/type combinations
+    CLI 0.3.9 enforces strict WSDL parity — invalid field/type combinations
     (e.g. TEXT_IMAGE_AD + title, MOBILE_APP_AD + href) are rejected by the CLI,
     not by this tool. Field/type compatibility:
 
-    - TEXT_AD: title, text, href.
-    - TEXT_IMAGE_AD: href, image_hash.
+    - TEXT_AD: title, text, href, title2, display_url_path, mobile, vcard_id,
+      sitelink_set_id, turbo_page_id, ad_extensions, image_hash.
+    - TEXT_IMAGE_AD: href, image_hash, turbo_page_id.
     - MOBILE_APP_AD: title, text, image_hash, tracking_url, action, age_label.
-
-    Note: fields not yet covered by typed CLI flags (Title2, SitelinkSetId,
-    AdExtensions, VCardId, TurboPageId, DisplayUrlPath, Mobile) must be filled
-    in via the Direct web UI after `ads_add` — see direct-cli upstream issue.
 
     Args:
         ad_group_id: Ad group ID to add the ad to.
@@ -187,12 +192,25 @@ def ads_add(
         title: Ad title (TEXT_AD / MOBILE_APP_AD).
         text: Ad text content (TEXT_AD / MOBILE_APP_AD).
         href: Ad URL (TEXT_AD / TEXT_IMAGE_AD).
-        image_hash: Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD).
+        image_hash: Ad image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD).
         tracking_url: MOBILE_APP_AD tracking URL.
         action: MOBILE_APP_AD call-to-action (MobileAppAdActionEnum, e.g. INSTALL).
         age_label: MOBILE_APP_AD age label (MobAppAgeLabelEnum).
+        title2: Second headline (TEXT_AD).
+        display_url_path: Display URL path (TEXT_AD).
+        mobile: "YES" or "NO" — mobile-only ad flag (TEXT_AD).
+        vcard_id: VCard ID (TEXT_AD).
+        sitelink_set_id: Sitelink set ID (TEXT_AD).
+        turbo_page_id: Turbo page ID (TEXT_AD / TEXT_IMAGE_AD).
+        ad_extensions: Comma-separated ad extension IDs (TEXT_AD).
         dry_run: Show the direct-cli request without sending it.
     """
+    if mobile is not None and mobile not in MOBILE_VALUES:
+        return ToolError(
+            error="invalid_mobile",
+            message=f"mobile must be one of {MOBILE_VALUES}; got '{mobile}'",
+        ).__dict__
+
     args = ["ads", "add", "--adgroup-id", str(ad_group_id)]
     if ad_type:
         args.extend(["--type", ad_type])
@@ -210,6 +228,20 @@ def ads_add(
         args.extend(["--action", action])
     if age_label:
         args.extend(["--age-label", age_label])
+    if title2:
+        args.extend(["--title2", title2])
+    if display_url_path:
+        args.extend(["--display-url-path", display_url_path])
+    if mobile is not None:
+        args.extend(["--mobile", mobile])
+    if vcard_id is not None:
+        args.extend(["--vcard-id", str(vcard_id)])
+    if sitelink_set_id is not None:
+        args.extend(["--sitelink-set-id", str(sitelink_set_id)])
+    if turbo_page_id is not None:
+        args.extend(["--turbo-page-id", str(turbo_page_id)])
+    if ad_extensions:
+        args.extend(["--ad-extensions", ad_extensions])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()
@@ -228,16 +260,25 @@ def ads_update(
     tracking_url: str | None = None,
     action: str | None = None,
     age_label: str | None = None,
+    title2: str | None = None,
+    display_url_path: str | None = None,
+    mobile: str | None = None,
+    vcard_id: int | None = None,
+    sitelink_set_id: int | None = None,
+    turbo_page_id: int | None = None,
+    ad_extensions: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update an ad.
 
     CLI 0.3.8 made `--type` required for `ads update` and removed the
     `--status` flag (use `ads_suspend / ads_resume / ads_archive /
-    ads_unarchive` for status changes). Field/type compatibility:
+    ads_unarchive` for status changes). CLI 0.3.9 added typed flags for
+    every TextAdUpdateItem WSDL field. Field/type compatibility:
 
-    - TEXT_AD: title, text, href.
-    - TEXT_IMAGE_AD: href, image_hash.
+    - TEXT_AD: title, text, href, title2, display_url_path, mobile, vcard_id,
+      sitelink_set_id, turbo_page_id, ad_extensions, image_hash.
+    - TEXT_IMAGE_AD: href, image_hash, turbo_page_id.
     - MOBILE_APP_AD: title, text, image_hash, tracking_url, action, age_label.
 
     Args:
@@ -246,20 +287,51 @@ def ads_update(
         title: Optional new title (TEXT_AD / MOBILE_APP_AD).
         text: Optional new text (TEXT_AD / MOBILE_APP_AD).
         href: Optional new URL (TEXT_AD / TEXT_IMAGE_AD).
-        image_hash: Optional new image hash (TEXT_IMAGE_AD / MOBILE_APP_AD).
+        image_hash: Optional new image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD).
         tracking_url: Optional MOBILE_APP_AD tracking URL.
         action: Optional MOBILE_APP_AD call-to-action.
         age_label: Optional MOBILE_APP_AD age label.
+        title2: Optional second headline (TEXT_AD).
+        display_url_path: Optional display URL path (TEXT_AD).
+        mobile: Optional "YES"/"NO" mobile-only ad flag (TEXT_AD).
+        vcard_id: Optional VCard ID (TEXT_AD).
+        sitelink_set_id: Optional sitelink set ID (TEXT_AD).
+        turbo_page_id: Optional Turbo page ID (TEXT_AD / TEXT_IMAGE_AD).
+        ad_extensions: Optional comma-separated ad extension IDs (TEXT_AD).
         dry_run: Show the direct-cli request without sending it.
     """
-    if not any((title, text, href, image_hash, tracking_url, action, age_label)):
+    if not any(
+        (
+            title,
+            text,
+            href,
+            image_hash,
+            tracking_url,
+            action,
+            age_label,
+            title2,
+            display_url_path,
+            mobile,
+            vcard_id,
+            sitelink_set_id,
+            turbo_page_id,
+            ad_extensions,
+        )
+    ):
         return ToolError(
             error="missing_update_fields",
             message=(
                 "Provide at least one of: title, text, href, image_hash, "
-                "tracking_url, action, age_label. For status changes use "
-                "ads_suspend / ads_resume / ads_archive / ads_unarchive."
+                "tracking_url, action, age_label, title2, display_url_path, "
+                "mobile, vcard_id, sitelink_set_id, turbo_page_id, "
+                "ad_extensions. For status changes use ads_suspend / "
+                "ads_resume / ads_archive / ads_unarchive."
             ),
+        ).__dict__
+    if mobile is not None and mobile not in MOBILE_VALUES:
+        return ToolError(
+            error="invalid_mobile",
+            message=f"mobile must be one of {MOBILE_VALUES}; got '{mobile}'",
         ).__dict__
 
     args = ["ads", "update", "--id", str(id), "--type", type]
@@ -277,6 +349,20 @@ def ads_update(
         args.extend(["--action", action])
     if age_label:
         args.extend(["--age-label", age_label])
+    if title2:
+        args.extend(["--title2", title2])
+    if display_url_path:
+        args.extend(["--display-url-path", display_url_path])
+    if mobile is not None:
+        args.extend(["--mobile", mobile])
+    if vcard_id is not None:
+        args.extend(["--vcard-id", str(vcard_id)])
+    if sitelink_set_id is not None:
+        args.extend(["--sitelink-set-id", str(sitelink_set_id)])
+    if turbo_page_id is not None:
+        args.extend(["--turbo-page-id", str(turbo_page_id)])
+    if ad_extensions:
+        args.extend(["--ad-extensions", ad_extensions])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -220,16 +220,23 @@ def campaigns_add(
     settings: list[str] | None = None,
     filter_average_cpc: int | None = None,
     counter_id: int | None = None,
+    counter_ids: str | None = None,
+    goal_id: int | None = None,
+    priority_goals: str | None = None,
+    average_cpa: int | None = None,
+    crr: int | None = None,
+    bid_ceiling: int | None = None,
+    notification_json: str | None = None,
+    time_targeting_json: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Create a new campaign.
 
-    CLI 0.3.8 removed the free-form `--json` flag from `campaigns add`. Use
-    `--search-strategy` / `--network-strategy` / `--setting` typed flags.
-
-    Note: CLI 0.3.8 does not yet expose Goals (CPA pay-for-conversion),
-    Notification, NetworkSettings or TimeTargeting — these have to be set
-    via the Direct web UI after `campaigns_add` until a future CLI release.
+    CLI 0.3.9 enforces strict WSDL parity for CPA strategies. Incompatible
+    combinations (e.g. `--crr` on AVERAGE_CPA, `--priority-goals` without a
+    `*_MULTIPLE_GOALS` strategy, `--counter-ids` on Smart) are rejected by the
+    CLI with `UsageError` before any API call — the plugin does not duplicate
+    these cross-field checks.
 
     Args:
         name: Campaign name.
@@ -246,7 +253,23 @@ def campaigns_add(
             (e.g. ["EnableEmailNotification=YES", "RequireServicing=NO"]).
         filter_average_cpc: Optional Smart campaign filter average CPC in micro-units
             (RUB × 1,000,000); CLI 0.2.10+ rejects values 0 < x < 100_000.
-        counter_id: Optional Smart campaign Metrica counter ID.
+        counter_id: Optional Smart campaign Metrika counter ID (single).
+        counter_ids: Optional comma-separated Metrika counter IDs for
+            TextCampaign / DynamicTextCampaign (`CounterIds`).
+        goal_id: Optional single Metrika goal ID for AVERAGE_CPA /
+            PAY_FOR_CONVERSION_CRR / AVERAGE_CPA_PER_CAMPAIGN /
+            AVERAGE_CPA_PER_FILTER strategies.
+        priority_goals: Optional comma-separated 'goal_id:value' pairs for
+            AVERAGE_CPA_MULTIPLE_GOALS / PAY_FOR_CONVERSION_MULTIPLE_GOALS.
+        average_cpa: Optional target CPA in micro-units (RUB × 1,000,000)
+            for AVERAGE_CPA strategies.
+        crr: Optional cost-revenue-ratio percentage for PAY_FOR_CONVERSION_CRR.
+        bid_ceiling: Optional bid ceiling in micro-units for the chosen
+            CPA strategy.
+        notification_json: Optional JSON for `CampaignBase.Notification`
+            ({"SmsSettings": {...}, "EmailSettings": {...}}).
+        time_targeting_json: Optional JSON for `CampaignAddItem.TimeTargeting`
+            ({"Schedule": [...], "ConsiderWorkingWeekends": "YES|NO", ...}).
         dry_run: Show the direct-cli request without sending it.
     """
     args = ["campaigns", "add", "--name", name, "--start-date", start_date]
@@ -267,6 +290,22 @@ def campaigns_add(
         args.extend(["--filter-average-cpc", str(filter_average_cpc)])
     if counter_id is not None:
         args.extend(["--counter-id", str(counter_id)])
+    if counter_ids:
+        args.extend(["--counter-ids", counter_ids])
+    if goal_id is not None:
+        args.extend(["--goal-id", str(goal_id)])
+    if priority_goals:
+        args.extend(["--priority-goals", priority_goals])
+    if average_cpa is not None:
+        args.extend(["--average-cpa", str(average_cpa)])
+    if crr is not None:
+        args.extend(["--crr", str(crr)])
+    if bid_ceiling is not None:
+        args.extend(["--bid-ceiling", str(bid_ceiling)])
+    if notification_json:
+        args.extend(["--notification", notification_json])
+    if time_targeting_json:
+        args.extend(["--time-targeting", time_targeting_json])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -153,31 +153,72 @@ def keywords_update(
 @mcp.tool()
 @handle_cli_errors
 def keywords_add(
-    ad_group_id: int,
-    keyword: str,
+    ad_group_id: int | None = None,
+    keyword: str | None = None,
     bid: int | None = None,
     context_bid: int | None = None,
     user_param_1: str | None = None,
     user_param_2: str | None = None,
+    from_file: str | None = None,
+    keywords_json: str | None = None,
     dry_run: bool = False,
 ) -> dict:
-    """Add a keyword to an ad group.
+    """Add one or many keywords to an ad group.
 
-    Note: this tool adds one keyword per invocation. Bulk-loading 100+
-    keywords is currently slow because direct-cli has no batch mode — see
-    upstream issue for `keywords add --from-file`.
+    Three mutually exclusive modes (CLI 0.3.9):
+
+    1. Single: ad_group_id + keyword (+ optional bid / context_bid / user_params).
+    2. JSONL batch: from_file = path to a .jsonl file, one keyword object per line.
+       Per-line schema (WSDL CamelCase): {"AdGroupId": int, "Keyword": str,
+       "Bid": int (micro-RUB), "ContextBid": int, "UserParam1": str,
+       "UserParam2": str}. Per-line AdGroupId overrides the top-level
+       ad_group_id default.
+    3. Inline JSON: keywords_json = a JSON array of the same objects.
+
+    CLI 0.3.9 forwards the array as a single Yandex Direct API request (up to
+    1000 keywords per call).
 
     Args:
-        ad_group_id: Ad group ID to add the keyword to.
-        keyword: Keyword text.
+        ad_group_id: Ad group ID. Required in single mode; optional default
+            in batch modes (each row's AdGroupId wins).
+        keyword: Keyword text (single mode only).
         bid: Optional search bid in micro-units (RUB × 1,000,000); CLI 0.2.10+
             rejects values 0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         context_bid: Optional context bid in micro-units (same rules as `bid`).
         user_param_1: Optional user parameter 1.
         user_param_2: Optional user parameter 2.
+        from_file: Path to a JSONL file with keyword objects (batch mode).
+        keywords_json: Inline JSON array of keyword objects (batch mode).
         dry_run: Show the direct-cli request without sending it.
     """
-    args = ["keywords", "add", "--adgroup-id", str(ad_group_id), "--keyword", keyword]
+    modes = (bool(keyword), bool(from_file), bool(keywords_json))
+    mode_count = sum(modes)
+    if mode_count == 0:
+        return ToolError(
+            error="missing_mode",
+            message=(
+                "Provide exactly one of: keyword (single), from_file (JSONL), "
+                "or keywords_json (inline JSON array)."
+            ),
+        ).__dict__
+    if mode_count > 1:
+        return ToolError(
+            error="conflicting_modes",
+            message=(
+                "keyword, from_file and keywords_json are mutually exclusive — "
+                "pass exactly one."
+            ),
+        ).__dict__
+
+    args = ["keywords", "add"]
+    if ad_group_id is not None:
+        args.extend(["--adgroup-id", str(ad_group_id)])
+    if keyword:
+        args.extend(["--keyword", keyword])
+    if from_file:
+        args.extend(["--from-file", from_file])
+    if keywords_json:
+        args.extend(["--keywords-json", keywords_json])
     if bid is not None:
         args.extend(["--bid", str(bid)])
     if context_bid is not None:

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -344,3 +344,169 @@ class TestAdsCrudOperations:
         result = ads_unarchive(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
+
+
+class TestAdsTypedTextAdFields:
+    """CLI 0.3.9: typed TextAd fields (title2, sitelinks, ad_extensions, etc)."""
+
+    def test_ads_add_passes_title2(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                title2="Second headline",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--title2" in argv
+        assert "Second headline" in argv
+
+    def test_ads_add_passes_display_url_path(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                display_url_path="catalog/items",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--display-url-path" in argv
+        assert "catalog/items" in argv
+
+    def test_ads_add_passes_mobile_yes(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                mobile="YES",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--mobile" in argv
+        assert "YES" in argv
+
+    def test_ads_add_rejects_mobile_invalid_value(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            result = ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                mobile="FOO",
+            )
+        assert isinstance(result, dict)
+        assert result["error"] == "invalid_mobile"
+        runner.run_json.assert_not_called()
+
+    def test_ads_add_passes_vcard_id(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                vcard_id=42,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--vcard-id" in argv
+        assert "42" in argv
+
+    def test_ads_add_passes_sitelink_set_id(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                sitelink_set_id=7,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--sitelink-set-id" in argv
+        assert "7" in argv
+
+    def test_ads_add_passes_turbo_page_id(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                turbo_page_id=12345,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--turbo-page-id" in argv
+        assert "12345" in argv
+
+    def test_ads_add_passes_ad_extensions(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_add(
+                ad_group_id=1,
+                ad_type="TEXT_AD",
+                title="t",
+                text="x",
+                href="https://x",
+                ad_extensions="111,222,333",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--ad-extensions" in argv
+        assert "111,222,333" in argv
+
+    def test_ads_update_passes_typed_text_ad_fields(self):
+        runner = _mock_runner({"Id": 555})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            ads_update(
+                id=555,
+                type="TEXT_AD",
+                title2="b",
+                display_url_path="path",
+                mobile="NO",
+                vcard_id=1,
+                sitelink_set_id=2,
+                turbo_page_id=3,
+                ad_extensions="100,200",
+            )
+        argv = runner.run_json.call_args[0][0]
+        for flag, value in (
+            ("--title2", "b"),
+            ("--display-url-path", "path"),
+            ("--mobile", "NO"),
+            ("--vcard-id", "1"),
+            ("--sitelink-set-id", "2"),
+            ("--turbo-page-id", "3"),
+            ("--ad-extensions", "100,200"),
+        ):
+            assert flag in argv, f"{flag} missing from argv"
+            assert value in argv, f"{value} missing from argv"
+
+    def test_ads_update_rejects_mobile_invalid_value(self):
+        runner = _mock_runner({"Id": 555})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            result = ads_update(id=555, type="TEXT_AD", mobile="FOO")
+        assert isinstance(result, dict)
+        assert result["error"] == "invalid_mobile"
+        runner.run_json.assert_not_called()
+
+    def test_ads_update_typed_field_alone_satisfies_change_check(self):
+        """title2 alone counts as a meaningful update — not 'missing_update_fields'."""
+        runner = _mock_runner({"Id": 555})
+        with patch("server.tools.ads.get_runner", return_value=runner):
+            result = ads_update(id=555, type="TEXT_AD", title2="b")
+        assert result["Id"] == 555
+        argv = runner.run_json.call_args[0][0]
+        assert "--title2" in argv

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -329,6 +329,113 @@ class TestCampaignsCrudOperations:
             argv = runner.run_json.call_args[0][0]
             assert "--dry-run" in argv
 
+    def test_campaigns_add_passes_counter_ids(self):
+        """CLI 0.3.9: --counter-ids for TextCampaign/DynamicText."""
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                counter_ids="111,222",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--counter-ids" in argv
+        assert "111,222" in argv
+
+    def test_campaigns_add_passes_goal_id(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                goal_id=12345,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--goal-id" in argv
+        assert "12345" in argv
+
+    def test_campaigns_add_passes_priority_goals(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                priority_goals="123:50,456:30",
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--priority-goals" in argv
+        assert "123:50,456:30" in argv
+
+    def test_campaigns_add_passes_average_cpa(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                average_cpa=500_000_000,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--average-cpa" in argv
+        assert "500000000" in argv
+
+    def test_campaigns_add_passes_crr(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                crr=15,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--crr" in argv
+        assert "15" in argv
+
+    def test_campaigns_add_passes_bid_ceiling(self):
+        runner = _mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                bid_ceiling=200_000_000,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--bid-ceiling" in argv
+        assert "200000000" in argv
+
+    def test_campaigns_add_passes_notification_json(self):
+        runner = _mock_runner({"Id": 1})
+        payload = '{"SmsSettings":{"Events":["FINISHED"]}}'
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                notification_json=payload,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--notification" in argv
+        assert payload in argv
+
+    def test_campaigns_add_passes_time_targeting_json(self):
+        runner = _mock_runner({"Id": 1})
+        payload = '{"ConsiderWorkingWeekends":"YES"}'
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                time_targeting_json=payload,
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--time-targeting" in argv
+        assert payload in argv
+
     def test_campaigns_delete_success(self):
         """Test deleting campaigns successfully."""
         runner = _mock_runner({"success": True})

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -164,6 +164,70 @@ class TestKeywordsCrudOperations:
             argv = runner.run_json.call_args[0][0]
             assert "--dry-run" in argv
 
+    def test_keywords_add_passes_from_file(self):
+        """CLI 0.3.9: JSONL batch via --from-file."""
+        runner = _mock_runner({"AddResults": [{"Id": 1}, {"Id": 2}]})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            keywords_add(from_file="/tmp/k.jsonl")
+            argv = runner.run_json.call_args[0][0]
+            assert "--from-file" in argv
+            assert "/tmp/k.jsonl" in argv
+            assert "--keyword" not in argv
+            assert "--keywords-json" not in argv
+
+    def test_keywords_add_passes_keywords_json(self):
+        """CLI 0.3.9: inline JSON batch via --keywords-json."""
+        runner = _mock_runner({"AddResults": [{"Id": 1}]})
+        payload = '[{"AdGroupId":1,"Keyword":"foo"}]'
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            keywords_add(keywords_json=payload)
+            argv = runner.run_json.call_args[0][0]
+            assert "--keywords-json" in argv
+            assert payload in argv
+
+    def test_keywords_add_batch_with_default_adgroup_id(self):
+        """ad_group_id is forwarded as default in batch mode."""
+        runner = _mock_runner({"AddResults": []})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            keywords_add(
+                ad_group_id=42,
+                keywords_json='[{"Keyword":"x"}]',
+            )
+            argv = runner.run_json.call_args[0][0]
+            assert "--adgroup-id" in argv
+            assert "42" in argv
+            assert "--keywords-json" in argv
+
+    def test_keywords_add_rejects_no_mode(self):
+        """Neither keyword nor batch flag → missing_mode, runner not invoked."""
+        runner = _mock_runner({"AddResults": []})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            result = keywords_add(ad_group_id=1)
+        assert isinstance(result, dict)
+        assert result["error"] == "missing_mode"
+        runner.run_json.assert_not_called()
+
+    def test_keywords_add_rejects_conflicting_modes(self):
+        """keyword + from_file → conflicting_modes, runner not invoked."""
+        runner = _mock_runner({"AddResults": []})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            result = keywords_add(keyword="x", from_file="/tmp/k.jsonl")
+        assert isinstance(result, dict)
+        assert result["error"] == "conflicting_modes"
+        runner.run_json.assert_not_called()
+
+    def test_keywords_add_rejects_all_three_modes(self):
+        """All three modes set → conflicting_modes."""
+        runner = _mock_runner({"AddResults": []})
+        with patch("server.tools.keywords.get_runner", return_value=runner):
+            result = keywords_add(
+                keyword="x",
+                from_file="/tmp/k.jsonl",
+                keywords_json="[{}]",
+            )
+        assert result["error"] == "conflicting_modes"
+        runner.run_json.assert_not_called()
+
     def test_keywords_delete_success(self):
         """Test deleting keywords successfully."""
         runner = _mock_runner({"success": True})


### PR DESCRIPTION
## Summary

- Exposes the 15 typed flags that `direct-cli` 0.3.9 added (direct-cli#216, #218, #219), closing upstream issues #202 / #203 / #204 that were tracked in our 0.3.8 alignment.
- All new MCP parameters are optional → no breaking change for existing callers; cross-field strategy validation stays on the CLI side per project policy.
- 25 new mock-based tests on flag propagation and mutex validation.

### What's exposed

| Tool | New parameters |
|---|---|
| `ads_add` / `ads_update` | `title2`, `display_url_path`, `mobile` (YES/NO, validated), `vcard_id`, `sitelink_set_id`, `turbo_page_id`, `ad_extensions` |
| `keywords_add` | `from_file` (JSONL), `keywords_json` (inline JSON array); three modes mutex with `keyword` — bad combos return `missing_mode` / `conflicting_modes` without invoking the runner |
| `campaigns_add` | `counter_ids`, `goal_id`, `priority_goals`, `average_cpa`, `crr`, `bid_ceiling`, `notification_json`, `time_targeting_json` |

`pyproject.toml` pin bumped to `direct-cli>=0.3.9`. `CLAUDE.md` gets a fresh "Breaking Changes (CLI 0.3.9 alignment)" section; old upstream gap notes ("not yet covered by typed CLI flags", "one keyword per invocation", "does not yet expose Goals") removed from docstrings.

## Test plan

- [x] `pytest -q` — 514 passed / 7 skipped
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy .` — no issues in 94 source files
- [ ] Smoke through Claude Code MCP: `ads_add(..., title2="...", sitelink_set_id=N, dry_run=True)`, `keywords_add(keywords_json='[...]', dry_run=True)`, `campaigns_add(..., goal_id=N, average_cpa=N, dry_run=True)` — verify argv contains expected typed flags.

Closes #110
Closes #111
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)