### PR TITLE
feat: audit MCP contract against live Yandex Direct WSDL (closes #85)

### DIFF
--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -452,14 +452,19 @@ def format_report(result: AuditResult) -> str:
     has_warnings = bool(
         result.stale_blocked_operations or result.unchecked_blocked_operations
     )
-    if result.exit_code == 0 and has_warnings:
-        lines.extend(["", "Result: OK WITH WARNINGS"])
-    elif result.exit_code == 0:
-        lines.extend(["", "Result: OK"])
+    # Annotate every non-OK summary with " WITH WARNINGS" when stale-blocked
+    # or wildcard-skipped entries are present, mirroring the existing OK
+    # path. The detailed list still lives in the ``## Warnings`` section
+    # above; the suffix is just the at-a-glance summary signal that one
+    # might otherwise miss when ``CONTRACT DRIFT`` or ``INCONCLUSIVE``
+    # captures the reader's attention first.
+    suffix = " WITH WARNINGS" if has_warnings else ""
+    if result.exit_code == 0:
+        lines.extend(["", f"Result: OK{suffix}"])
     elif result.exit_code == 1:
-        lines.extend(["", "Result: CONTRACT DRIFT"])
+        lines.extend(["", f"Result: CONTRACT DRIFT{suffix}"])
     else:
-        lines.extend(["", "Result: INCONCLUSIVE"])
+        lines.extend(["", f"Result: INCONCLUSIVE{suffix}"])
 
     return "\n".join(lines)
 

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -23,6 +23,26 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from server.contract import PUBLIC_CONTRACT, TRANSPORT_BLOCKED_OPERATIONS  # noqa: E402
 
+# Canonical list of WSDL services straight from the upstream ``direct-cli``
+# package — the authoritative source-of-truth for the live v5 surface. Used
+# to discover services Yandex publishes that the MCP contract has not yet
+# declared (the original goal of issue #85). The import is wrapped because
+# older ``direct-cli`` builds may not ship ``wsdl_coverage``; the audit then
+# degrades gracefully to contract-only coverage and prints a warning.
+try:
+    from direct_cli.wsdl_coverage import (  # type: ignore[import-untyped]  # noqa: E402
+        CANONICAL_API_SERVICES as _CANONICAL_API_SERVICES_RAW,
+    )
+    from direct_cli.wsdl_coverage import (  # type: ignore[import-untyped]  # noqa: E402
+        NON_WSDL_SERVICES as _NON_WSDL_SERVICES_RAW,
+    )
+except Exception:  # pragma: no cover — old direct-cli without wsdl_coverage
+    _CANONICAL_API_SERVICES_RAW: list[str] = []  # type: ignore[no-redef]
+    _NON_WSDL_SERVICES_RAW: set[str] = set()  # type: ignore[no-redef]
+
+CANONICAL_API_SERVICES: frozenset[str] = frozenset(_CANONICAL_API_SERVICES_RAW)
+NON_WSDL_SERVICES: frozenset[str] = frozenset(_NON_WSDL_SERVICES_RAW)
+
 WSDL_BASE_URL = "https://api.direct.yandex.com/v5"
 WSDL_NS = "http://schemas.xmlsoap.org/wsdl/"
 
@@ -31,6 +51,13 @@ WSDL_NS = "http://schemas.xmlsoap.org/wsdl/"
 WSDL_ENDPOINTS_BY_SERVICE: dict[str, str] = {
     "dynamicads": "dynamictextadtargets",
     "retargeting": "retargetinglists",
+}
+
+# Reverse map: WSDL endpoint name -> contract service name. Used when
+# resolving a service discovered from ``CANONICAL_API_SERVICES`` back to a
+# contract identifier (e.g. ``dynamictextadtargets`` -> ``dynamicads``).
+WSDL_TO_CONTRACT_SERVICE: dict[str, str] = {
+    wsdl: contract for contract, wsdl in WSDL_ENDPOINTS_BY_SERVICE.items()
 }
 
 # Legacy names can still appear in TRANSPORT_BLOCKED_OPERATIONS because that
@@ -253,6 +280,18 @@ def compare_wsdl_to_contract(
     )
 
 
+def _resolve_audit_service(name: str) -> str:
+    """Normalise a user-supplied service name to a contract key.
+
+    Accepts both contract names (``dynamicads``) and WSDL endpoint names
+    (``dynamictextadtargets``) — the latter is reverse-mapped via
+    ``WSDL_TO_CONTRACT_SERVICE``. Returns the input unchanged for plain
+    contract names and for unknown values; the caller decides whether the
+    resolved key is auditable.
+    """
+    return WSDL_TO_CONTRACT_SERVICE.get(name, name)
+
+
 def run_live_audit(
     *,
     timeout: float,
@@ -261,15 +300,42 @@ def run_live_audit(
     fetcher: Callable[[str, float], frozenset[str]] = fetch_wsdl_operations,
 ) -> AuditResult:
     declared = auditable_contract_methods()
-    service_names = services or frozenset(declared)
+    declared_services = frozenset(declared)
+    # Union of declared services and any v5 WSDL services upstream publishes.
+    # The latter is what lets ``compare_wsdl_to_contract`` actually populate
+    # ``missing_services`` for newly added Yandex endpoints — the original
+    # goal of issue #85. ``CANONICAL_API_SERVICES`` is WSDL-endpoint named,
+    # so we reverse-map it before union to keep keys consistent.
+    discovered_services = frozenset(
+        _resolve_audit_service(name) for name in CANONICAL_API_SERVICES
+    )
+
+    if services is None:
+        service_names = declared_services | discovered_services
+    else:
+        # Normalise caller input: accept both contract and WSDL-endpoint
+        # spellings so ``--service dynamictextadtargets`` works too.
+        service_names = frozenset(_resolve_audit_service(s) for s in services)
 
     wsdl_methods: dict[str, frozenset[str]] = {}
     fetch_errors: dict[str, str] = {}
 
     for service in sorted(service_names):
-        if service not in declared:
+        if service in NON_WSDL_SERVICES:
             fetch_errors[service] = (
-                "service is not a WSDL-backed Direct v5 contract service"
+                "non-WSDL service (JSON API); skipped by the WSDL audit"
+            )
+            continue
+        wsdl_endpoint = service_to_wsdl_endpoint(service)
+        is_known = (
+            service in declared_services
+            or service in discovered_services
+            or wsdl_endpoint in CANONICAL_API_SERVICES
+        )
+        if not is_known:
+            fetch_errors[service] = (
+                "not a known v5 WSDL service (neither in PUBLIC_CONTRACT nor "
+                "in direct-cli CANONICAL_API_SERVICES)"
             )
             continue
         url = wsdl_url_for_service(service, base_url)
@@ -304,6 +370,17 @@ def format_report(result: AuditResult) -> str:
         "",
         f"Checked WSDL services: {len(result.checked_services)}",
     ]
+
+    if not CANONICAL_API_SERVICES:
+        lines.extend(
+            [
+                "",
+                "WARNING: ``direct_cli.wsdl_coverage`` is unavailable in this "
+                "environment, so the audit cannot discover services outside "
+                "PUBLIC_CONTRACT. Upgrade ``direct-cli`` to restore full "
+                "missing-service detection (issue #85).",
+            ]
+        )
 
     if result.fetch_errors:
         lines.extend(["", "## Inconclusive WSDL Fetches"])

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -98,10 +98,16 @@ class AuditResult:
 
     @property
     def exit_code(self) -> int:
-        if self.fetch_errors:
-            return 2
+        # Drift takes priority over inconclusive fetches: a CI job relying on
+        # exit codes must still alert on real contract drift even when one
+        # WSDL endpoint hiccups. Conflating "we don't know" with "we know
+        # there's no drift" silently swallows the signal from the
+        # successfully-audited services. ``2`` is reserved for the pure
+        # inconclusive case (only fetch errors, no drift).
         if self.has_contract_drift:
             return 1
+        if self.fetch_errors:
+            return 2
         return 0
 
 
@@ -161,7 +167,20 @@ def fetch_wsdl_operations(url: str, timeout: float) -> frozenset[str]:
 def auditable_contract_methods(
     contract_methods: Mapping[str, Sequence[str]] | None = None,
 ) -> dict[str, frozenset[str]]:
-    """Return only Direct v5 WSDL-backed service methods in WSDL naming."""
+    """Return service methods to audit, normalised to WSDL camelCase naming.
+
+    Two modes:
+
+    * **Default (``contract_methods is None``)** — derive from
+      ``PUBLIC_CONTRACT``, filtering down to tools whose
+      ``authority == "wsdl"`` so only Direct v5 WSDL-backed services are
+      returned. This is the production path called by ``run_live_audit``.
+    * **Test override (``contract_methods`` provided)** — the caller is
+      responsible for passing only WSDL-relevant entries. The mapping is
+      returned as-is (with snake_case method names converted to
+      camelCase). Non-WSDL services such as ``reports`` will pass through
+      unfiltered, so tests must not include them in this dict.
+    """
     if contract_methods is not None:
         return {
             service: frozenset(method_to_wsdl_name(method) for method in methods)
@@ -276,7 +295,13 @@ def compare_wsdl_to_contract(
             stale_blocked.add(public_name)
 
     return AuditResult(
-        checked_services=frozenset(wsdl_services & declared_services),
+        # All WSDLs we successfully fetched — including services discovered
+        # via ``CANONICAL_API_SERVICES`` but not yet declared in the
+        # contract. These services were genuinely examined (which is what
+        # ``Checked WSDL services`` in the report claims); intersecting with
+        # ``declared_services`` here would silently drop the newly-found
+        # ones that ``missing_services`` is about to flag.
+        checked_services=frozenset(wsdl_services),
         missing_services=missing_services,
         missing_methods=missing_methods,
         extra_contract_methods=extra_contract_methods,

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Audit the MCP public Direct v5 contract against live Yandex Direct WSDL.
+
+The plugin intentionally exposes a thin MCP layer over the ``direct`` CLI. This
+script validates the WSDL-backed part of ``server.contract`` without touching
+the reports API, v4 Live tools, CLI helpers, or plugin-only tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+from xml.etree import ElementTree as ET
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from server.contract import PUBLIC_CONTRACT, TRANSPORT_BLOCKED_OPERATIONS  # noqa: E402
+
+WSDL_BASE_URL = "https://api.direct.yandex.com/v5"
+WSDL_NS = "http://schemas.xmlsoap.org/wsdl/"
+
+# ``DIRECT_API_SERVICE_METHODS`` uses the public MCP/direct-cli service names.
+# A few official WSDL endpoints are named differently.
+WSDL_ENDPOINTS_BY_SERVICE: dict[str, str] = {
+    "dynamicads": "dynamictextadtargets",
+    "retargeting": "retargetinglists",
+}
+
+# Legacy names can still appear in TRANSPORT_BLOCKED_OPERATIONS because that
+# mapping also documents removed public aliases.
+BLOCKED_SERVICE_ALIASES: dict[str, str] = {
+    "dynamic_ads": "dynamicads",
+    "negative_keywords": "negativekeywords",
+}
+
+
+class WSDLFetchError(RuntimeError):
+    """Raised when a WSDL endpoint cannot be fetched or parsed."""
+
+
+@dataclass(frozen=True)
+class BlockedOperation:
+    public_name: str
+    service: str
+    method: str | None
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    checked_services: frozenset[str]
+    missing_services: dict[str, frozenset[str]] = field(default_factory=dict)
+    missing_methods: dict[str, frozenset[str]] = field(default_factory=dict)
+    extra_contract_methods: dict[str, frozenset[str]] = field(default_factory=dict)
+    stale_blocked_operations: frozenset[str] = field(default_factory=frozenset)
+    unchecked_blocked_operations: frozenset[str] = field(default_factory=frozenset)
+    fetch_errors: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def has_contract_drift(self) -> bool:
+        return bool(
+            self.missing_services or self.missing_methods or self.extra_contract_methods
+        )
+
+    @property
+    def exit_code(self) -> int:
+        if self.fetch_errors:
+            return 2
+        if self.has_contract_drift:
+            return 1
+        return 0
+
+
+def method_to_wsdl_name(method: str) -> str:
+    """Convert raw blocked-operation snake_case method names to WSDL camelCase."""
+    parts = method.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+def service_to_wsdl_endpoint(service: str) -> str:
+    """Return the official WSDL endpoint name for a contract service name."""
+    return WSDL_ENDPOINTS_BY_SERVICE.get(service, service)
+
+
+def wsdl_url_for_service(service: str, base_url: str = WSDL_BASE_URL) -> str:
+    endpoint = service_to_wsdl_endpoint(service)
+    return f"{base_url.rstrip('/')}/{endpoint}?wsdl"
+
+
+def parse_wsdl_operations(content: bytes) -> frozenset[str]:
+    """Extract operation names from all WSDL portType nodes."""
+    root = ET.fromstring(content)
+    operations: set[str] = set()
+    for port_type in root.findall(f".//{{{WSDL_NS}}}portType"):
+        for operation in port_type.findall(f"{{{WSDL_NS}}}operation"):
+            name = operation.attrib.get("name")
+            if name:
+                operations.add(name)
+    return frozenset(operations)
+
+
+def fetch_wsdl_operations(url: str, timeout: float) -> frozenset[str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return parse_wsdl_operations(response.read())
+    except urllib.error.HTTPError as exc:
+        raise WSDLFetchError(f"HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise WSDLFetchError(str(exc.reason)) from exc
+    except (TimeoutError, OSError) as exc:
+        # ``urllib`` only wraps connect-phase failures in ``URLError``. A read
+        # timeout that stalls in the middle of ``response.read()`` surfaces as
+        # a bare ``TimeoutError`` / ``socket.timeout`` (alias of
+        # ``TimeoutError`` since Python 3.10), and connection resets / broken
+        # pipes during the body transfer come through as other ``OSError``
+        # subclasses. Without this clause one slow service would abort the
+        # whole live audit instead of being recorded as an inconclusive fetch.
+        raise WSDLFetchError(f"network error: {exc}") from exc
+    except ET.ParseError as exc:
+        raise WSDLFetchError(f"XML parse error: {exc}") from exc
+
+
+def auditable_contract_methods(
+    contract_methods: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, frozenset[str]]:
+    """Return only Direct v5 WSDL-backed service methods in WSDL naming."""
+    if contract_methods is not None:
+        return {
+            service: frozenset(method_to_wsdl_name(method) for method in methods)
+            for service, methods in contract_methods.items()
+        }
+
+    methods_by_service: dict[str, set[str]] = {}
+    for tool in PUBLIC_CONTRACT:
+        if tool.authority != "wsdl" or tool.cli_service is None:
+            continue
+        canonical = tool.tapi_canonical
+        if canonical is None:
+            continue
+        methods_by_service.setdefault(tool.cli_service, set()).add(canonical)
+
+    return {
+        service: frozenset(methods)
+        for service, methods in sorted(methods_by_service.items())
+    }
+
+
+def _resolve_blocked_operation(
+    public_name: str,
+    known_services: frozenset[str],
+) -> BlockedOperation:
+    if public_name.endswith("_*"):
+        raw_service = public_name[:-2]
+        service = BLOCKED_SERVICE_ALIASES.get(raw_service, raw_service)
+        return BlockedOperation(public_name=public_name, service=service, method=None)
+
+    candidates = sorted(
+        set(known_services) | set(BLOCKED_SERVICE_ALIASES),
+        key=len,
+        reverse=True,
+    )
+    for candidate in candidates:
+        prefix = f"{candidate}_"
+        if public_name.startswith(prefix):
+            service = BLOCKED_SERVICE_ALIASES.get(candidate, candidate)
+            raw_method = public_name[len(prefix) :]
+            return BlockedOperation(
+                public_name=public_name,
+                service=service,
+                method=method_to_wsdl_name(raw_method),
+            )
+
+    return BlockedOperation(public_name=public_name, service=public_name, method=None)
+
+
+def blocked_methods_by_service(
+    blocked_operations: Mapping[str, str],
+    known_services: frozenset[str],
+) -> tuple[dict[str, frozenset[str]], frozenset[str]]:
+    blocked: dict[str, set[str]] = {}
+    unchecked: set[str] = set()
+
+    for public_name in blocked_operations:
+        operation = _resolve_blocked_operation(public_name, known_services)
+        if operation.method is None:
+            unchecked.add(public_name)
+            continue
+        blocked.setdefault(operation.service, set()).add(operation.method)
+
+    return (
+        {service: frozenset(methods) for service, methods in blocked.items()},
+        frozenset(unchecked),
+    )
+
+
+def compare_wsdl_to_contract(
+    wsdl_methods: Mapping[str, frozenset[str]],
+    contract_methods: Mapping[str, Sequence[str]] | None = None,
+    blocked_operations: Mapping[str, str] = TRANSPORT_BLOCKED_OPERATIONS,
+) -> AuditResult:
+    declared = auditable_contract_methods(contract_methods)
+    declared_services = frozenset(declared)
+    wsdl_services = frozenset(wsdl_methods)
+    known_services = (
+        declared_services | wsdl_services | frozenset(WSDL_ENDPOINTS_BY_SERVICE)
+    )
+    blocked, unchecked_blocked = blocked_methods_by_service(
+        blocked_operations, known_services
+    )
+
+    missing_services = {
+        service: frozenset(wsdl_methods[service])
+        for service in sorted(wsdl_services - declared_services)
+    }
+
+    missing_methods: dict[str, frozenset[str]] = {}
+    extra_contract_methods: dict[str, frozenset[str]] = {}
+
+    for service in sorted(declared_services & wsdl_services):
+        blocked_methods = blocked.get(service, frozenset())
+        missing = wsdl_methods[service] - declared[service] - blocked_methods
+        extra = declared[service] - wsdl_methods[service]
+        if missing:
+            missing_methods[service] = frozenset(missing)
+        if extra:
+            extra_contract_methods[service] = frozenset(extra)
+
+    stale_blocked: set[str] = set()
+    for public_name in blocked_operations:
+        operation = _resolve_blocked_operation(public_name, known_services)
+        if operation.method is None:
+            continue
+        service_declared = declared.get(operation.service, frozenset())
+        service_wsdl = wsdl_methods.get(operation.service)
+        if operation.method in service_declared:
+            stale_blocked.add(public_name)
+        elif service_wsdl is not None and operation.method not in service_wsdl:
+            stale_blocked.add(public_name)
+
+    return AuditResult(
+        checked_services=frozenset(wsdl_services & declared_services),
+        missing_services=missing_services,
+        missing_methods=missing_methods,
+        extra_contract_methods=extra_contract_methods,
+        stale_blocked_operations=frozenset(stale_blocked),
+        unchecked_blocked_operations=unchecked_blocked,
+    )
+
+
+def run_live_audit(
+    *,
+    timeout: float,
+    services: frozenset[str] | None = None,
+    base_url: str = WSDL_BASE_URL,
+    fetcher: Callable[[str, float], frozenset[str]] = fetch_wsdl_operations,
+) -> AuditResult:
+    declared = auditable_contract_methods()
+    service_names = services or frozenset(declared)
+
+    wsdl_methods: dict[str, frozenset[str]] = {}
+    fetch_errors: dict[str, str] = {}
+
+    for service in sorted(service_names):
+        if service not in declared:
+            fetch_errors[service] = (
+                "service is not a WSDL-backed Direct v5 contract service"
+            )
+            continue
+        url = wsdl_url_for_service(service, base_url)
+        try:
+            wsdl_methods[service] = fetcher(url, timeout)
+        except WSDLFetchError as exc:
+            fetch_errors[service] = f"{url}: {exc}"
+
+    result = compare_wsdl_to_contract(wsdl_methods)
+    return AuditResult(
+        checked_services=result.checked_services,
+        missing_services=result.missing_services,
+        missing_methods=result.missing_methods,
+        extra_contract_methods=result.extra_contract_methods,
+        stale_blocked_operations=result.stale_blocked_operations,
+        unchecked_blocked_operations=result.unchecked_blocked_operations,
+        fetch_errors=fetch_errors,
+    )
+
+
+def _format_method_map(items: Mapping[str, frozenset[str]]) -> list[str]:
+    lines: list[str] = []
+    for service, methods in sorted(items.items()):
+        method_list = "`, `".join(sorted(methods))
+        lines.append(f"- `{service}`: `{method_list}`")
+    return lines
+
+
+def format_report(result: AuditResult) -> str:
+    lines = [
+        "# Yandex Direct WSDL Audit",
+        "",
+        f"Checked WSDL services: {len(result.checked_services)}",
+    ]
+
+    if result.fetch_errors:
+        lines.extend(["", "## Inconclusive WSDL Fetches"])
+        for service, error in sorted(result.fetch_errors.items()):
+            lines.append(f"- `{service}`: {error}")
+
+    if (
+        result.missing_services
+        or result.missing_methods
+        or result.extra_contract_methods
+    ):
+        lines.extend(["", "## Contract Drift"])
+        if result.missing_services:
+            lines.append("")
+            lines.append("Missing services in DIRECT_API_SERVICE_METHODS:")
+            lines.extend(_format_method_map(result.missing_services))
+        if result.missing_methods:
+            lines.append("")
+            lines.append("Missing methods in DIRECT_API_SERVICE_METHODS:")
+            lines.extend(_format_method_map(result.missing_methods))
+        if result.extra_contract_methods:
+            lines.append("")
+            lines.append("Contract methods absent from live WSDL:")
+            lines.extend(_format_method_map(result.extra_contract_methods))
+
+    if result.stale_blocked_operations or result.unchecked_blocked_operations:
+        lines.extend(["", "## Warnings"])
+        if result.stale_blocked_operations:
+            lines.append("")
+            lines.append("Stale TRANSPORT_BLOCKED_OPERATIONS entries:")
+            for operation in sorted(result.stale_blocked_operations):
+                lines.append(f"- `{operation}`")
+        if result.unchecked_blocked_operations:
+            lines.append("")
+            lines.append("Unchecked wildcard/non-service blocked entries:")
+            for operation in sorted(result.unchecked_blocked_operations):
+                lines.append(f"- `{operation}`")
+
+    has_warnings = bool(
+        result.stale_blocked_operations or result.unchecked_blocked_operations
+    )
+    if result.exit_code == 0 and has_warnings:
+        lines.extend(["", "Result: OK WITH WARNINGS"])
+    elif result.exit_code == 0:
+        lines.extend(["", "Result: OK"])
+    elif result.exit_code == 1:
+        lines.extend(["", "Result: CONTRACT DRIFT"])
+    else:
+        lines.extend(["", "Result: INCONCLUSIVE"])
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="WSDL fetch timeout in seconds.",
+    )
+    parser.add_argument(
+        "--service",
+        action="append",
+        dest="services",
+        help="Limit the audit to one contract service; can be repeated.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=WSDL_BASE_URL,
+        help="Base URL for v5 WSDL endpoints.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    services = frozenset(args.services) if args.services else None
+    result = run_live_audit(
+        timeout=args.timeout,
+        services=services,
+        base_url=args.base_url,
+    )
+    print(format_report(result))
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -9,6 +9,7 @@ the reports API, v4 Live tools, CLI helpers, or plugin-only tools.
 from __future__ import annotations
 
 import argparse
+import http.client
 import sys
 import urllib.error
 import urllib.request
@@ -140,14 +141,18 @@ def fetch_wsdl_operations(url: str, timeout: float) -> frozenset[str]:
         raise WSDLFetchError(f"HTTP {exc.code}") from exc
     except urllib.error.URLError as exc:
         raise WSDLFetchError(str(exc.reason)) from exc
-    except (TimeoutError, OSError) as exc:
-        # ``urllib`` only wraps connect-phase failures in ``URLError``. A read
-        # timeout that stalls in the middle of ``response.read()`` surfaces as
-        # a bare ``TimeoutError`` / ``socket.timeout`` (alias of
-        # ``TimeoutError`` since Python 3.10), and connection resets / broken
-        # pipes during the body transfer come through as other ``OSError``
-        # subclasses. Without this clause one slow service would abort the
-        # whole live audit instead of being recorded as an inconclusive fetch.
+    except (TimeoutError, OSError, http.client.HTTPException) as exc:
+        # ``urllib`` only wraps connect-phase failures in ``URLError``. Body-
+        # phase failures escape it through three distinct channels:
+        #   - ``TimeoutError`` / ``socket.timeout`` (alias of ``TimeoutError``
+        #     on Python 3.10+) when the read stalls past ``timeout``.
+        #   - ``OSError`` subclasses (``ConnectionResetError``,
+        #     ``BrokenPipeError`` …) when the connection drops mid-body.
+        #   - ``http.client.HTTPException`` subclasses such as
+        #     ``IncompleteRead`` when the server promises ``Content-Length``
+        #     bytes but closes the socket early — this is *not* an
+        #     ``OSError`` and would otherwise abort the whole live audit on
+        #     a single truncated response.
         raise WSDLFetchError(f"network error: {exc}") from exc
     except ET.ParseError as exc:
         raise WSDLFetchError(f"XML parse error: {exc}") from exc

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -274,14 +274,22 @@ def test_fetch_wsdl_operations_wraps_body_read_timeout():
 
 
 def test_run_live_audit_continues_after_single_service_timeout():
-    """One slow service must not abort the audit of the rest of the suite."""
+    """One slow service must not abort the audit of the rest of the suite.
+
+    Tests the pure-inconclusive path: a flaky fetch alongside services that
+    perfectly match the contract → ``exit_code == 2`` (drift would override).
+    """
+    declared = audit_wsdl.auditable_contract_methods()
 
     def flaky_fetcher(url: str, timeout: float) -> frozenset[str]:
         if "campaigns?wsdl" in url:
             raise audit_wsdl.WSDLFetchError("network error: timed out")
-        return frozenset({"get"})
+        # Mirror the declared surface for non-flaky services so no drift
+        # signal is produced — this test isolates the inconclusive path.
+        service = url.split("/")[-1].split("?")[0]
+        return declared.get(service, frozenset())
 
-    contract_services = frozenset(audit_wsdl.auditable_contract_methods())
+    contract_services = frozenset(declared)
     sample_services = frozenset({"campaigns", "bidmodifiers"}) & contract_services
 
     result = audit_wsdl.run_live_audit(
@@ -295,3 +303,63 @@ def test_run_live_audit_continues_after_single_service_timeout():
     # The other service still made it through the run.
     assert "bidmodifiers" not in result.fetch_errors
     assert result.exit_code == 2  # inconclusive because of the fetch_error
+
+
+def test_audit_result_exit_code_prioritises_drift_over_fetch_errors():
+    """claude[bot] PR #124 cycle-review (Critical): real drift must beat
+    inconclusive fetch errors in ``exit_code``. A CI job that uses the exit
+    code to alert on drift would otherwise silently skip the alert whenever
+    *any* WSDL endpoint hiccuped.
+    """
+    drift_only = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        missing_services={"futureservice": frozenset({"get"})},
+    )
+    assert drift_only.exit_code == 1
+
+    fetch_errors_only = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        fetch_errors={"adgroups": "network error: timed out"},
+    )
+    assert fetch_errors_only.exit_code == 2
+
+    drift_and_fetch_errors = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        missing_services={"futureservice": frozenset({"get"})},
+        fetch_errors={"adgroups": "network error: timed out"},
+    )
+    # Drift wins: a real contract gap must not be hidden by an unrelated
+    # transient network failure.
+    assert drift_and_fetch_errors.exit_code == 1
+
+    clean = audit_wsdl.AuditResult(checked_services=frozenset({"campaigns"}))
+    assert clean.exit_code == 0
+
+
+def test_run_live_audit_counts_discovered_services_in_checked_services():
+    """claude[bot] PR #124 cycle-review (Moderate) + Copilot: services
+    discovered via ``CANONICAL_API_SERVICES`` but not yet in the contract
+    were genuinely fetched, so the report's ``Checked WSDL services``
+    counter must include them — otherwise a 29-service live run with one
+    newly-published Yandex service prints ``Checked WSDL services: 28``
+    and quietly under-reports.
+    """
+    monkeypatch_target = audit_wsdl
+    original = audit_wsdl.CANONICAL_API_SERVICES
+    try:
+        audit_wsdl.CANONICAL_API_SERVICES = frozenset({"futureservice"})
+
+        def fake_fetcher(url: str, timeout: float) -> frozenset[str]:
+            if url.endswith("/futureservice?wsdl"):
+                return frozenset({"get", "add"})
+            raise AssertionError(f"unexpected URL: {url}")
+
+        result = audit_wsdl.run_live_audit(
+            timeout=1.0,
+            services=frozenset({"futureservice"}),
+            fetcher=fake_fetcher,
+        )
+        assert "futureservice" in result.checked_services
+        assert "futureservice" in result.missing_services
+    finally:
+        monkeypatch_target.CANONICAL_API_SERVICES = original

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -1,0 +1,169 @@
+"""Tests for the live WSDL contract audit helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "audit_wsdl.py"
+spec = importlib.util.spec_from_file_location("audit_wsdl", MODULE_PATH)
+assert spec is not None
+audit_wsdl = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = audit_wsdl
+spec.loader.exec_module(audit_wsdl)
+
+
+def test_method_to_wsdl_name_normalizes_snake_case_methods():
+    assert audit_wsdl.method_to_wsdl_name("set_auto") == "setAuto"
+    assert audit_wsdl.method_to_wsdl_name("get_geo_regions") == "getGeoRegions"
+    assert (
+        audit_wsdl.method_to_wsdl_name("add_passport_organization_member")
+        == "addPassportOrganizationMember"
+    )
+
+
+def test_parse_wsdl_operations_extracts_port_type_operations():
+    xml = b"""
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/">
+      <portType name="StrategiesServicePortType">
+        <operation name="add" />
+        <operation name="archive" />
+        <operation name="get" />
+      </portType>
+      <binding name="IgnoredBinding">
+        <operation name="notFromPortType" />
+      </binding>
+    </definitions>
+    """
+
+    assert audit_wsdl.parse_wsdl_operations(xml) == frozenset({"add", "archive", "get"})
+
+
+def test_compare_reports_missing_service_method_and_stale_blocked_operation():
+    wsdl_methods = {
+        "campaigns": frozenset({"get", "add"}),
+        "strategies": frozenset({"get", "add", "update", "archive", "unarchive"}),
+        "bidmodifiers": frozenset({"get"}),
+    }
+    contract_methods = {
+        "campaigns": ("get",),
+        "bidmodifiers": ("get",),
+        "reports": ("get",),
+    }
+
+    result = audit_wsdl.compare_wsdl_to_contract(
+        wsdl_methods,
+        contract_methods,
+        {
+            "campaigns_get": "already declared in the contract",
+            "bidmodifiers_toggle": "operation no longer exists in live WSDL",
+        },
+    )
+
+    assert result.exit_code == 1
+    assert result.missing_services == {
+        "strategies": frozenset({"get", "add", "update", "archive", "unarchive"})
+    }
+    assert result.missing_methods == {"campaigns": frozenset({"add"})}
+    assert result.extra_contract_methods == {}
+    assert result.stale_blocked_operations == frozenset(
+        {"campaigns_get", "bidmodifiers_toggle"}
+    )
+
+    report = audit_wsdl.format_report(result)
+    assert "Missing services in DIRECT_API_SERVICE_METHODS" in report
+    assert "Missing methods in DIRECT_API_SERVICE_METHODS" in report
+    assert "Stale TRANSPORT_BLOCKED_OPERATIONS entries" in report
+
+
+def test_run_live_audit_excludes_reports_and_uses_wsdl_endpoint_aliases():
+    fetched: list[str] = []
+
+    def fake_fetcher(url: str, timeout: float) -> frozenset[str]:
+        fetched.append(url)
+        assert timeout == 3.0
+        if url.endswith("/dynamictextadtargets?wsdl"):
+            return frozenset({"get", "add", "delete", "suspend", "resume", "setBids"})
+        if url.endswith("/retargetinglists?wsdl"):
+            return frozenset({"get", "add", "update", "delete"})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    result = audit_wsdl.run_live_audit(
+        timeout=3.0,
+        services=frozenset({"dynamicads", "retargeting"}),
+        fetcher=fake_fetcher,
+    )
+
+    assert result.exit_code == 0
+    assert fetched == [
+        "https://api.direct.yandex.com/v5/dynamictextadtargets?wsdl",
+        "https://api.direct.yandex.com/v5/retargetinglists?wsdl",
+    ]
+
+
+def test_run_live_audit_marks_non_wsdl_service_as_inconclusive():
+    result = audit_wsdl.run_live_audit(timeout=3.0, services=frozenset({"reports"}))
+
+    assert result.exit_code == 2
+    assert result.fetch_errors == {
+        "reports": "service is not a WSDL-backed Direct v5 contract service"
+    }
+
+
+def test_fetch_wsdl_operations_wraps_body_read_timeout():
+    """A ``TimeoutError`` raised mid-read must be wrapped in WSDLFetchError.
+
+    ``urllib`` only wraps connect-phase failures in ``URLError``; a stall
+    inside ``response.read()`` surfaces a bare ``TimeoutError`` (which is
+    also the alias ``socket.timeout`` on Python 3.10+). The fetcher must
+    convert it into ``WSDLFetchError`` so ``run_live_audit`` records the
+    service as an inconclusive fetch instead of aborting the whole run.
+    """
+    import urllib.request
+    from unittest.mock import MagicMock, patch
+
+    class _ReadTimeoutResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def read(self):
+            raise TimeoutError("simulated body-read stall")
+
+    with patch.object(
+        urllib.request, "urlopen", MagicMock(return_value=_ReadTimeoutResponse())
+    ):
+        try:
+            audit_wsdl.fetch_wsdl_operations("https://example.invalid/?wsdl", 1.0)
+        except audit_wsdl.WSDLFetchError as exc:
+            assert "network error" in str(exc)
+        else:  # pragma: no cover — defensive
+            raise AssertionError("WSDLFetchError was not raised")
+
+
+def test_run_live_audit_continues_after_single_service_timeout():
+    """One slow service must not abort the audit of the rest of the suite."""
+
+    def flaky_fetcher(url: str, timeout: float) -> frozenset[str]:
+        if "campaigns?wsdl" in url:
+            raise audit_wsdl.WSDLFetchError("network error: timed out")
+        return frozenset({"get"})
+
+    contract_services = frozenset(audit_wsdl.auditable_contract_methods())
+    sample_services = frozenset({"campaigns", "bidmodifiers"}) & contract_services
+
+    result = audit_wsdl.run_live_audit(
+        timeout=1.0,
+        services=sample_services,
+        fetcher=flaky_fetcher,
+    )
+
+    assert "campaigns" in result.fetch_errors
+    assert "timed out" in result.fetch_errors["campaigns"]
+    # The other service still made it through the run.
+    assert "bidmodifiers" not in result.fetch_errors
+    assert result.exit_code == 2  # inconclusive because of the fetch_error

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -76,6 +76,44 @@ def test_compare_reports_missing_service_method_and_stale_blocked_operation():
     assert "Missing services in DIRECT_API_SERVICE_METHODS" in report
     assert "Missing methods in DIRECT_API_SERVICE_METHODS" in report
     assert "Stale TRANSPORT_BLOCKED_OPERATIONS entries" in report
+    # claude[bot] PR #124 iter 2 minor observation: ``CONTRACT DRIFT``
+    # alone hides the warnings; the summary should mirror the existing
+    # ``OK WITH WARNINGS`` suffix on non-OK exits too.
+    assert "Result: CONTRACT DRIFT WITH WARNINGS" in report
+
+
+def test_format_report_appends_with_warnings_suffix_on_inconclusive():
+    """Stale-blocked entries during an inconclusive run must surface in
+    the summary line, not just the ``## Warnings`` section above it."""
+    inconclusive_with_warnings = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        fetch_errors={"adgroups": "network error"},
+        stale_blocked_operations=frozenset({"bidmodifiers_toggle"}),
+    )
+    report = audit_wsdl.format_report(inconclusive_with_warnings)
+    assert "Result: INCONCLUSIVE WITH WARNINGS" in report
+
+
+def test_format_report_keeps_plain_summary_when_no_warnings():
+    """Plain ``CONTRACT DRIFT`` / ``INCONCLUSIVE`` / ``OK`` summaries
+    must stay unchanged when no warnings are present."""
+    drift_clean = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        missing_services={"futureservice": frozenset({"get"})},
+    )
+    assert "Result: CONTRACT DRIFT\n" in audit_wsdl.format_report(drift_clean) + "\n"
+    assert "WITH WARNINGS" not in audit_wsdl.format_report(drift_clean)
+
+    inconclusive_clean = audit_wsdl.AuditResult(
+        checked_services=frozenset({"campaigns"}),
+        fetch_errors={"adgroups": "network error"},
+    )
+    assert "Result: INCONCLUSIVE" in audit_wsdl.format_report(inconclusive_clean)
+    assert "WITH WARNINGS" not in audit_wsdl.format_report(inconclusive_clean)
+
+    ok = audit_wsdl.AuditResult(checked_services=frozenset({"campaigns"}))
+    assert "Result: OK" in audit_wsdl.format_report(ok)
+    assert "WITH WARNINGS" not in audit_wsdl.format_report(ok)
 
 
 def test_run_live_audit_excludes_reports_and_uses_wsdl_endpoint_aliases():

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -104,12 +104,106 @@ def test_run_live_audit_excludes_reports_and_uses_wsdl_endpoint_aliases():
 
 
 def test_run_live_audit_marks_non_wsdl_service_as_inconclusive():
+    """Reports is a JSON API, not a WSDL service — it must skip the WSDL audit."""
     result = audit_wsdl.run_live_audit(timeout=3.0, services=frozenset({"reports"}))
 
     assert result.exit_code == 2
     assert result.fetch_errors == {
-        "reports": "service is not a WSDL-backed Direct v5 contract service"
+        "reports": "non-WSDL service (JSON API); skipped by the WSDL audit"
     }
+
+
+def test_run_live_audit_discovers_canonical_service_missing_from_contract(
+    monkeypatch,
+):
+    """Codex review (PR #124 P2): a service published by Yandex but absent
+    from PUBLIC_CONTRACT must show up in ``missing_services``.
+
+    Previously ``run_live_audit`` would never fetch anything outside the
+    contract, so ``missing_services`` was effectively unreachable in real
+    runs — defeating the original goal of issue #85.
+    """
+    monkeypatch.setattr(
+        audit_wsdl,
+        "CANONICAL_API_SERVICES",
+        frozenset({"futureservice"}),
+    )
+
+    def fake_fetcher(url: str, timeout: float) -> frozenset[str]:
+        if url.endswith("/futureservice?wsdl"):
+            return frozenset({"get", "add"})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    # Explicit scope keeps the test independent of the full live contract
+    # surface — we only care that ``futureservice`` (canonical but absent
+    # from PUBLIC_CONTRACT) gets fetched and reported as missing.
+    result = audit_wsdl.run_live_audit(
+        timeout=1.0,
+        services=frozenset({"futureservice"}),
+        fetcher=fake_fetcher,
+    )
+
+    assert "futureservice" in result.missing_services
+    assert result.missing_services["futureservice"] == frozenset({"get", "add"})
+    assert result.exit_code == 1  # contract drift detected
+
+
+def test_run_live_audit_resolves_wsdl_endpoint_aliases_in_explicit_services():
+    """``--service dynamictextadtargets`` must resolve back to the contract
+    name ``dynamicads`` rather than failing as an unknown service."""
+
+    def fake_fetcher(url: str, timeout: float) -> frozenset[str]:
+        assert url.endswith("/dynamictextadtargets?wsdl")
+        return frozenset({"get", "add", "delete", "suspend", "resume", "setBids"})
+
+    result = audit_wsdl.run_live_audit(
+        timeout=1.0,
+        services=frozenset({"dynamictextadtargets"}),
+        fetcher=fake_fetcher,
+    )
+
+    assert "dynamicads" in result.checked_services
+    assert "dynamictextadtargets" not in result.fetch_errors
+    assert "dynamicads" not in result.fetch_errors
+
+
+def test_run_live_audit_marks_unknown_service_as_inconclusive():
+    """A name that exists neither in contract nor in CANONICAL_API_SERVICES
+    must be reported as inconclusive instead of silently passing."""
+    result = audit_wsdl.run_live_audit(
+        timeout=1.0,
+        services=frozenset({"definitely-not-a-service"}),
+    )
+
+    assert result.exit_code == 2
+    assert "definitely-not-a-service" in result.fetch_errors
+    assert (
+        "not a known v5 WSDL service" in result.fetch_errors["definitely-not-a-service"]
+    )
+
+
+def test_run_live_audit_degrades_gracefully_without_canonical_source(monkeypatch):
+    """When ``direct_cli.wsdl_coverage`` is unavailable, the audit must
+    still work using contract-only coverage and surface a warning in the
+    report instead of crashing."""
+    monkeypatch.setattr(audit_wsdl, "CANONICAL_API_SERVICES", frozenset())
+
+    def fake_fetcher(url: str, timeout: float) -> frozenset[str]:
+        return frozenset(
+            audit_wsdl.auditable_contract_methods()[url.split("/")[-1].split("?")[0]]
+        )
+
+    declared = frozenset(audit_wsdl.auditable_contract_methods())
+    sample = frozenset({"campaigns"}) & declared
+
+    result = audit_wsdl.run_live_audit(
+        timeout=1.0,
+        services=sample,
+        fetcher=fake_fetcher,
+    )
+    assert result.exit_code in {0, 1}
+    report = audit_wsdl.format_report(result)
+    assert "direct_cli.wsdl_coverage" in report
 
 
 def test_fetch_wsdl_operations_wraps_body_read_timeout():

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -206,6 +206,40 @@ def test_run_live_audit_degrades_gracefully_without_canonical_source(monkeypatch
     assert "direct_cli.wsdl_coverage" in report
 
 
+def test_fetch_wsdl_operations_wraps_incomplete_read():
+    """``http.client.IncompleteRead`` raised mid-read must be wrapped.
+
+    Codex review (PR #124 iter 2, P2): truncated responses surface as
+    ``HTTPException`` subclasses, not ``OSError`` / ``TimeoutError`` /
+    ``URLError``. Without an explicit catch one flaky endpoint would
+    abort the entire live audit instead of being recorded as an
+    inconclusive fetch in ``fetch_errors``.
+    """
+    import http.client
+    import urllib.request
+    from unittest.mock import MagicMock, patch
+
+    class _TruncatedResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def read(self):
+            raise http.client.IncompleteRead(b"<?xml partial", expected=99999)
+
+    with patch.object(
+        urllib.request, "urlopen", MagicMock(return_value=_TruncatedResponse())
+    ):
+        try:
+            audit_wsdl.fetch_wsdl_operations("https://example.invalid/?wsdl", 1.0)
+        except audit_wsdl.WSDLFetchError as exc:
+            assert "network error" in str(exc)
+        else:  # pragma: no cover — defensive
+            raise AssertionError("WSDLFetchError was not raised")
+
+
 def test_fetch_wsdl_operations_wraps_body_read_timeout():
     """A ``TimeoutError`` raised mid-read must be wrapped in WSDLFetchError.
 


### PR DESCRIPTION
## Summary

- Add `scripts/audit_wsdl.py` — live WSDL audit of the WSDL-backed half of the MCP public contract. Source of truth is `PUBLIC_CONTRACT` (no parallel list to drift). Reports missing services, missing methods, contract methods absent from live WSDL, stale `TRANSPORT_BLOCKED_OPERATIONS` entries, and wildcard blocked entries that cannot be audited per-method. Exits 0 / 1 / 2 for OK / contract drift / inconclusive.
- Two public service names are renamed to their official WSDL endpoint names — `dynamicads` → `dynamictextadtargets`, `retargeting` → `retargetinglists`. The mapping lives in `WSDL_ENDPOINTS_BY_SERVICE`.
- Networking: `urllib` only wraps connect-phase failures in `URLError`. A stall inside `response.read()` raises a bare `TimeoutError` / `socket.timeout` and connection resets surface as other `OSError` subclasses. `fetch_wsdl_operations` wraps both into `WSDLFetchError` so one slow service is recorded as an inconclusive fetch in `run_live_audit` instead of aborting the whole audit (caught the issue from the Codex review pass on this branch).

## Current live audit result

```
Checked WSDL services: 29
Result: OK WITH WARNINGS
- bidmodifiers_toggle      — stale TRANSPORT_BLOCKED_OPERATIONS entry
- dynamicads_update        — stale TRANSPORT_BLOCKED_OPERATIONS entry
- negativekeywords_*       — wildcard, skipped by design
```

Missing services / missing methods / contract methods absent from live WSDL: **0**. The Yandex Direct v5 WSDL surface declared in `PUBLIC_CONTRACT` (including `strategies`) is 1:1 with the live API today.

The two stale `TRANSPORT_BLOCKED_OPERATIONS` warnings are real findings worth a separate follow-up:
- `bidmodifiers_toggle` — Yandex deprecated this API operation on 2025-11-13; the CLI dropped the subcommand in 0.2.8. The blocked entry can be retired.
- `dynamicads_update` — the WSDL exposes `update`, but `direct dynamicads` has no `update` subcommand. The entry documents an actual transport gap; either upstream CLI adds the subcommand or the blocked entry stays.

## Test plan

- [x] `pytest -q tests/test_audit_wsdl.py -v` — 7 passed (snake→camel, portType parse, missing-service / method / stale-blocked compare, endpoint-alias live audit, non-WSDL-service inconclusive path, body-read timeout wrapping, partial-failure continuation).
- [x] `pytest -q` — 613 passed, 7 skipped (live tests, skipped without `--run-live-safe`).
- [x] `ruff check scripts/audit_wsdl.py tests/test_audit_wsdl.py` — All checks passed.
- [x] `ruff format --check scripts/audit_wsdl.py tests/test_audit_wsdl.py` — already formatted.
- [x] `mypy scripts/audit_wsdl.py tests/test_audit_wsdl.py` — Success, no issues found in 2 source files.
- [x] `python3 scripts/audit_wsdl.py` against the real Yandex API — Result: OK WITH WARNINGS (29 WSDL services, drift 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)