### PR TITLE
feat: align with direct-cli 0.3.10 (closes #114 pts 1, 3, 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ skills/                     — domain knowledge (SKILL.md files)
 MCP → direct → tapi-yandex-direct → Yandex.Direct API
 ```
 
-- MCP **never** calls Yandex.Direct directly.
+- MCP **never** calls Yandex.Direct directly. This is absolute — even as a workaround for a missing/broken CLI feature, the plugin does not bypass `direct-cli` via `urllib`, raw HTTP, or `tapi-yandex-direct` imports. If CLI lacks something, file an upstream issue in `axisrow/direct-cli` and wait for the release.
 - `direct` is the only execution/transport boundary.
 - `tapi-yandex-direct` naming is the default source reused by the CLI.
 - WSDL / Reports spec wins when CLI convenience names drift.
@@ -369,9 +369,8 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 
 - All money parameters (bids, budgets, CPC/CPA, ceilings) are in **micro-units**: 15 RUB = 15,000,000. CLI 0.2.10+ rejects values `0 < x < 100_000` with a "did you mean × 1_000_000?" hint.
 - API batch limit: max 10 IDs per request
-- Campaign IDs ~73-77M range belong to a second account (foreign_campaign error)
 - OAuth tokens are stored by `direct-cli` profiles, normally in `~/.direct-cli/auth.json`.
-- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.9`.
+- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.10`.
 - `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yandex-direct-mcp-plugin"
 version = "0.1.12"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.3.9"]
+dependencies = ["mcp", "direct-cli>=0.3.10"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -79,8 +79,7 @@ _HINTS_BY_ERROR_CODE: dict[int, str] = {
     ),
     8800: (
         "Object not found. Either the ID is wrong or it belongs to a "
-        "different client. For ads_*, the plugin already pre-checks foreign "
-        "campaign IDs — for other tools, verify with a *_get call."
+        "different client. Verify with a *_get call."
     ),
     9300: (
         "Too many objects in one request. Yandex API caps batch size at "

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -4,8 +4,6 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 MAX_BATCH_SIZE = 10
-FOREIGN_CAMPAIGN_MIN = 73_000_000
-FOREIGN_CAMPAIGN_MAX = 77_999_999
 MOBILE_VALUES = ("YES", "NO")
 
 
@@ -22,18 +20,6 @@ def _check_batch_limit(ids_str: str) -> ToolError | None:
             error="batch_limit",
             message=f"Maximum {MAX_BATCH_SIZE} IDs per request. Got: {len(ids)}",
         )
-    return None
-
-
-def _get_foreign_campaign_id(ids_str: str) -> str | None:
-    """Return the first campaign ID in the foreign account range (73M-77M), or None."""
-    for id_str in _parse_ids(ids_str):
-        try:
-            cid = int(id_str)
-            if FOREIGN_CAMPAIGN_MIN <= cid <= FOREIGN_CAMPAIGN_MAX:
-                return id_str
-        except ValueError:
-            continue
     return None
 
 
@@ -88,14 +74,6 @@ def ads_list(
         batch_error = _check_batch_limit(normalized_campaign_ids)
         if batch_error:
             return batch_error.__dict__
-        foreign_id = _get_foreign_campaign_id(normalized_campaign_ids)
-        if foreign_id:
-            return ToolError(
-                error="foreign_campaign",
-                message=(
-                    f"Campaign {foreign_id} is unavailable — belongs to another account"
-                ),
-            ).__dict__
 
     args = ["ads", "get", "--format", "json"]
     if normalized_campaign_ids:

--- a/server/tools/auth_tools.py
+++ b/server/tools/auth_tools.py
@@ -256,11 +256,22 @@ class AuthCredential(BaseModel):
 
 @mcp.tool()
 async def auth_login(
-    ctx: Context, login: str | None = None, profile: str | None = None
+    ctx: Context,
+    login: str | None = None,
+    profile: str | None = None,
+    force: bool = False,
 ) -> dict:
-    """Start interactive OAuth login through direct-cli."""
+    """Start interactive OAuth login through direct-cli.
+
+    Args:
+        login: Optional Yandex.Direct Client-Login to save with the profile.
+        profile: direct-cli profile name (default — active profile).
+        force: Re-run OAuth flow even if the profile is already valid. Use
+            this to switch the active account or to refresh an existing token
+            without manually editing ``~/.direct-cli/auth.json``.
+    """
     status = auth_status(profile)
-    if status.get("valid"):
+    if status.get("valid") and not force:
         return {"already_authenticated": True, **status}
     target_profile = _resolve_profile_name(profile)
 

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -1,8 +1,17 @@
 """MCP tools for sitelinks management."""
 
+import json
+
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
+
+_SITELINK_FIELD_MAP = {
+    "title": "Title",
+    "href": "Href",
+    "description": "Description",
+    "turbo_page_id": "TurboPageId",
+}
 
 
 @mcp.tool(name="sitelinks_get")
@@ -37,29 +46,85 @@ def sitelinks_list(
     return get_runner().run_json(cmd)
 
 
+def _to_wsdl_sitelink(item: dict) -> dict | ToolError:
+    """Convert snake_case dict to WSDL CamelCase keys.
+
+    Unknown keys are rejected to surface typos early.
+    """
+    result: dict = {}
+    for key, value in item.items():
+        wsdl_key = _SITELINK_FIELD_MAP.get(key)
+        if wsdl_key is None:
+            return ToolError(
+                error="unknown_field",
+                message=(
+                    f"Unknown sitelink field {key!r}. "
+                    f"Allowed: {sorted(_SITELINK_FIELD_MAP)}."
+                ),
+            )
+        result[wsdl_key] = value
+    return result
+
+
 @mcp.tool()
 @handle_cli_errors
-def sitelinks_add(sitelinks: list[str], dry_run: bool = False) -> dict:
+def sitelinks_add(
+    sitelinks: list[str] | None = None,
+    items: list[dict] | None = None,
+    from_file: str | None = None,
+    dry_run: bool = False,
+) -> dict:
     """Add a sitelinks set.
 
-    CLI 0.3.8 expects each sitelink as a pipe-delimited string passed via
-    repeatable --sitelink: ``TITLE|HREF[|DESCRIPTION]``.
+    CLI 0.3.10 accepts three mutually exclusive input modes:
+
+    - ``sitelinks`` — list of pipe-delimited specs ``TITLE|HREF[|DESCRIPTION]``,
+      forwarded via repeatable ``--sitelink``. Escape literal ``|`` as ``\\|``
+      (for example, UTM templates with ``cid|{campaign_id}``).
+    - ``items`` — list of dicts with snake_case keys ``title`` / ``href`` /
+      ``description`` / ``turbo_page_id``. The plugin re-keys to WSDL CamelCase
+      and sends them as ``--sitelink-json`` (no pipe escaping needed).
+    - ``from_file`` — path to a JSONL file with one sitelink object per line,
+      forwarded as ``--sitelinks-from-file``.
 
     Args:
-        sitelinks: List of sitelink specs in ``TITLE|HREF[|DESCRIPTION]`` form.
-            Example: ``["About|https://example.com/about|Learn more",
-            "Pricing|https://example.com/pricing"]``.
+        sitelinks: Pipe-delimited specs. Example: ``["About|https://x.com/a|Info"]``.
+        items: Structured objects. Example:
+            ``[{"title": "Главная", "href": "https://x.com/?utm=cid|{cid}"}]``.
+        from_file: Filesystem path passed to direct-cli unchanged.
         dry_run: Show the direct-cli request without sending it.
     """
-    if not sitelinks:
+    modes = [m for m in (sitelinks, items, from_file) if m]
+    if not modes:
         return ToolError(
-            error="missing_sitelinks",
-            message="Provide at least one sitelink spec (TITLE|HREF[|DESCRIPTION]).",
+            error="missing_mode",
+            message=(
+                "Provide exactly one of: sitelinks (list[str]), "
+                "items (list[dict]), or from_file (path)."
+            ),
+        ).__dict__
+    if len(modes) > 1:
+        return ToolError(
+            error="conflicting_modes",
+            message="Pass exactly one of sitelinks, items, or from_file — not several.",
         ).__dict__
 
     args = ["sitelinks", "add"]
-    for spec in sitelinks:
-        args.extend(["--sitelink", spec])
+    if sitelinks is not None:
+        for spec in sitelinks:
+            args.extend(["--sitelink", spec])
+    elif items is not None:
+        wsdl_items: list[dict] = []
+        for item in items:
+            converted = _to_wsdl_sitelink(item)
+            if isinstance(converted, ToolError):
+                return converted.__dict__
+            wsdl_items.append(converted)
+        args.extend(["--sitelink-json", json.dumps(wsdl_items, ensure_ascii=False)])
+    else:
+        assert from_file is not None
+        args.extend(["--sitelinks-from-file", from_file])
+
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -94,8 +94,16 @@ def sitelinks_add(
         from_file: Filesystem path passed to direct-cli unchanged.
         dry_run: Show the direct-cli request without sending it.
     """
-    modes = [m for m in (sitelinks, items, from_file) if m]
-    if not modes:
+    provided = [
+        name
+        for name, value in (
+            ("sitelinks", sitelinks),
+            ("items", items),
+            ("from_file", from_file),
+        )
+        if value is not None
+    ]
+    if not provided:
         return ToolError(
             error="missing_mode",
             message=(
@@ -103,10 +111,28 @@ def sitelinks_add(
                 "items (list[dict]), or from_file (path)."
             ),
         ).__dict__
-    if len(modes) > 1:
+    if len(provided) > 1:
         return ToolError(
             error="conflicting_modes",
-            message="Pass exactly one of sitelinks, items, or from_file — not several.",
+            message=(
+                "Pass exactly one of sitelinks, items, or from_file — "
+                f"got: {', '.join(provided)}."
+            ),
+        ).__dict__
+    if sitelinks is not None and not sitelinks:
+        return ToolError(
+            error="empty_mode",
+            message="sitelinks must contain at least one spec.",
+        ).__dict__
+    if items is not None and not items:
+        return ToolError(
+            error="empty_mode",
+            message="items must contain at least one sitelink object.",
+        ).__dict__
+    if from_file is not None and not from_file:
+        return ToolError(
+            error="empty_mode",
+            message="from_file must be a non-empty path.",
         ).__dict__
 
     args = ["sitelinks", "add"]

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -54,13 +54,6 @@ def test_ads_list_ignores_blank_filters():
         assert "--ids" not in call_args
 
 
-def test_ads_foreign_campaign():
-    """Test 12: Campaign belongs to second account (73-77M range)."""
-    result = ads_list(campaign_ids="75000001")
-    assert "error" in result
-    assert result["error"] == "foreign_campaign"
-
-
 def test_ads_batch_limit():
     """Test 13: Too many IDs."""
     ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -265,6 +265,31 @@ class TestAuthLogin:
         result = asyncio.run(auth_login(MagicMock()))
         assert result["already_authenticated"] is True
 
+    @patch("server.tools.auth_tools.auth_status", return_value={"valid": True})
+    @patch("server.tools.auth_tools._find_direct", return_value="/usr/bin/direct")
+    @patch("server.tools.auth_tools._resolve_profile_name", return_value="default")
+    @patch("server.tools.auth_tools.DirectCliRunner.run")
+    def test_auth_login_force_reauth_when_already_valid(
+        self, mock_run, _mock_resolve, _mock_find, _mock_status
+    ) -> None:
+        mock_run.return_value = _completed(
+            json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
+        )
+        mock_ctx = MagicMock()
+        mock_result = MagicMock()
+        mock_result.action = "decline"
+        mock_result.data = None
+        mock_ctx.elicit = AsyncMock(return_value=mock_result)
+
+        result = asyncio.run(auth_login(mock_ctx, force=True))
+
+        assert result == {"cancelled": True, "message": "Авторизация отменена."}
+        mock_run.assert_called_once_with(
+            ["auth", "login", "--profile", "default", "--format", "json"],
+            timeout=30,
+            input="",
+        )
+
     @patch("server.tools.auth_tools.auth_status", return_value={"valid": False})
     @patch("server.tools.auth_tools._find_direct", return_value=None)
     def test_auth_login_cli_not_found(self, _mock_find, _mock_status) -> None:

--- a/tests/test_sitelinks.py
+++ b/tests/test_sitelinks.py
@@ -1,5 +1,6 @@
 """Tests for sitelinks MCP tools."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,7 +71,7 @@ class TestSitelinksList:
 
 
 class TestSitelinksAdd:
-    """Tests for sitelinks_add tool (CLI 0.3.8: repeatable --sitelink)."""
+    """Tests for sitelinks_add tool (CLI 0.3.10: three input modes)."""
 
     def test_add_sitelinks_success(self):
         """Each sitelink spec becomes a separate --sitelink argument."""
@@ -97,9 +98,65 @@ class TestSitelinksAdd:
                 ]
             )
 
-    def test_add_sitelinks_empty_list(self):
-        result = sitelinks_add(sitelinks=[])
-        assert result["error"] == "missing_sitelinks"
+    def test_add_sitelinks_items_serialized_to_camelcase_json(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 456}
+        with patch("server.tools.sitelinks.get_runner", return_value=runner):
+            sitelinks_add(
+                items=[
+                    {
+                        "title": "Главная",
+                        "href": "https://example.com/?utm=cid|{cid}",
+                        "description": "На главную",
+                    },
+                    {"title": "Прайс", "href": "https://example.com/p"},
+                ]
+            )
+
+        called_args = runner.run_json.call_args[0][0]
+        assert called_args[0:2] == ["sitelinks", "add"]
+        assert "--sitelink-json" in called_args
+        json_idx = called_args.index("--sitelink-json")
+        payload = json.loads(called_args[json_idx + 1])
+        assert payload == [
+            {
+                "Title": "Главная",
+                "Href": "https://example.com/?utm=cid|{cid}",
+                "Description": "На главную",
+            },
+            {"Title": "Прайс", "Href": "https://example.com/p"},
+        ]
+
+    def test_add_sitelinks_items_unknown_field(self):
+        result = sitelinks_add(items=[{"title": "X", "url": "https://x"}])
+        assert result["error"] == "unknown_field"
+        assert "url" in result["message"]
+
+    def test_add_sitelinks_from_file(self):
+        runner = MagicMock()
+        runner.run_json.return_value = {"Id": 789}
+        with patch("server.tools.sitelinks.get_runner", return_value=runner):
+            sitelinks_add(from_file="/tmp/sitelinks.jsonl")
+
+        runner.run_json.assert_called_once_with(
+            [
+                "sitelinks",
+                "add",
+                "--sitelinks-from-file",
+                "/tmp/sitelinks.jsonl",
+            ]
+        )
+
+    def test_add_sitelinks_missing_mode(self):
+        result = sitelinks_add()
+        assert result["error"] == "missing_mode"
+
+    def test_add_sitelinks_conflicting_modes(self):
+        result = sitelinks_add(
+            sitelinks=["A|https://a"],
+            items=[{"title": "B", "href": "https://b"}],
+        )
+        assert result["error"] == "conflicting_modes"
 
     def test_add_sitelinks_dry_run(self):
         runner = MagicMock()

--- a/tests/test_sitelinks.py
+++ b/tests/test_sitelinks.py
@@ -165,6 +165,36 @@ class TestSitelinksAdd:
             sitelinks_add(sitelinks=["A|https://a"], dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
 
+    def test_add_sitelinks_empty_list_rejected(self):
+        """sitelinks=[] is a chosen mode with no data — must fail before CLI call."""
+        result = sitelinks_add(sitelinks=[])
+        assert result["error"] == "empty_mode"
+
+    def test_add_sitelinks_empty_items_rejected(self):
+        result = sitelinks_add(items=[])
+        assert result["error"] == "empty_mode"
+
+    def test_add_sitelinks_empty_from_file_rejected(self):
+        result = sitelinks_add(from_file="")
+        assert result["error"] == "empty_mode"
+
+    def test_add_sitelinks_empty_plus_nonempty_is_conflict(self):
+        """sitelinks=[] + items=[...] must NOT silently drop items.
+
+        Regression for the bug where mode detection used truthiness while
+        dispatch used `is not None` — the empty sitelinks would take the
+        dispatch branch and produce a CLI call with no --sitelink args.
+        """
+        result = sitelinks_add(
+            sitelinks=[],
+            items=[{"title": "X", "href": "https://x"}],
+        )
+        assert result["error"] == "conflicting_modes"
+
+    def test_add_sitelinks_empty_items_plus_from_file_is_conflict(self):
+        result = sitelinks_add(items=[], from_file="/tmp/x.jsonl")
+        assert result["error"] == "conflicting_modes"
+
 
 class TestSitelinksDelete:
     """Tests for sitelinks_delete tool."""

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -9,7 +9,7 @@ from server.cli.runner import (
     DirectCliRunner,
 )
 from server.tools.ads import _check_batch_limit as ads_check_batch_limit
-from server.tools.ads import _get_foreign_campaign_id, _parse_ids
+from server.tools.ads import _parse_ids
 from server.tools.auth_tools import _human_readable_time
 from server.tools.keywords import _check_batch_limit as keywords_check_batch_limit
 
@@ -190,11 +190,6 @@ def test_ads_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
     result = ads_check_batch_limit(",".join(str(i) for i in range(11)))
     assert result is not None
     assert result.error == "batch_limit"
-
-
-def test_get_foreign_campaign_id_detects_only_foreign_range() -> None:
-    assert _get_foreign_campaign_id("abc,72999999,73000000,5") == "73000000"
-    assert _get_foreign_campaign_id("100,200,abc") is None
 
 
 def test_keywords_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:


### PR DESCRIPTION
Closes 3 of 4 пункта #114; пункт 2 (TrackingParams) заблокирован upstream.

## Summary

- **`sitelinks_add`** теперь принимает три формата ввода (CLI 0.3.10 mutex flags):
  - `sitelinks: list[str]` — pipe-delimited specs, escape `\|` поддерживает сам CLI
  - `items: list[dict]` — структурированные объекты, плагин re-keys `title`/`href`/`description`/`turbo_page_id` → WSDL CamelCase и шлёт через `--sitelink-json`
  - `from_file: str` — путь к JSONL → `--sitelinks-from-file`
  - mutex-валидация: ровно один режим (`missing_mode` / `conflicting_modes`)
  - **Закрывает блокер для UTM-шаблонов с `|` в URL** (issue #114 п. 1)
- **`auth_login(force=True)`** — пропускает `already_authenticated` и перезапускает OAuth flow. Решает сценарий переключения между агентским и клиентскими аккаунтами (#114 п. 3)
- **Удалена клиентская блокировка `ads_get` для диапазона 73M-77M** — ошибки чужих кампаний теперь приходят от Yandex API напрямую (#114 п. 4)
- **`direct-cli>=0.3.10`** в `pyproject.toml`; обновлено `CLAUDE.md`

Issue #114 п. 2 (`TrackingParams`) остаётся открытым: типизированного флага в CLI 0.3.10 нет, контракт запрещает обходить CLI. Заведён upstream issue [axisrow/direct-cli#230](https://github.com/axisrow/direct-cli/issues/230) (milestone **0.3.11**).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy server/` — 0 issues
- [x] `pytest` — **517 passed, 7 skipped, 0 failed**
- [x] Реальный CLI dry-run: `direct sitelinks add --sitelink-json '[{...,"Href":"https://x.com/?utm=cid|{cid}"}]' --dry-run` — `|` в URL уходит в API request без искажения
- [ ] Ручной smoke-тест `auth_login(force=True)` в живой среде (после merge — если потребуется)
- [ ] Ручной smoke-тест `sitelinks_add(items=[...])` через MCP (после merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)