### PR TITLE
[codex] Align plugin with direct-cli 0.3.12

### DIFF
--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -31,10 +31,10 @@ from server.contract import PUBLIC_CONTRACT, TRANSPORT_BLOCKED_OPERATIONS  # noq
 # older ``direct-cli`` builds may not ship ``wsdl_coverage``; the audit then
 # degrades gracefully to contract-only coverage and prints a warning.
 try:
-    from direct_cli.wsdl_coverage import (  # type: ignore[import-untyped]  # noqa: E402
+    from direct_cli.wsdl_coverage import (  # type: ignore[import-not-found, import-untyped]  # noqa: E402
         CANONICAL_API_SERVICES as _CANONICAL_API_SERVICES_RAW,
     )
-    from direct_cli.wsdl_coverage import (  # type: ignore[import-untyped]  # noqa: E402
+    from direct_cli.wsdl_coverage import (  # type: ignore[import-not-found, import-untyped]  # noqa: E402
         NON_WSDL_SERVICES as _NON_WSDL_SERVICES_RAW,
     )
 except Exception:  # pragma: no cover — old direct-cli without wsdl_coverage

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -164,8 +164,19 @@ def adgroups_add(
         region_ids: Comma-separated region IDs for targeting.
         domain_url: Domain URL for DYNAMIC_TEXT_AD_GROUP.
         feed_id: Feed ID for SMART_AD_GROUP.
+        feed_category_ids: Comma-separated feed category IDs.
         ad_title_source: Title source for SMART_AD_GROUP.
         ad_body_source: Body source for SMART_AD_GROUP.
+        autotargeting_categories: Repeated autotargeting category specs.
+        autotargeting_settings_*: Autotargeting setting values.
+        offer_retargeting: Offer retargeting setting.
+        store_url: Mobile app store URL.
+        target_device_types: Mobile app target device types.
+        target_carrier: Mobile app target carrier.
+        target_operating_system_version: Mobile app target OS version.
+        negative_keywords: Ad group negative keyword specs.
+        negative_keyword_shared_set_ids: Negative keyword shared set IDs.
+        tracking_params: Tracking parameter specs.
         dry_run: Show the direct request without sending it.
     """
     args = [

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -2,9 +2,42 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit
+from server.tools.helpers import CliOption, append_cli_options, check_batch_limit
 
 MAX_BATCH_SIZE = 10
+
+ADGROUP_EXTRA_OPTIONS = (
+    CliOption("autotargeting_categories", "--autotargeting-category", repeat=True),
+    CliOption("autotargeting_settings_exact", "--autotargeting-settings-exact"),
+    CliOption("autotargeting_settings_narrow", "--autotargeting-settings-narrow"),
+    CliOption(
+        "autotargeting_settings_alternative",
+        "--autotargeting-settings-alternative",
+    ),
+    CliOption("autotargeting_settings_accessory", "--autotargeting-settings-accessory"),
+    CliOption("autotargeting_settings_broader", "--autotargeting-settings-broader"),
+    CliOption(
+        "autotargeting_settings_without_brands",
+        "--autotargeting-settings-without-brands",
+    ),
+    CliOption(
+        "autotargeting_settings_with_advertiser_brand",
+        "--autotargeting-settings-with-advertiser-brand",
+    ),
+    CliOption(
+        "autotargeting_settings_with_competitors_brand",
+        "--autotargeting-settings-with-competitors-brand",
+    ),
+    CliOption("feed_category_ids", "--feed-category-ids"),
+    CliOption("offer_retargeting", "--offer-retargeting"),
+    CliOption("store_url", "--store-url"),
+    CliOption("target_device_types", "--target-device-types"),
+    CliOption("target_carrier", "--target-carrier"),
+    CliOption("target_operating_system_version", "--target-operating-system-version"),
+    CliOption("negative_keywords", "--negative-keywords"),
+    CliOption("negative_keyword_shared_set_ids", "--negative-keyword-shared-set-ids"),
+    CliOption("tracking_params", "--tracking-params"),
+)
 
 
 def _check_batch_limit(ids_str: str) -> ToolError | None:
@@ -97,8 +130,26 @@ def adgroups_add(
     region_ids: str | None = None,
     domain_url: str | None = None,
     feed_id: int | None = None,
+    feed_category_ids: str | None = None,
     ad_title_source: str | None = None,
     ad_body_source: str | None = None,
+    autotargeting_categories: list[str] | None = None,
+    autotargeting_settings_exact: str | None = None,
+    autotargeting_settings_narrow: str | None = None,
+    autotargeting_settings_alternative: str | None = None,
+    autotargeting_settings_accessory: str | None = None,
+    autotargeting_settings_broader: str | None = None,
+    autotargeting_settings_without_brands: str | None = None,
+    autotargeting_settings_with_advertiser_brand: str | None = None,
+    autotargeting_settings_with_competitors_brand: str | None = None,
+    offer_retargeting: str | None = None,
+    store_url: str | None = None,
+    target_device_types: str | None = None,
+    target_carrier: str | None = None,
+    target_operating_system_version: str | None = None,
+    negative_keywords: str | None = None,
+    negative_keyword_shared_set_ids: str | None = None,
+    tracking_params: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Create a new ad group.
@@ -137,6 +188,7 @@ def adgroups_add(
         args.extend(["--ad-title-source", ad_title_source])
     if ad_body_source is not None:
         args.extend(["--ad-body-source", ad_body_source])
+    append_cli_options(args, locals(), ADGROUP_EXTRA_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()
@@ -150,6 +202,28 @@ def adgroups_update(
     name: str | None = None,
     status: str | None = None,
     region_ids: str | None = None,
+    domain_url: str | None = None,
+    dynamic_feed: str | None = None,
+    negative_keywords: str | None = None,
+    negative_keyword_shared_set_ids: str | None = None,
+    tracking_params: str | None = None,
+    feed_id: int | None = None,
+    feed_category_ids: str | None = None,
+    ad_title_source: str | None = None,
+    ad_body_source: str | None = None,
+    offer_retargeting: str | None = None,
+    target_device_types: str | None = None,
+    target_carrier: str | None = None,
+    target_operating_system_version: str | None = None,
+    autotargeting_categories: list[str] | None = None,
+    autotargeting_settings_exact: str | None = None,
+    autotargeting_settings_narrow: str | None = None,
+    autotargeting_settings_alternative: str | None = None,
+    autotargeting_settings_accessory: str | None = None,
+    autotargeting_settings_broader: str | None = None,
+    autotargeting_settings_without_brands: str | None = None,
+    autotargeting_settings_with_advertiser_brand: str | None = None,
+    autotargeting_settings_with_competitors_brand: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update an ad group.
@@ -164,10 +238,11 @@ def adgroups_update(
         region_ids: Comma-separated region IDs for targeting.
         dry_run: Show the direct request without sending it.
     """
-    if not any((name, status, region_ids)):
+    values = locals()
+    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, status, region_ids",
+            message="Provide at least one typed ad group field to update.",
         ).__dict__
 
     args = ["adgroups", "update", "--id", str(id)]
@@ -177,6 +252,17 @@ def adgroups_update(
         args.extend(["--status", status])
     if region_ids is not None:
         args.extend(["--region-ids", region_ids])
+    if domain_url is not None:
+        args.extend(["--domain-url", domain_url])
+    if dynamic_feed is not None:
+        args.extend(["--dynamic-feed", dynamic_feed])
+    if feed_id is not None:
+        args.extend(["--feed-id", str(feed_id)])
+    if ad_title_source is not None:
+        args.extend(["--ad-title-source", ad_title_source])
+    if ad_body_source is not None:
+        args.extend(["--ad-body-source", ad_body_source])
+    append_cli_options(args, values, ADGROUP_EXTRA_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -2,9 +2,64 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import CliOption, append_cli_options
 
 MAX_BATCH_SIZE = 10
 MOBILE_VALUES = ("YES", "NO")
+
+ADS_ADD_EXTRA_OPTIONS = (
+    CliOption("titles", "--titles"),
+    CliOption("texts", "--texts"),
+    CliOption("image_hashes", "--image-hashes"),
+    CliOption("mobile_app_features", "--mobile-app-feature", repeat=True),
+    CliOption("final_url", "--final-url"),
+    CliOption("video_extension_creative_id", "--video-extension-creative-id"),
+    CliOption("price_extension_price", "--price-extension-price"),
+    CliOption("price_extension_old_price", "--price-extension-old-price"),
+    CliOption("price_extension_price_qualifier", "--price-extension-price-qualifier"),
+    CliOption("price_extension_price_currency", "--price-extension-price-currency"),
+    CliOption("video_extension_ids", "--video-extension-ids"),
+    CliOption("business_id", "--business-id"),
+    CliOption("prefer_vcard_over_business", "--prefer-vcard-over-business"),
+    CliOption("erir_ad_description", "--erir-ad-description"),
+    CliOption("creative_id", "--creative-id"),
+    CliOption("tracking_pixels", "--tracking-pixels"),
+    CliOption("logo_extension_hash", "--logo-extension-hash"),
+    CliOption("feed_id", "--feed-id"),
+    CliOption("feed_filter_conditions", "--feed-filter-condition", repeat=True),
+    CliOption("title_sources", "--title-sources"),
+    CliOption("text_sources", "--text-sources"),
+    CliOption("default_texts", "--default-texts"),
+)
+
+ADS_UPDATE_EXTRA_OPTIONS = (
+    CliOption("status", "--status"),
+    CliOption("titles", "--titles"),
+    CliOption("texts", "--texts"),
+    CliOption("image_hashes", "--image-hashes"),
+    CliOption("mobile_app_features", "--mobile-app-feature", repeat=True),
+    CliOption("callouts_add", "--callouts-add"),
+    CliOption("callouts_remove", "--callouts-remove"),
+    CliOption("callouts_set", "--callouts-set"),
+    CliOption("video_extension_creative_id", "--video-extension-creative-id"),
+    CliOption("video_extension_ids", "--video-extension-ids"),
+    CliOption("price_extension_price", "--price-extension-price"),
+    CliOption("price_extension_old_price", "--price-extension-old-price"),
+    CliOption("price_extension_price_qualifier", "--price-extension-price-qualifier"),
+    CliOption("price_extension_price_currency", "--price-extension-price-currency"),
+    CliOption("business_id", "--business-id"),
+    CliOption("prefer_vcard_over_business", "--prefer-vcard-over-business"),
+    CliOption("erir_ad_description", "--erir-ad-description"),
+    CliOption("logo_extension_hash", "--logo-extension-hash"),
+    CliOption("creative_id", "--creative-id"),
+    CliOption("creative_erir_ad_description", "--creative-erir-ad-description"),
+    CliOption("final_url", "--final-url"),
+    CliOption("tracking_pixels", "--tracking-pixels"),
+    CliOption("feed_filter_conditions", "--feed-filter-condition", repeat=True),
+    CliOption("title_sources", "--title-sources"),
+    CliOption("text_sources", "--text-sources"),
+    CliOption("default_texts", "--default-texts"),
+)
 
 
 def _parse_ids(ids_str: str) -> list[str]:
@@ -139,11 +194,15 @@ def ads_add(
     ad_type: str | None = None,
     title: str | None = None,
     text: str | None = None,
+    titles: str | None = None,
+    texts: str | None = None,
     href: str | None = None,
     image_hash: str | None = None,
+    image_hashes: str | None = None,
     tracking_url: str | None = None,
     action: str | None = None,
     age_label: str | None = None,
+    mobile_app_features: list[str] | None = None,
     title2: str | None = None,
     display_url_path: str | None = None,
     mobile: str | None = None,
@@ -151,6 +210,24 @@ def ads_add(
     sitelink_set_id: int | None = None,
     turbo_page_id: int | None = None,
     ad_extensions: str | None = None,
+    final_url: str | None = None,
+    video_extension_creative_id: int | None = None,
+    price_extension_price: str | None = None,
+    price_extension_old_price: str | None = None,
+    price_extension_price_qualifier: str | None = None,
+    price_extension_price_currency: str | None = None,
+    video_extension_ids: str | None = None,
+    business_id: int | None = None,
+    prefer_vcard_over_business: str | None = None,
+    erir_ad_description: str | None = None,
+    creative_id: int | None = None,
+    tracking_pixels: str | None = None,
+    logo_extension_hash: str | None = None,
+    feed_id: int | None = None,
+    feed_filter_conditions: list[str] | None = None,
+    title_sources: str | None = None,
+    text_sources: str | None = None,
+    default_texts: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Create a new ad.
@@ -220,6 +297,7 @@ def ads_add(
         args.extend(["--turbo-page-id", str(turbo_page_id)])
     if ad_extensions:
         args.extend(["--ad-extensions", ad_extensions])
+    append_cli_options(args, locals(), ADS_ADD_EXTRA_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()
@@ -230,14 +308,19 @@ def ads_add(
 @handle_cli_errors
 def ads_update(
     id: int,
-    type: str,
+    type: str | None = None,
+    status: str | None = None,
     title: str | None = None,
     text: str | None = None,
+    titles: str | None = None,
+    texts: str | None = None,
     href: str | None = None,
     image_hash: str | None = None,
+    image_hashes: str | None = None,
     tracking_url: str | None = None,
     action: str | None = None,
     age_label: str | None = None,
+    mobile_app_features: list[str] | None = None,
     title2: str | None = None,
     display_url_path: str | None = None,
     mobile: str | None = None,
@@ -245,6 +328,27 @@ def ads_update(
     sitelink_set_id: int | None = None,
     turbo_page_id: int | None = None,
     ad_extensions: str | None = None,
+    callouts_add: str | None = None,
+    callouts_remove: str | None = None,
+    callouts_set: str | None = None,
+    video_extension_creative_id: int | None = None,
+    video_extension_ids: str | None = None,
+    price_extension_price: str | None = None,
+    price_extension_old_price: str | None = None,
+    price_extension_price_qualifier: str | None = None,
+    price_extension_price_currency: str | None = None,
+    business_id: int | None = None,
+    prefer_vcard_over_business: str | None = None,
+    erir_ad_description: str | None = None,
+    logo_extension_hash: str | None = None,
+    creative_id: int | None = None,
+    creative_erir_ad_description: str | None = None,
+    final_url: str | None = None,
+    tracking_pixels: str | None = None,
+    feed_filter_conditions: list[str] | None = None,
+    title_sources: str | None = None,
+    text_sources: str | None = None,
+    default_texts: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update an ad.
@@ -282,11 +386,15 @@ def ads_update(
         (
             title,
             text,
+            titles,
+            texts,
             href,
             image_hash,
+            image_hashes,
             tracking_url,
             action,
             age_label,
+            mobile_app_features,
             title2,
             display_url_path,
             mobile,
@@ -294,6 +402,28 @@ def ads_update(
             sitelink_set_id,
             turbo_page_id,
             ad_extensions,
+            status,
+            callouts_add,
+            callouts_remove,
+            callouts_set,
+            video_extension_creative_id,
+            video_extension_ids,
+            price_extension_price,
+            price_extension_old_price,
+            price_extension_price_qualifier,
+            price_extension_price_currency,
+            business_id,
+            prefer_vcard_over_business,
+            erir_ad_description,
+            logo_extension_hash,
+            creative_id,
+            creative_erir_ad_description,
+            final_url,
+            tracking_pixels,
+            feed_filter_conditions,
+            title_sources,
+            text_sources,
+            default_texts,
         )
     ):
         return ToolError(
@@ -312,7 +442,9 @@ def ads_update(
             message=f"mobile must be one of {MOBILE_VALUES}; got '{mobile}'",
         ).__dict__
 
-    args = ["ads", "update", "--id", str(id), "--type", type]
+    args = ["ads", "update", "--id", str(id)]
+    if type is not None:
+        args.extend(["--type", type])
     if title:
         args.extend(["--title", title])
     if text:
@@ -341,6 +473,7 @@ def ads_update(
         args.extend(["--turbo-page-id", str(turbo_page_id)])
     if ad_extensions:
         args.extend(["--ad-extensions", ad_extensions])
+    append_cli_options(args, locals(), ADS_UPDATE_EXTRA_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -353,10 +353,10 @@ def ads_update(
 ) -> dict:
     """Update an ad.
 
-    CLI 0.3.8 made `--type` required for `ads update` and removed the
-    `--status` flag (use `ads_suspend / ads_resume / ads_archive /
-    ads_unarchive` for status changes). CLI 0.3.9 added typed flags for
-    every TextAdUpdateItem WSDL field. Field/type compatibility:
+    CLI 0.3.12 exposes typed flags for supported ad update subtypes. `type`
+    is optional when the CLI can apply the supplied fields without an explicit
+    subtype, and `status` is accepted for typed status updates.
+    Field/type compatibility examples:
 
     - TEXT_AD: title, text, href, title2, display_url_path, mobile, vcard_id,
       sitelink_set_id, turbo_page_id, ad_extensions, image_hash.
@@ -365,14 +365,20 @@ def ads_update(
 
     Args:
         id: Ad ID to update.
-        type: Ad subtype (TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD). Required.
+        type: Optional ad subtype (TEXT_AD, TEXT_IMAGE_AD, MOBILE_APP_AD, and
+            newer 0.3.12 subtype families).
+        status: Optional ad status value.
         title: Optional new title (TEXT_AD / MOBILE_APP_AD).
         text: Optional new text (TEXT_AD / MOBILE_APP_AD).
+        titles: Structured title list for responsive/shopping/listing subtypes.
+        texts: Structured text list for responsive/shopping/listing subtypes.
         href: Optional new URL (TEXT_AD / TEXT_IMAGE_AD).
         image_hash: Optional new image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD).
+        image_hashes: Structured image hash list for multi-image subtypes.
         tracking_url: Optional MOBILE_APP_AD tracking URL.
         action: Optional MOBILE_APP_AD call-to-action.
         age_label: Optional MOBILE_APP_AD age label.
+        mobile_app_features: Repeated MOBILE_APP_AD feature specs.
         title2: Optional second headline (TEXT_AD).
         display_url_path: Optional display URL path (TEXT_AD).
         mobile: Optional "YES"/"NO" mobile-only ad flag (TEXT_AD).
@@ -380,6 +386,16 @@ def ads_update(
         sitelink_set_id: Optional sitelink set ID (TEXT_AD).
         turbo_page_id: Optional Turbo page ID (TEXT_AD / TEXT_IMAGE_AD).
         ad_extensions: Optional comma-separated ad extension IDs (TEXT_AD).
+        callouts_add/callouts_remove/callouts_set: Callout update operations.
+        video_extension_*: Video extension typed fields.
+        price_extension_*: Price extension typed fields.
+        business_id/prefer_vcard_over_business: Business/VCard binding fields.
+        erir_ad_description: ERIR ad description.
+        logo_extension_hash: Logo extension hash.
+        creative_id/creative_erir_ad_description: Ad builder creative fields.
+        final_url/tracking_pixels: Final URL and tracking pixel fields.
+        feed_filter_conditions: Repeated feed filter condition specs.
+        title_sources/text_sources/default_texts: Smart/ad builder text sources.
         dry_run: Show the direct request without sending it.
     """
     if not any(
@@ -429,11 +445,14 @@ def ads_update(
         return ToolError(
             error="missing_update_fields",
             message=(
-                "Provide at least one of: title, text, href, image_hash, "
-                "tracking_url, action, age_label, title2, display_url_path, "
-                "mobile, vcard_id, sitelink_set_id, turbo_page_id, "
-                "ad_extensions. For status changes use ads_suspend / "
-                "ads_resume / ads_archive / ads_unarchive."
+                "Provide at least one typed update field, for example: title, "
+                "text, href, image_hash, tracking_url, action, age_label, "
+                "title2, display_url_path, mobile, vcard_id, sitelink_set_id, "
+                "turbo_page_id, ad_extensions, status, callouts_*, "
+                "video_extension_*, price_extension_*, business_id, "
+                "creative_id, final_url, tracking_pixels, "
+                "feed_filter_conditions, title_sources, text_sources, or "
+                "default_texts."
             ),
         ).__dict__
     if mobile is not None and mobile not in MOBILE_VALUES:

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -17,6 +17,7 @@ _BIDMOD_TYPES = (
     "RETARGETING_ADJUSTMENT",
     "SERP_LAYOUT_ADJUSTMENT",
     "SMART_AD_ADJUSTMENT",
+    "SMART_TV_ADJUSTMENT",
     "TABLET_ADJUSTMENT",
     "VIDEO_ADJUSTMENT",
 )
@@ -143,6 +144,7 @@ def bidmodifiers_add(
     region_id: int | None = None,
     serp_layout: str | None = None,
     income_grade: str | None = None,
+    operating_system_type: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Add a bid modifier.
@@ -190,6 +192,8 @@ def bidmodifiers_add(
         args.extend(["--serp-layout", serp_layout])
     if income_grade is not None:
         args.extend(["--income-grade", income_grade])
+    if operating_system_type is not None:
+        args.extend(["--operating-system-type", operating_system_type])
     if dry_run:
         args.append("--dry-run")
 

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -73,12 +73,18 @@ def bids_set(
 ) -> dict:
     """Set a keyword bid.
 
-    CLI 0.3.8 dropped --json; the only typed knob is --bid for a single keyword.
+    CLI 0.3.12 supports keyword-, campaign-, and ad-group-scoped bid updates
+    with typed search/context bid, autotargeting, and priority fields.
 
     Args:
-        keyword_id: Keyword ID.
+        keyword_id: Keyword ID selector.
+        campaign_id: Campaign ID selector.
+        ad_group_id: Ad group ID selector.
         bid: Bid in micro-units (RUB × 1,000,000); CLI 0.2.10+ rejects values
             0 < x < 100_000 with a "did you mean × 1_000_000" hint.
+        context_bid: Context bid in micro-units.
+        autotargeting_search_bid_is_auto: Autotargeting search bid auto flag.
+        priority: Strategy priority.
         dry_run: Show the direct request without sending it.
     """
     if keyword_id is None and campaign_id is None and ad_group_id is None:

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -62,8 +62,13 @@ def bids_list(
 @mcp.tool(name="bids_set")
 @handle_cli_errors
 def bids_set(
-    keyword_id: int,
+    keyword_id: int | None = None,
+    campaign_id: int | None = None,
+    ad_group_id: int | None = None,
     bid: int | None = None,
+    context_bid: int | None = None,
+    autotargeting_search_bid_is_auto: str | None = None,
+    priority: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Set a keyword bid.
@@ -76,9 +81,45 @@ def bids_set(
             0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         dry_run: Show the direct request without sending it.
     """
-    args = ["bids", "set", "--keyword-id", str(keyword_id)]
+    if keyword_id is None and campaign_id is None and ad_group_id is None:
+        return ToolError(
+            error="missing_target_scope",
+            message="Provide at least one of: keyword_id, campaign_id, ad_group_id",
+        ).__dict__
+    if (
+        bid is None
+        and context_bid is None
+        and autotargeting_search_bid_is_auto is None
+        and priority is None
+    ):
+        return ToolError(
+            error="missing_update_fields",
+            message=(
+                "Provide at least one of: bid, context_bid, "
+                "autotargeting_search_bid_is_auto, priority"
+            ),
+        ).__dict__
+
+    args = ["bids", "set"]
+    if campaign_id is not None:
+        args.extend(["--campaign-id", str(campaign_id)])
+    if ad_group_id is not None:
+        args.extend(["--adgroup-id", str(ad_group_id)])
+    if keyword_id is not None:
+        args.extend(["--keyword-id", str(keyword_id)])
     if bid is not None:
         args.extend(["--bid", str(bid)])
+    if context_bid is not None:
+        args.extend(["--context-bid", str(context_bid)])
+    if autotargeting_search_bid_is_auto is not None:
+        args.extend(
+            [
+                "--autotargeting-search-bid-is-auto",
+                autotargeting_search_bid_is_auto,
+            ]
+        )
+    if priority is not None:
+        args.extend(["--priority", priority])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -101,6 +101,17 @@ CAMPAIGN_MUTATION_OPTIONS = (
 )
 
 
+def _provided_update_value(value: object) -> bool:
+    """Return whether an optional update value should satisfy the update guard."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
 @mcp.tool(name="campaigns_get")
 @handle_cli_errors
 def campaigns_list(
@@ -279,7 +290,7 @@ def campaigns_update(
         for key, value in values.items()
         if key not in {"id", "dry_run", "notification_json", "time_targeting_json"}
     ]
-    if not any(optional_values):
+    if not any(_provided_update_value(value) for value in optional_values):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed campaign field to update.",

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -3,7 +3,7 @@
 from server.cli.runner import CliAuthError, CliNotFoundError
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit
+from server.tools.helpers import CliOption, append_cli_options, check_batch_limit
 
 CAMPAIGN_GET_SELECTOR_FLAGS = (
     ("text_campaign_fields", "--text-campaign-fields"),
@@ -28,6 +28,76 @@ CAMPAIGN_GET_SELECTOR_FLAGS = (
         "unified_campaign_package_bidding_strategy_platforms_fields",
         "--unified-campaign-package-bidding-strategy-platforms-fields",
     ),
+)
+
+CAMPAIGN_MUTATION_OPTIONS = (
+    CliOption("settings", "--setting", repeat=True),
+    CliOption("search_strategy", "--search-strategy"),
+    CliOption("network_strategy", "--network-strategy"),
+    CliOption("filter_average_cpc", "--filter-average-cpc"),
+    CliOption("counter_id", "--counter-id"),
+    CliOption("counter_ids", "--counter-ids"),
+    CliOption("dynamic_placement_search_results", "--dynamic-placement-search-results"),
+    CliOption(
+        "dynamic_placement_product_gallery",
+        "--dynamic-placement-product-gallery",
+    ),
+    CliOption("goal_id", "--goal-id"),
+    CliOption("priority_goals", "--priority-goals"),
+    CliOption("relevant_keywords_budget_percent", "--relevant-keywords-budget-percent"),
+    CliOption("relevant_keywords_mode", "--relevant-keywords-mode"),
+    CliOption(
+        "relevant_keywords_optimize_goal_id",
+        "--relevant-keywords-optimize-goal-id",
+    ),
+    CliOption("attribution_model", "--attribution-model"),
+    CliOption("package_strategy_id", "--package-strategy-id"),
+    CliOption(
+        "package_strategy_from_campaign_id", "--package-strategy-from-campaign-id"
+    ),
+    CliOption("package_platform_search", "--package-platform-search"),
+    CliOption("package_platform_search_result", "--package-platform-search-result"),
+    CliOption("package_platform_product_gallery", "--package-platform-product-gallery"),
+    CliOption("package_platform_maps", "--package-platform-maps"),
+    CliOption(
+        "package_platform_search_organization_list",
+        "--package-platform-search-organization-list",
+    ),
+    CliOption("package_platform_network", "--package-platform-network"),
+    CliOption("package_platform_dynamic_places", "--package-platform-dynamic-places"),
+    CliOption("negative_keyword_shared_set_ids", "--negative-keyword-shared-set-ids"),
+    CliOption("frequency_cap_impressions", "--frequency-cap-impressions"),
+    CliOption("frequency_cap_period_days", "--frequency-cap-period-days"),
+    CliOption("frequency_cap_period_all", "--frequency-cap-period-all", is_flag=True),
+    CliOption("video_target", "--video-target"),
+    CliOption("average_cpa", "--average-cpa"),
+    CliOption("crr", "--crr"),
+    CliOption("bid_ceiling", "--bid-ceiling"),
+    CliOption("notification", "--notification"),
+    CliOption("time_targeting", "--time-targeting"),
+    CliOption("client_info", "--client-info"),
+    CliOption("sms_events", "--sms-events"),
+    CliOption("sms_time_from", "--sms-time-from"),
+    CliOption("sms_time_to", "--sms-time-to"),
+    CliOption("notification_email", "--notification-email"),
+    CliOption(
+        "notification_check_position_interval",
+        "--notification-check-position-interval",
+    ),
+    CliOption("notification_warning_balance", "--notification-warning-balance"),
+    CliOption("notification_send_account_news", "--notification-send-account-news"),
+    CliOption("notification_send_warnings", "--notification-send-warnings"),
+    CliOption("time_zone", "--time-zone"),
+    CliOption("negative_keywords", "--negative-keywords"),
+    CliOption("blocked_ips", "--blocked-ips"),
+    CliOption("excluded_sites", "--excluded-sites"),
+    CliOption("time_targeting_schedule", "--time-targeting-schedule", repeat=True),
+    CliOption("consider_working_weekends", "--consider-working-weekends"),
+    CliOption("holidays_suspend_on_holidays", "--holidays-suspend-on-holidays"),
+    CliOption("holidays_bid_percent", "--holidays-bid-percent"),
+    CliOption("holidays_start_hour", "--holidays-start-hour"),
+    CliOption("holidays_end_hour", "--holidays-end-hour"),
+    CliOption("tracking_params", "--tracking-params"),
 )
 
 
@@ -132,6 +202,55 @@ def campaigns_update(
     budget: int | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
+    settings: list[str] | None = None,
+    counter_id: int | None = None,
+    counter_ids: str | None = None,
+    dynamic_placement_search_results: str | None = None,
+    dynamic_placement_product_gallery: str | None = None,
+    priority_goals: str | None = None,
+    relevant_keywords_budget_percent: int | None = None,
+    relevant_keywords_mode: str | None = None,
+    relevant_keywords_optimize_goal_id: int | None = None,
+    attribution_model: str | None = None,
+    package_strategy_id: int | None = None,
+    package_strategy_from_campaign_id: int | None = None,
+    package_platform_search: str | None = None,
+    package_platform_search_result: str | None = None,
+    package_platform_product_gallery: str | None = None,
+    package_platform_maps: str | None = None,
+    package_platform_search_organization_list: str | None = None,
+    package_platform_network: str | None = None,
+    package_platform_dynamic_places: str | None = None,
+    negative_keyword_shared_set_ids: str | None = None,
+    frequency_cap_impressions: int | None = None,
+    frequency_cap_period_days: int | None = None,
+    frequency_cap_period_all: bool = False,
+    video_target: str | None = None,
+    notification: str | None = None,
+    time_targeting: str | None = None,
+    client_info: str | None = None,
+    sms_events: str | None = None,
+    sms_time_from: str | None = None,
+    sms_time_to: str | None = None,
+    notification_email: str | None = None,
+    notification_check_position_interval: str | None = None,
+    notification_warning_balance: int | None = None,
+    notification_send_account_news: str | None = None,
+    notification_send_warnings: str | None = None,
+    time_zone: str | None = None,
+    negative_keywords: str | None = None,
+    blocked_ips: str | None = None,
+    excluded_sites: str | None = None,
+    time_targeting_schedule: list[str] | None = None,
+    consider_working_weekends: str | None = None,
+    holidays_suspend_on_holidays: str | None = None,
+    holidays_bid_percent: int | None = None,
+    holidays_start_hour: int | None = None,
+    holidays_end_hour: int | None = None,
+    campaign_type: str | None = None,
+    tracking_params: str | None = None,
+    notification_json: str | None = None,
+    time_targeting_json: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update campaign fields.
@@ -150,16 +269,20 @@ def campaigns_update(
         end_date: Optional new end date (YYYY-MM-DD).
         dry_run: Show the direct request without sending it.
     """
-    if (
-        name is None
-        and status is None
-        and budget is None
-        and start_date is None
-        and end_date is None
-    ):
+    values = locals()
+    if notification is None and notification_json is not None:
+        values["notification"] = notification_json
+    if time_targeting is None and time_targeting_json is not None:
+        values["time_targeting"] = time_targeting_json
+    optional_values = [
+        value
+        for key, value in values.items()
+        if key not in {"id", "dry_run", "notification_json", "time_targeting_json"}
+    ]
+    if not any(optional_values):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, status, budget, start_date, end_date",
+            message="Provide at least one typed campaign field to update.",
         ).__dict__
 
     args = ["campaigns", "update", "--id", str(id)]
@@ -173,6 +296,9 @@ def campaigns_update(
         args.extend(["--start-date", start_date])
     if end_date:
         args.extend(["--end-date", end_date])
+    if campaign_type is not None:
+        args.extend(["--type", campaign_type])
+    append_cli_options(args, values, CAMPAIGN_MUTATION_OPTIONS)
     if dry_run:
         args.append("--dry-run")
 
@@ -226,6 +352,48 @@ def campaigns_add(
     average_cpa: int | None = None,
     crr: int | None = None,
     bid_ceiling: int | None = None,
+    dynamic_placement_search_results: str | None = None,
+    dynamic_placement_product_gallery: str | None = None,
+    relevant_keywords_budget_percent: int | None = None,
+    relevant_keywords_mode: str | None = None,
+    relevant_keywords_optimize_goal_id: int | None = None,
+    attribution_model: str | None = None,
+    package_strategy_id: int | None = None,
+    package_strategy_from_campaign_id: int | None = None,
+    package_platform_search: str | None = None,
+    package_platform_search_result: str | None = None,
+    package_platform_product_gallery: str | None = None,
+    package_platform_maps: str | None = None,
+    package_platform_search_organization_list: str | None = None,
+    package_platform_network: str | None = None,
+    package_platform_dynamic_places: str | None = None,
+    negative_keyword_shared_set_ids: str | None = None,
+    frequency_cap_impressions: int | None = None,
+    frequency_cap_period_days: int | None = None,
+    frequency_cap_period_all: bool = False,
+    video_target: str | None = None,
+    notification: str | None = None,
+    time_targeting: str | None = None,
+    client_info: str | None = None,
+    sms_events: str | None = None,
+    sms_time_from: str | None = None,
+    sms_time_to: str | None = None,
+    notification_email: str | None = None,
+    notification_check_position_interval: str | None = None,
+    notification_warning_balance: int | None = None,
+    notification_send_account_news: str | None = None,
+    notification_send_warnings: str | None = None,
+    time_zone: str | None = None,
+    negative_keywords: str | None = None,
+    blocked_ips: str | None = None,
+    excluded_sites: str | None = None,
+    time_targeting_schedule: list[str] | None = None,
+    consider_working_weekends: str | None = None,
+    holidays_suspend_on_holidays: str | None = None,
+    holidays_bid_percent: int | None = None,
+    holidays_start_hour: int | None = None,
+    holidays_end_hour: int | None = None,
+    tracking_params: str | None = None,
     notification_json: str | None = None,
     time_targeting_json: str | None = None,
     dry_run: bool = False,
@@ -302,10 +470,26 @@ def campaigns_add(
         args.extend(["--crr", str(crr)])
     if bid_ceiling is not None:
         args.extend(["--bid-ceiling", str(bid_ceiling)])
-    if notification_json:
-        args.extend(["--notification", notification_json])
-    if time_targeting_json:
-        args.extend(["--time-targeting", time_targeting_json])
+    values = locals()
+    if notification is None and notification_json is not None:
+        values["notification"] = notification_json
+    if time_targeting is None and time_targeting_json is not None:
+        values["time_targeting"] = time_targeting_json
+    for already_appended in (
+        "search_strategy",
+        "network_strategy",
+        "settings",
+        "filter_average_cpc",
+        "counter_id",
+        "counter_ids",
+        "goal_id",
+        "priority_goals",
+        "average_cpa",
+        "crr",
+        "bid_ceiling",
+    ):
+        values[already_appended] = None
+    append_cli_options(args, values, CAMPAIGN_MUTATION_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/changes.py
+++ b/server/tools/changes.py
@@ -61,10 +61,13 @@ def changes_check(
     https://yandex.ru/dev/direct/doc/ref-v5/changes/check.html.
 
     Args:
-        field_names: Comma-separated FieldNames (required by API). Allowed:
-            ``CampaignIds``, ``AdGroupIds``, ``AdIds``, ``CampaignsStat``.
         timestamp: ISO 8601 timestamp. A bare ``YYYY-MM-DDTHH:MM:SS`` is
             normalized to UTC (``...Z``); explicit offsets are kept as-is.
+        field_names: Backward-compatible alias for ``fields``.
+        fields: Optional comma-separated FieldNames. If omitted, no ``--fields``
+            flag is forwarded and the CLI/API default applies. Allowed:
+            ``CampaignIds``, ``AdGroupIds``, ``AdIds``, ``CampaignsStat``.
+            When both aliases are passed, ``fields`` takes precedence.
         campaign_ids: Comma-separated campaign IDs (up to 3000). Mutually
             exclusive with ``ad_group_ids`` and ``ad_ids``.
         ad_group_ids: Comma-separated ad group IDs (up to 10000). Mutually

--- a/server/tools/changes.py
+++ b/server/tools/changes.py
@@ -48,8 +48,9 @@ def _validate_field_names(field_names: str) -> ToolError | None:
 @mcp.tool()
 @handle_cli_errors
 def changes_check(
-    field_names: str,
     timestamp: str,
+    field_names: str | None = None,
+    fields: str | None = None,
     campaign_ids: str | None = None,
     ad_group_ids: str | None = None,
     ad_ids: str | None = None,
@@ -71,9 +72,11 @@ def changes_check(
         ad_ids: Comma-separated ad IDs (up to 50000). Mutually exclusive
             with ``campaign_ids`` and ``ad_group_ids``.
     """
-    field_error = _validate_field_names(field_names)
-    if field_error:
-        return field_error.__dict__
+    selected_fields = fields if fields is not None else field_names
+    if selected_fields is not None:
+        field_error = _validate_field_names(selected_fields)
+        if field_error:
+            return field_error.__dict__
 
     provided: list[tuple[str, str, str, int]] = []
     for cli_flag, label, value, limit in (
@@ -119,11 +122,10 @@ def changes_check(
         value,
         "--timestamp",
         _normalize_timestamp(timestamp),
-        "--fields",
-        field_names,
-        "--format",
-        "json",
     ]
+    if selected_fields is not None:
+        args.extend(["--fields", selected_fields])
+    args.extend(["--format", "json"])
     return get_runner().run_json(args)
 
 

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -2,6 +2,35 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import CliOption, append_cli_options
+
+ERIR_OPTIONS = (
+    CliOption("erir_organization_name", "--erir-organization-name"),
+    CliOption("erir_organization_kpp", "--erir-organization-kpp"),
+    CliOption("erir_organization_epay_number", "--erir-organization-epay-number"),
+    CliOption("erir_organization_reg_number", "--erir-organization-reg-number"),
+    CliOption("erir_organization_oksm_number", "--erir-organization-oksm-number"),
+    CliOption("erir_organization_okved_code", "--erir-organization-okved-code"),
+    CliOption("erir_contract_number", "--erir-contract-number"),
+    CliOption("erir_contract_date", "--erir-contract-date"),
+    CliOption("erir_contract_type", "--erir-contract-type"),
+    CliOption("erir_contract_action_type", "--erir-contract-action-type"),
+    CliOption("erir_contract_subject_type", "--erir-contract-subject-type"),
+    CliOption("erir_contract_is_agency_payment", "--erir-contract-is-agency-payment"),
+    CliOption("erir_contract_price_amount", "--erir-contract-price-amount"),
+    CliOption(
+        "erir_contract_price_including_vat",
+        "--erir-contract-price-including-vat",
+    ),
+    CliOption("erir_contragent_name", "--erir-contragent-name"),
+    CliOption("erir_contragent_kpp", "--erir-contragent-kpp"),
+    CliOption("erir_contragent_phone", "--erir-contragent-phone"),
+    CliOption("erir_contragent_epay_number", "--erir-contragent-epay-number"),
+    CliOption("erir_contragent_reg_number", "--erir-contragent-reg-number"),
+    CliOption("erir_contragent_oksm_number", "--erir-contragent-oksm-number"),
+    CliOption("erir_contragent_tin_type", "--erir-contragent-tin-type"),
+    CliOption("erir_contragent_tin", "--erir-contragent-tin"),
+)
 
 
 @mcp.tool()
@@ -44,6 +73,28 @@ def clients_update(
     settings: list[str] | None = None,
     tin_type: str | None = None,
     tin: str | None = None,
+    erir_organization_name: str | None = None,
+    erir_organization_kpp: str | None = None,
+    erir_organization_epay_number: str | None = None,
+    erir_organization_reg_number: str | None = None,
+    erir_organization_oksm_number: str | None = None,
+    erir_organization_okved_code: str | None = None,
+    erir_contract_number: str | None = None,
+    erir_contract_date: str | None = None,
+    erir_contract_type: str | None = None,
+    erir_contract_action_type: str | None = None,
+    erir_contract_subject_type: str | None = None,
+    erir_contract_is_agency_payment: str | None = None,
+    erir_contract_price_amount: str | None = None,
+    erir_contract_price_including_vat: str | None = None,
+    erir_contragent_name: str | None = None,
+    erir_contragent_kpp: str | None = None,
+    erir_contragent_phone: str | None = None,
+    erir_contragent_epay_number: str | None = None,
+    erir_contragent_reg_number: str | None = None,
+    erir_contragent_oksm_number: str | None = None,
+    erir_contragent_tin_type: str | None = None,
+    erir_contragent_tin: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update the authenticated client's settings.
@@ -64,24 +115,11 @@ def clients_update(
         tin: Taxpayer identification number.
         dry_run: Show the direct request without sending it.
     """
-    if not any(
-        (
-            client_info,
-            phone,
-            notification_email,
-            notification_lang,
-            email_subscriptions,
-            settings,
-            tin_type,
-            tin,
-        )
-    ):
+    values = locals()
+    if not any(value for key, value in values.items() if key not in {"dry_run"}):
         return ToolError(
             error="missing_update_fields",
-            message=(
-                "Provide at least one of: client_info, phone, notification_email, "
-                "notification_lang, email_subscriptions, settings, tin_type, tin"
-            ),
+            message="Provide at least one typed client field to update.",
         ).__dict__
 
     args = ["clients", "update"]
@@ -103,6 +141,7 @@ def clients_update(
         args.extend(["--tin-type", tin_type])
     if tin is not None:
         args.extend(["--tin", tin])
+    append_cli_options(args, values, ERIR_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -113,6 +113,12 @@ def clients_update(
         settings: List of OPTION=YES|NO entries (repeats CLI's --setting flag).
         tin_type: TIN type.
         tin: Taxpayer identification number.
+        erir_organization_*: ERIR organization fields, including name, KPP,
+            ePay number, registration number, OKSM number, and OKVED code.
+        erir_contract_*: ERIR contract fields, including number, date, type,
+            action type, subject type, agency payment, price amount, and VAT flag.
+        erir_contragent_*: ERIR contragent fields, including name, KPP, phone,
+            ePay number, registration number, OKSM number, TIN type, and TIN.
         dry_run: Show the direct request without sending it.
     """
     values = locals()

--- a/server/tools/dynamic_feed_ad_targets.py
+++ b/server/tools/dynamic_feed_ad_targets.py
@@ -75,7 +75,9 @@ def dynamic_feed_ad_targets_add(
     Args:
         ad_group_id: Ad group ID.
         name: Target name.
-        condition: Condition spec (e.g. "OPERAND:OPERATOR:ARG1|ARG2").
+        condition: Single condition spec (e.g. "OPERAND:OPERATOR:ARG1|ARG2").
+        conditions: Additional condition specs; each item is forwarded as
+            repeated ``--condition``.
         bid: Optional search bid in micro-units (RUB × 1,000,000); CLI 0.2.10+
             rejects values 0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         context_bid: Optional context bid in micro-units (same rules as `bid`).

--- a/server/tools/dynamic_feed_ad_targets.py
+++ b/server/tools/dynamic_feed_ad_targets.py
@@ -63,6 +63,7 @@ def dynamic_feed_ad_targets_list(
 def dynamic_feed_ad_targets_add(
     ad_group_id: int,
     name: str,
+    conditions: list[str] | None = None,
     condition: str | None = None,
     bid: int | None = None,
     context_bid: int | None = None,
@@ -92,6 +93,9 @@ def dynamic_feed_ad_targets_add(
     ]
     if condition is not None:
         args.extend(["--condition", condition])
+    if conditions:
+        for spec in conditions:
+            args.extend(["--condition", spec])
     if bid is not None:
         args.extend(["--bid", str(bid)])
     if context_bid is not None:

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -2,8 +2,17 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import CliOption, append_cli_options
 
 BUSINESS_TYPES = ("RETAIL", "HOTELS", "REALTY", "AUTOMOBILES", "FLIGHTS", "OTHER")
+
+FEED_SOURCE_OPTIONS = (
+    CliOption("file_feed_path", "--file-feed-path"),
+    CliOption("file_feed_filename", "--file-feed-filename"),
+    CliOption("remove_utm_tags", "--remove-utm-tags"),
+    CliOption("feed_login", "--feed-login"),
+    CliOption("feed_password", "--feed-password"),
+)
 
 
 @mcp.tool(name="feeds_get")
@@ -39,8 +48,13 @@ def feeds_list(
 @handle_cli_errors
 def feeds_add(
     name: str,
-    url: str,
     business_type: str,
+    url: str | None = None,
+    file_feed_path: str | None = None,
+    file_feed_filename: str | None = None,
+    remove_utm_tags: str | None = None,
+    feed_login: str | None = None,
+    feed_password: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Add a new feed.
@@ -69,11 +83,11 @@ def feeds_add(
         "add",
         "--name",
         name,
-        "--url",
-        url,
-        "--business-type",
-        business_type,
     ]
+    if url is not None:
+        args.extend(["--url", url])
+    append_cli_options(args, locals(), FEED_SOURCE_OPTIONS)
+    args.extend(["--business-type", business_type])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()
@@ -86,6 +100,13 @@ def feeds_update(
     id: int,
     name: str | None = None,
     url: str | None = None,
+    file_feed_path: str | None = None,
+    file_feed_filename: str | None = None,
+    remove_utm_tags: str | None = None,
+    feed_login: str | None = None,
+    feed_password: str | None = None,
+    clear_feed_login: bool = False,
+    clear_feed_password: bool = False,
     dry_run: bool = False,
 ) -> dict:
     """Update an existing feed.
@@ -98,10 +119,11 @@ def feeds_update(
         url: Optional new feed URL.
         dry_run: Show the direct request without sending it.
     """
-    if not any((name, url)):
+    values = locals()
+    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, url",
+            message="Provide at least one typed feed field to update.",
         ).__dict__
 
     args = ["feeds", "update", "--id", str(id)]
@@ -109,6 +131,11 @@ def feeds_update(
         args.extend(["--name", name])
     if url is not None:
         args.extend(["--url", url])
+    append_cli_options(args, values, FEED_SOURCE_OPTIONS)
+    if clear_feed_login:
+        args.append("--clear-feed-login")
+    if clear_feed_password:
+        args.append("--clear-feed-password")
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -59,14 +59,20 @@ def feeds_add(
 ) -> dict:
     """Add a new feed.
 
-    CLI 0.3.8 requires --business-type (WSDL FeedAddItem.BusinessType,
-    minOccurs=1) and removed the free-form --json flag.
+    CLI 0.3.12 supports URL feeds and file-feed uploads through typed flags.
+    Provide `url` for a UrlFeed source, or `file_feed_path` plus optional
+    `file_feed_filename` for a FileFeed upload.
 
     Args:
         name: Feed name.
-        url: Feed URL.
         business_type: Business type — one of RETAIL, HOTELS, REALTY,
             AUTOMOBILES, FLIGHTS, OTHER.
+        url: Feed URL for UrlFeed.
+        file_feed_path: Local file path to upload for FileFeed.
+        file_feed_filename: Optional uploaded file name override.
+        remove_utm_tags: Optional remove-UTM setting.
+        feed_login: Optional feed basic-auth login.
+        feed_password: Optional feed basic-auth password.
         dry_run: Show the direct request without sending it.
     """
     if business_type not in BUSINESS_TYPES:

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -1,5 +1,8 @@
 """Shared helpers for MCP tool modules."""
 
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
 from server.cli.runner import (
     CliAuthError,
     CliNotFoundError,
@@ -9,6 +12,45 @@ from server.cli.runner import (
 from server.tools import ToolError
 
 MAX_BATCH_SIZE = 10
+
+
+@dataclass(frozen=True)
+class CliOption:
+    """Declarative mapping from an MCP parameter to a `direct` CLI flag."""
+
+    name: str
+    flag: str
+    repeat: bool = False
+    is_flag: bool = False
+
+
+def append_cli_options(
+    args: list[str],
+    values: Mapping[str, object],
+    options: Sequence[CliOption],
+) -> None:
+    """Append optional `direct` CLI flags from function locals."""
+    for option in options:
+        value = values.get(option.name)
+        if value is None:
+            continue
+        if option.is_flag:
+            if value:
+                args.append(option.flag)
+            continue
+        if option.repeat:
+            if not value:
+                continue
+            if isinstance(value, str):
+                args.extend([option.flag, value])
+                continue
+            if not isinstance(value, Iterable):
+                args.extend([option.flag, str(value)])
+                continue
+            for item in value:
+                args.extend([option.flag, str(item)])
+            continue
+        args.extend([option.flag, str(value)])
 
 
 def parse_ids(ids_str: str) -> list[str]:

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -47,9 +47,13 @@ def keyword_bids_list(
 @mcp.tool(name="keywordbids_set")
 @handle_cli_errors
 def keyword_bids_set(
-    keyword_id: int,
+    keyword_id: int | None = None,
+    campaign_id: int | None = None,
+    ad_group_id: int | None = None,
     search_bid: int | None = None,
     network_bid: int | None = None,
+    autotargeting_search_bid_is_auto: str | None = None,
+    priority: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Set keyword bids.
@@ -61,17 +65,45 @@ def keyword_bids_set(
         network_bid: Optional network bid in micro-units (same rules as `search_bid`).
         dry_run: Show the direct request without sending it.
     """
-    if search_bid is None and network_bid is None:
+    if keyword_id is None and campaign_id is None and ad_group_id is None:
+        return ToolError(
+            error="missing_target_scope",
+            message="Provide at least one of: keyword_id, campaign_id, ad_group_id",
+        ).__dict__
+    if (
+        search_bid is None
+        and network_bid is None
+        and autotargeting_search_bid_is_auto is None
+        and priority is None
+    ):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: search_bid, network_bid",
+            message=(
+                "Provide at least one of: search_bid, network_bid, "
+                "autotargeting_search_bid_is_auto, priority"
+            ),
         ).__dict__
 
-    args = ["keywordbids", "set", "--keyword-id", str(keyword_id)]
+    args = ["keywordbids", "set"]
+    if campaign_id is not None:
+        args.extend(["--campaign-id", str(campaign_id)])
+    if ad_group_id is not None:
+        args.extend(["--adgroup-id", str(ad_group_id)])
+    if keyword_id is not None:
+        args.extend(["--keyword-id", str(keyword_id)])
     if search_bid is not None:
         args.extend(["--search-bid", str(search_bid)])
     if network_bid is not None:
         args.extend(["--network-bid", str(network_bid)])
+    if autotargeting_search_bid_is_auto is not None:
+        args.extend(
+            [
+                "--autotargeting-search-bid-is-auto",
+                autotargeting_search_bid_is_auto,
+            ]
+        )
+    if priority is not None:
+        args.extend(["--priority", priority])
     if dry_run:
         args.append("--dry-run")
     runner = get_runner()

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -59,10 +59,14 @@ def keyword_bids_set(
     """Set keyword bids.
 
     Args:
-        keyword_id: Keyword ID.
+        keyword_id: Keyword ID selector.
+        campaign_id: Campaign ID selector.
+        ad_group_id: Ad group ID selector.
         search_bid: Optional search bid in micro-units (RUB × 1,000,000); CLI 0.2.10+
             rejects values 0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         network_bid: Optional network bid in micro-units (same rules as `search_bid`).
+        autotargeting_search_bid_is_auto: Autotargeting search bid auto flag.
+        priority: Strategy priority.
         dry_run: Show the direct request without sending it.
     """
     if keyword_id is None and campaign_id is None and ad_group_id is None:

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -2,8 +2,36 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import CliOption, append_cli_options
 
 MAX_BATCH_SIZE = 10
+
+KEYWORD_AUTOTARGETING_OPTIONS = (
+    CliOption("autotargeting_categories", "--autotargeting-category", repeat=True),
+    CliOption(
+        "autotargeting_brand_options", "--autotargeting-brand-option", repeat=True
+    ),
+    CliOption("autotargeting_settings_exact", "--autotargeting-settings-exact"),
+    CliOption("autotargeting_settings_narrow", "--autotargeting-settings-narrow"),
+    CliOption(
+        "autotargeting_settings_alternative",
+        "--autotargeting-settings-alternative",
+    ),
+    CliOption("autotargeting_settings_accessory", "--autotargeting-settings-accessory"),
+    CliOption("autotargeting_settings_broader", "--autotargeting-settings-broader"),
+    CliOption(
+        "autotargeting_settings_without_brands",
+        "--autotargeting-settings-without-brands",
+    ),
+    CliOption(
+        "autotargeting_settings_with_advertiser_brand",
+        "--autotargeting-settings-with-advertiser-brand",
+    ),
+    CliOption(
+        "autotargeting_settings_with_competitors_brand",
+        "--autotargeting-settings-with-competitors-brand",
+    ),
+)
 
 
 def _check_batch_limit(ids_str: str) -> ToolError | None:
@@ -101,6 +129,19 @@ def keywords_update(
     keyword: str | None = None,
     user_param_1: str | None = None,
     user_param_2: str | None = None,
+    autotargeting_categories: list[str] | None = None,
+    autotargeting_brand_options: list[str] | None = None,
+    autotargeting_settings_exact: str | None = None,
+    autotargeting_settings_narrow: str | None = None,
+    autotargeting_settings_alternative: str | None = None,
+    autotargeting_settings_accessory: str | None = None,
+    autotargeting_settings_broader: str | None = None,
+    autotargeting_settings_without_brands: str | None = None,
+    autotargeting_settings_with_advertiser_brand: str | None = None,
+    autotargeting_settings_with_competitors_brand: str | None = None,
+    bid: str | None = None,
+    context_bid: str | None = None,
+    status: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Update keyword text or user params.
@@ -116,10 +157,11 @@ def keywords_update(
         user_param_2: Optional user parameter 2.
         dry_run: Show the direct request without sending it.
     """
-    if not any((keyword, user_param_1, user_param_2)):
+    values = locals()
+    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: keyword, user_param_1, user_param_2",
+            message="Provide at least one typed keyword field to update.",
         ).__dict__
 
     runner = get_runner()
@@ -130,6 +172,13 @@ def keywords_update(
         args.extend(["--user-param-1", user_param_1])
     if user_param_2 is not None:
         args.extend(["--user-param-2", user_param_2])
+    append_cli_options(args, values, KEYWORD_AUTOTARGETING_OPTIONS)
+    if bid is not None:
+        args.extend(["--bid", bid])
+    if context_bid is not None:
+        args.extend(["--context-bid", context_bid])
+    if status is not None:
+        args.extend(["--status", status])
     if dry_run:
         args.append("--dry-run")
     cli_output = runner.run_json(args)
@@ -157,6 +206,18 @@ def keywords_add(
     keyword: str | None = None,
     bid: int | None = None,
     context_bid: int | None = None,
+    autotargeting_search_bid_is_auto: str | None = None,
+    priority: str | None = None,
+    autotargeting_categories: list[str] | None = None,
+    autotargeting_brand_options: list[str] | None = None,
+    autotargeting_settings_exact: str | None = None,
+    autotargeting_settings_narrow: str | None = None,
+    autotargeting_settings_alternative: str | None = None,
+    autotargeting_settings_accessory: str | None = None,
+    autotargeting_settings_broader: str | None = None,
+    autotargeting_settings_without_brands: str | None = None,
+    autotargeting_settings_with_advertiser_brand: str | None = None,
+    autotargeting_settings_with_competitors_brand: str | None = None,
     user_param_1: str | None = None,
     user_param_2: str | None = None,
     from_file: str | None = None,
@@ -223,6 +284,16 @@ def keywords_add(
         args.extend(["--bid", str(bid)])
     if context_bid is not None:
         args.extend(["--context-bid", str(context_bid)])
+    if autotargeting_search_bid_is_auto is not None:
+        args.extend(
+            [
+                "--autotargeting-search-bid-is-auto",
+                autotargeting_search_bid_is_auto,
+            ]
+        )
+    if priority is not None:
+        args.extend(["--priority", priority])
+    append_cli_options(args, locals(), KEYWORD_AUTOTARGETING_OPTIONS)
     if user_param_1 is not None:
         args.extend(["--user-param-1", user_param_1])
     if user_param_2 is not None:

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -146,15 +146,22 @@ def keywords_update(
 ) -> dict:
     """Update keyword text or user params.
 
-    Note: bid changes go through `keywordbids_set`, not this tool — CLI's
-    `keywords update` does not accept `--bid` flags. CLI 0.3.8 also removed
-    the free-form `--json` flag.
+    CLI 0.3.12 accepts typed bid, status, and autotargeting projection fields
+    here. `keywordbids_set` remains the bulk bid-management tool, but this
+    wrapper mirrors the `direct keywords update` flags for single keyword
+    updates.
 
     Args:
         id: Keyword ID.
         keyword: Optional new keyword text.
         user_param_1: Optional user parameter 1.
         user_param_2: Optional user parameter 2.
+        autotargeting_categories: Repeated autotargeting category specs.
+        autotargeting_brand_options: Repeated autotargeting brand option specs.
+        autotargeting_settings_*: Autotargeting setting values.
+        bid: Optional search bid.
+        context_bid: Optional context bid.
+        status: Optional keyword status.
         dry_run: Show the direct request without sending it.
     """
     values = locals()

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -46,6 +46,8 @@ def retargeting_list(
 def retargeting_add(
     name: str,
     list_type: str = "RETARGETING",
+    description: str | None = None,
+    rules: list[str] | None = None,
     rule: str | None = None,
     dry_run: bool = False,
 ) -> dict:
@@ -78,6 +80,11 @@ def retargeting_add(
     ]
     if rule is not None:
         args.extend(["--rule", rule])
+    if description is not None:
+        args.extend(["--description", description])
+    if rules:
+        for spec in rules:
+            args.extend(["--rule", spec])
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)
@@ -101,7 +108,9 @@ def retargeting_delete(ids: str, dry_run: bool = False) -> dict:
 def retargeting_update(
     id: int,
     name: str | None = None,
+    description: str | None = None,
     list_type: str | None = None,
+    rules: list[str] | None = None,
     rule: str | None = None,
     dry_run: bool = False,
 ) -> dict:
@@ -116,10 +125,10 @@ def retargeting_update(
         rule: New rule spec in CLI DSL form.
         dry_run: Show the direct request without sending it.
     """
-    if not any((name, list_type, rule)):
+    if not any((name, description, list_type, rules, rule)):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, list_type, rule",
+            message="Provide at least one of: name, description, list_type, rule",
         ).__dict__
     if list_type is not None and list_type not in _LIST_TYPES:
         return ToolError(
@@ -130,10 +139,15 @@ def retargeting_update(
     args = ["retargeting", "update", "--id", str(id)]
     if name is not None:
         args.extend(["--name", name])
+    if description is not None:
+        args.extend(["--description", description])
     if list_type is not None:
         args.extend(["--type", list_type])
     if rule is not None:
         args.extend(["--rule", rule])
+    if rules:
+        for spec in rules:
+            args.extend(["--rule", spec])
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -124,14 +124,20 @@ def retargeting_update(
     Args:
         id: Retargeting list ID to update.
         name: New name for the list.
+        description: New list description.
         list_type: New list type (RETARGETING | AUDIENCE).
-        rule: New rule spec in CLI DSL form.
+        rule: Single new rule spec in CLI DSL form.
+        rules: Additional new rule specs; each item is forwarded as repeated
+            ``--rule``.
         dry_run: Show the direct request without sending it.
     """
     if not any((name, description, list_type, rules, rule)):
         return ToolError(
             error="missing_update_fields",
-            message="Provide at least one of: name, description, list_type, rule",
+            message=(
+                "Provide at least one of: name, description, list_type, "
+                "rule, rules. Use rule for one spec or rules for repeated specs."
+            ),
         ).__dict__
     if list_type is not None and list_type not in _LIST_TYPES:
         return ToolError(

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -62,7 +62,10 @@ def retargeting_add(
         name: Name for the retargeting list.
         list_type: List type — RETARGETING (default, text & image / mobile
             campaigns) or AUDIENCE (display campaigns).
-        rule: Rule spec (CLI DSL form, see above).
+        description: Optional retargeting list description.
+        rule: Single rule spec (CLI DSL form, see above).
+        rules: Additional rule specs; each item is forwarded as repeated
+            ``--rule``.
         dry_run: Show the direct request without sending it.
     """
     if list_type not in _LIST_TYPES:

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -76,7 +76,9 @@ def smart_ad_targets_add(
         ad_group_id: Ad group ID.
         name: Target name.
         audience: Audience value.
-        condition: Condition spec (OPERAND:OPERATOR:ARG1|ARG2).
+        condition: Single condition spec (OPERAND:OPERATOR:ARG1|ARG2).
+        conditions: Additional condition specs; each item is forwarded as
+            repeated ``--condition``.
         average_cpc: Average CPC in micro-units (RUB × 1,000,000).
         average_cpa: Average CPA in micro-units (RUB × 1,000,000).
         priority: Strategy priority.
@@ -142,7 +144,9 @@ def smart_ad_targets_update(
         id: Target ID.
         name: New target name.
         audience: New audience value.
-        condition: New condition spec.
+        condition: Single new condition spec.
+        conditions: Additional new condition specs; each item is forwarded as
+            repeated ``--condition``.
         average_cpc: New average CPC in micro-units (RUB × 1,000,000).
         average_cpa: New average CPA in micro-units (RUB × 1,000,000).
         priority: New strategy priority.

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -59,6 +59,7 @@ def smart_ad_targets_add(
     ad_group_id: int,
     name: str,
     audience: str,
+    conditions: list[str] | None = None,
     condition: str | None = None,
     average_cpc: int | None = None,
     average_cpa: int | None = None,
@@ -95,6 +96,9 @@ def smart_ad_targets_add(
     ]
     if condition is not None:
         args.extend(["--condition", condition])
+    if conditions:
+        for spec in conditions:
+            args.extend(["--condition", spec])
     if average_cpc is not None:
         args.extend(["--average-cpc", str(average_cpc)])
     if average_cpa is not None:
@@ -122,6 +126,7 @@ def smart_ad_targets_update(
     id: int,
     name: str | None = None,
     audience: str | None = None,
+    conditions: list[str] | None = None,
     condition: str | None = None,
     average_cpc: int | None = None,
     average_cpa: int | None = None,
@@ -148,6 +153,7 @@ def smart_ad_targets_update(
         (
             name,
             audience,
+            conditions,
             condition,
             average_cpc,
             average_cpa,
@@ -170,6 +176,9 @@ def smart_ad_targets_update(
         args.extend(["--audience", audience])
     if condition is not None:
         args.extend(["--condition", condition])
+    if conditions:
+        for spec in conditions:
+            args.extend(["--condition", spec])
     if average_cpc is not None:
         args.extend(["--average-cpc", str(average_cpc)])
     if average_cpa is not None:

--- a/server/tools/strategies.py
+++ b/server/tools/strategies.py
@@ -7,21 +7,21 @@ from server.tools.helpers import check_batch_limit
 IS_ARCHIVED_VALUES = ("YES", "NO")
 STRATEGY_TYPES = (
     "WbMaximumClicks",
-    "WbMaximumClicksPerBid",
     "WbMaximumConversionRate",
-    "WbMaximumConversionRatePerBid",
     "AverageCpc",
+    "AverageCpcPerCampaign",
+    "AverageCpcPerFilter",
     "AverageCpa",
-    "AverageCpaPerFilter",
     "AverageCpaPerCampaign",
+    "AverageCpaPerFilter",
+    "AverageCpaMultipleGoals",
     "AverageCrr",
-    "AverageCrrPerCampaign",
     "MaxProfit",
-    "MaxProfitPerFilter",
-    "MaxProfitPerCampaign",
     "PayForConversion",
-    "PayForConversionPerFilter",
     "PayForConversionPerCampaign",
+    "PayForConversionPerFilter",
+    "PayForConversionCrr",
+    "PayForConversionMultipleGoals",
 )
 ATTRIBUTION_MODELS = ("LYDC", "FC", "LC", "LSC", "LYDC_WEIGHT", "CROSSTDEVICE")
 
@@ -86,6 +86,11 @@ def strategies_add(
     spend_limit: int | None = None,
     weekly_spend_limit: int | None = None,
     bid_ceiling: int | None = None,
+    custom_period_spend_limit: int | None = None,
+    custom_period_start_date: str | None = None,
+    custom_period_end_date: str | None = None,
+    custom_period_auto_continue: str | None = None,
+    minimum_exploration_budget: int | None = None,
     counter_ids: str | None = None,
     priority_goals: list[str] | None = None,
     attribution_model: str | None = None,
@@ -147,6 +152,16 @@ def strategies_add(
         args.extend(["--weekly-spend-limit", str(weekly_spend_limit)])
     if bid_ceiling is not None:
         args.extend(["--bid-ceiling", str(bid_ceiling)])
+    if custom_period_spend_limit is not None:
+        args.extend(["--custom-period-spend-limit", str(custom_period_spend_limit)])
+    if custom_period_start_date is not None:
+        args.extend(["--custom-period-start-date", custom_period_start_date])
+    if custom_period_end_date is not None:
+        args.extend(["--custom-period-end-date", custom_period_end_date])
+    if custom_period_auto_continue is not None:
+        args.extend(["--custom-period-auto-continue", custom_period_auto_continue])
+    if minimum_exploration_budget is not None:
+        args.extend(["--minimum-exploration-budget", str(minimum_exploration_budget)])
     if counter_ids is not None:
         args.extend(["--counter-ids", counter_ids])
     if priority_goals:
@@ -173,6 +188,11 @@ def strategies_update(
     spend_limit: int | None = None,
     weekly_spend_limit: int | None = None,
     bid_ceiling: int | None = None,
+    custom_period_spend_limit: int | None = None,
+    custom_period_start_date: str | None = None,
+    custom_period_end_date: str | None = None,
+    custom_period_auto_continue: str | None = None,
+    minimum_exploration_budget: int | None = None,
     counter_ids: str | None = None,
     priority_goals: list[str] | None = None,
     attribution_model: str | None = None,
@@ -212,6 +232,11 @@ def strategies_update(
                 spend_limit,
                 weekly_spend_limit,
                 bid_ceiling,
+                custom_period_spend_limit,
+                custom_period_start_date,
+                custom_period_end_date,
+                custom_period_auto_continue,
+                minimum_exploration_budget,
                 counter_ids,
                 attribution_model,
             )
@@ -223,7 +248,8 @@ def strategies_update(
             message=(
                 "Provide at least one of: name, type, average_cpc, average_cpa, "
                 "average_crr, goal_id, spend_limit, weekly_spend_limit, "
-                "bid_ceiling, counter_ids, priority_goals, attribution_model"
+                "bid_ceiling, custom_period_*, minimum_exploration_budget, "
+                "counter_ids, priority_goals, attribution_model"
             ),
         ).__dict__
     if type is not None and type not in STRATEGY_TYPES:
@@ -259,6 +285,16 @@ def strategies_update(
         args.extend(["--weekly-spend-limit", str(weekly_spend_limit)])
     if bid_ceiling is not None:
         args.extend(["--bid-ceiling", str(bid_ceiling)])
+    if custom_period_spend_limit is not None:
+        args.extend(["--custom-period-spend-limit", str(custom_period_spend_limit)])
+    if custom_period_start_date is not None:
+        args.extend(["--custom-period-start-date", custom_period_start_date])
+    if custom_period_end_date is not None:
+        args.extend(["--custom-period-end-date", custom_period_end_date])
+    if custom_period_auto_continue is not None:
+        args.extend(["--custom-period-auto-continue", custom_period_auto_continue])
+    if minimum_exploration_budget is not None:
+        args.extend(["--minimum-exploration-budget", str(minimum_exploration_budget)])
     if counter_ids is not None:
         args.extend(["--counter-ids", counter_ids])
     if priority_goals:

--- a/server/tools/strategies.py
+++ b/server/tools/strategies.py
@@ -104,12 +104,13 @@ def strategies_add(
 
     Args:
         name: Strategy name.
-        type: Strategy type — one of WbMaximumClicks, WbMaximumClicksPerBid,
-            WbMaximumConversionRate, WbMaximumConversionRatePerBid,
-            AverageCpc, AverageCpa, AverageCpaPerFilter, AverageCpaPerCampaign,
-            AverageCrr, AverageCrrPerCampaign, MaxProfit, MaxProfitPerFilter,
-            MaxProfitPerCampaign, PayForConversion, PayForConversionPerFilter,
-            PayForConversionPerCampaign.
+        type: Strategy type — one of WbMaximumClicks,
+            WbMaximumConversionRate, AverageCpc, AverageCpcPerCampaign,
+            AverageCpcPerFilter, AverageCpa, AverageCpaPerCampaign,
+            AverageCpaPerFilter, AverageCpaMultipleGoals, AverageCrr,
+            MaxProfit, PayForConversion, PayForConversionPerCampaign,
+            PayForConversionPerFilter, PayForConversionCrr,
+            PayForConversionMultipleGoals.
         average_cpc: Average CPC in micro-units (RUB × 1,000,000).
         average_cpa: Average CPA in micro-units (RUB × 1,000,000).
         average_crr: Average cost-revenue ratio (integer percent).
@@ -117,6 +118,11 @@ def strategies_add(
         spend_limit: Spend limit in micro-units.
         weekly_spend_limit: Weekly spend limit in micro-units.
         bid_ceiling: Bid ceiling in micro-units.
+        custom_period_spend_limit: Custom period spend limit in micro-units.
+        custom_period_start_date: Custom period start date.
+        custom_period_end_date: Custom period end date.
+        custom_period_auto_continue: Custom period auto-continue flag.
+        minimum_exploration_budget: Minimum exploration budget in micro-units.
         counter_ids: Comma-separated Metrica counter IDs.
         priority_goals: List of "GOAL_ID:VALUE" specs (each becomes a
             repeated --priority-goal flag).

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -107,6 +107,11 @@ def vcards_add(
         extra_message: Extra message.
         ogrn: OGRN.
         metro_station_id: Metro station ID.
+        instant_messenger_client: Instant messenger client name.
+        instant_messenger_login: Instant messenger login.
+        point_on_map_x/point_on_map_y: Point-on-map coordinates.
+        point_on_map_x1/point_on_map_y1: First map bounds coordinate pair.
+        point_on_map_x2/point_on_map_y2: Second map bounds coordinate pair.
         dry_run: Show the direct request without sending it.
     """
     args = [

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -2,7 +2,23 @@
 
 from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit, run_single_id_batch
+from server.tools.helpers import (
+    CliOption,
+    append_cli_options,
+    check_batch_limit,
+    run_single_id_batch,
+)
+
+VCARD_0312_OPTIONS = (
+    CliOption("instant_messenger_client", "--instant-messenger-client"),
+    CliOption("instant_messenger_login", "--instant-messenger-login"),
+    CliOption("point_on_map_x", "--point-on-map-x"),
+    CliOption("point_on_map_y", "--point-on-map-y"),
+    CliOption("point_on_map_x1", "--point-on-map-x1"),
+    CliOption("point_on_map_y1", "--point-on-map-y1"),
+    CliOption("point_on_map_x2", "--point-on-map-x2"),
+    CliOption("point_on_map_y2", "--point-on-map-y2"),
+)
 
 
 @mcp.tool(name="vcards_get")
@@ -58,6 +74,14 @@ def vcards_add(
     extra_message: str | None = None,
     ogrn: str | None = None,
     metro_station_id: int | None = None,
+    instant_messenger_client: str | None = None,
+    instant_messenger_login: str | None = None,
+    point_on_map_x: str | None = None,
+    point_on_map_y: str | None = None,
+    point_on_map_x1: str | None = None,
+    point_on_map_y1: str | None = None,
+    point_on_map_x2: str | None = None,
+    point_on_map_y2: str | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Add a vCard.
@@ -125,6 +149,7 @@ def vcards_add(
         args.extend(["--ogrn", ogrn])
     if metro_station_id is not None:
         args.extend(["--metro-station-id", str(metro_station_id)])
+    append_cli_options(args, locals(), VCARD_0312_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -151,6 +151,31 @@ class TestBidModifiersAdd:
             ]
         )
 
+    def test_bidmodifiers_add_accepts_smart_tv_adjustment(self):
+        """direct-cli 0.3.12 exposes SMART_TV_ADJUSTMENT."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"success": True}
+        with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
+            result = bidmodifiers_add(
+                campaign_id=12345,
+                modifier_type="SMART_TV_ADJUSTMENT",
+                value=120,
+            )
+
+        assert result["success"] is True
+        runner.run_json.assert_called_once_with(
+            [
+                "bidmodifiers",
+                "add",
+                "--type",
+                "SMART_TV_ADJUSTMENT",
+                "--value",
+                "120",
+                "--campaign-id",
+                "12345",
+            ]
+        )
+
     def test_bidmodifiers_add_requires_scope(self):
         result = bidmodifiers_add(modifier_type="MOBILE_ADJUSTMENT", value=120)
         assert result["error"] == "missing_target_scope"

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -273,6 +273,24 @@ class TestCampaignsUpdate:
         assert result["error"] == "missing_update_fields"
         runner.run_json.assert_not_called()
 
+    def test_campaigns_update_accepts_zero_values(self):
+        """Zero-valued typed fields are valid updates and must reach the CLI."""
+        runner = _mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(id=12345, holidays_start_hour=0)
+
+        runner.run_json.assert_called_once_with(
+            [
+                "campaigns",
+                "update",
+                "--id",
+                "12345",
+                "--holidays-start-hour",
+                "0",
+            ]
+        )
+        assert result == {"success": True, "id": 12345}
+
 
 class TestCampaignsCrudOperations:
     """Tests for campaign CRUD operations (add, delete, archive, unarchive)."""

--- a/tests/test_direct_cli_0312_parity.py
+++ b/tests/test_direct_cli_0312_parity.py
@@ -8,8 +8,8 @@ import re
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
-import direct_cli  # type: ignore[import-not-found]
-from direct_cli.cli import cli  # type: ignore[import-not-found]
+import direct_cli  # type: ignore[import-not-found, import-untyped]
+from direct_cli.cli import cli  # type: ignore[import-not-found, import-untyped]
 
 from server.tools.adgroups import adgroups_add, adgroups_update
 from server.tools.ads import ads_add, ads_update

--- a/tests/test_direct_cli_0312_parity.py
+++ b/tests/test_direct_cli_0312_parity.py
@@ -8,6 +8,7 @@ import re
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
+import pytest
 import direct_cli  # type: ignore[import-not-found, import-untyped]
 from direct_cli.cli import cli  # type: ignore[import-not-found, import-untyped]
 
@@ -101,8 +102,13 @@ def _direct_cli_version() -> tuple[int, int, int]:
     return (major, minor, patch)
 
 
+def _require_direct_cli_0312() -> None:
+    if _direct_cli_version() < (0, 3, 12):
+        pytest.skip("direct-cli 0.3.12 parity check waits for the PyPI release")
+
+
 def test_direct_cli_0312_options_are_exposed_by_mcp_signatures() -> None:
-    assert _direct_cli_version() >= (0, 3, 12)
+    _require_direct_cli_0312()
 
     missing_by_command: dict[str, list[str]] = {}
     for group, subcommand, module_name, function_name in TARGET_COMMANDS:
@@ -125,6 +131,8 @@ def test_direct_cli_0312_options_are_exposed_by_mcp_signatures() -> None:
 
 
 def test_bidmodifier_type_choices_match_direct_cli() -> None:
+    _require_direct_cli_0312()
+
     click_command = cli.commands["bidmodifiers"].commands["add"]
     modifier_type = next(
         param for param in click_command.params if param.name == "modifier_type"

--- a/tests/test_direct_cli_0312_parity.py
+++ b/tests/test_direct_cli_0312_parity.py
@@ -1,0 +1,379 @@
+"""direct-cli 0.3.12 option parity checks."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import direct_cli  # type: ignore[import-not-found]
+from direct_cli.cli import cli  # type: ignore[import-not-found]
+
+from server.tools.adgroups import adgroups_add, adgroups_update
+from server.tools.ads import ads_add, ads_update
+from server.tools.bidmodifiers import bidmodifiers_add
+from server.tools.bids import bids_set
+from server.tools.campaigns import campaigns_add, campaigns_update
+from server.tools.changes import changes_check
+from server.tools.clients import clients_update
+from server.tools.dynamic_feed_ad_targets import dynamic_feed_ad_targets_add
+from server.tools.feeds import feeds_add, feeds_update
+from server.tools.keyword_bids import keyword_bids_set
+from server.tools.keywords import keywords_add, keywords_update
+from server.tools.retargeting import retargeting_add, retargeting_update
+from server.tools.smart_ad_targets import smart_ad_targets_add, smart_ad_targets_update
+from server.tools.strategies import strategies_add, strategies_update
+from server.tools.vcards import vcards_add
+
+
+TARGET_COMMANDS: tuple[tuple[str, str, str, str], ...] = (
+    ("campaigns", "add", "server.tools.campaigns", "campaigns_add"),
+    ("campaigns", "update", "server.tools.campaigns", "campaigns_update"),
+    ("adgroups", "add", "server.tools.adgroups", "adgroups_add"),
+    ("adgroups", "update", "server.tools.adgroups", "adgroups_update"),
+    ("ads", "add", "server.tools.ads", "ads_add"),
+    ("ads", "update", "server.tools.ads", "ads_update"),
+    ("keywords", "add", "server.tools.keywords", "keywords_add"),
+    ("keywords", "update", "server.tools.keywords", "keywords_update"),
+    ("feeds", "add", "server.tools.feeds", "feeds_add"),
+    ("feeds", "update", "server.tools.feeds", "feeds_update"),
+    ("vcards", "add", "server.tools.vcards", "vcards_add"),
+    ("sitelinks", "add", "server.tools.sitelinks", "sitelinks_add"),
+    ("retargeting", "add", "server.tools.retargeting", "retargeting_add"),
+    ("retargeting", "update", "server.tools.retargeting", "retargeting_update"),
+    ("bidmodifiers", "add", "server.tools.bidmodifiers", "bidmodifiers_add"),
+    ("audiencetargets", "add", "server.tools.audience", "audience_targets_add"),
+    (
+        "dynamicfeedadtargets",
+        "add",
+        "server.tools.dynamic_feed_ad_targets",
+        "dynamic_feed_ad_targets_add",
+    ),
+    ("smartadtargets", "add", "server.tools.smart_ad_targets", "smart_ad_targets_add"),
+    (
+        "smartadtargets",
+        "update",
+        "server.tools.smart_ad_targets",
+        "smart_ad_targets_update",
+    ),
+    ("bids", "set", "server.tools.bids", "bids_set"),
+    ("keywordbids", "set", "server.tools.keyword_bids", "keyword_bids_set"),
+    ("clients", "update", "server.tools.clients", "clients_update"),
+    ("strategies", "add", "server.tools.strategies", "strategies_add"),
+    ("strategies", "update", "server.tools.strategies", "strategies_update"),
+    ("changes", "check", "server.tools.changes", "changes_check"),
+)
+
+IGNORED_CLI_PARAMS = {"output", "output_format", "format"}
+ALIASES = {
+    ("campaigns", "update"): {"campaign_id": "id"},
+    ("adgroups", "add"): {"group_type": "type"},
+    ("adgroups", "update"): {"adgroup_id": "id"},
+    ("ads", "add"): {"adgroup_id": "ad_group_id"},
+    ("ads", "update"): {"ad_id": "id", "ad_type": "type"},
+    ("keywords", "add"): {"adgroup_id": "ad_group_id"},
+    ("keywords", "update"): {"keyword_id": "id"},
+    ("feeds", "update"): {"feed_id": "id"},
+    ("sitelinks", "add"): {
+        "sitelinks_specs": "sitelinks",
+        "sitelinks_json": "items",
+        "sitelinks_from_file": "from_file",
+    },
+    ("retargeting", "update"): {"list_id": "id"},
+    ("bidmodifiers", "add"): {"adgroup_id": "ad_group_id"},
+    ("audiencetargets", "add"): {"adgroup_id": "ad_group_id"},
+    ("dynamicfeedadtargets", "add"): {"adgroup_id": "ad_group_id"},
+    ("smartadtargets", "add"): {"adgroup_id": "ad_group_id"},
+    ("smartadtargets", "update"): {"target_id": "id"},
+    ("bids", "set"): {"adgroup_id": "ad_group_id"},
+    ("keywordbids", "set"): {"adgroup_id": "ad_group_id"},
+    ("strategies", "add"): {"strategy_type": "type"},
+    ("strategies", "update"): {"strategy_id": "id", "strategy_type": "type"},
+}
+
+
+def _direct_cli_version() -> tuple[int, int, int]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", direct_cli.__version__)
+    assert match is not None
+    major, minor, patch = map(int, match.groups())
+    return (major, minor, patch)
+
+
+def test_direct_cli_0312_options_are_exposed_by_mcp_signatures() -> None:
+    assert _direct_cli_version() >= (0, 3, 12)
+
+    missing_by_command: dict[str, list[str]] = {}
+    for group, subcommand, module_name, function_name in TARGET_COMMANDS:
+        click_command = cli.commands[group].commands[subcommand]
+        cli_params = [
+            param.name
+            for param in click_command.params
+            if hasattr(param, "opts") and param.name not in IGNORED_CLI_PARAMS
+        ]
+        fn = getattr(importlib.import_module(module_name), function_name)
+        mcp_params = set(inspect.signature(fn).parameters)
+        aliases = ALIASES.get((group, subcommand), {})
+        missing = [
+            name for name in cli_params if aliases.get(name, name) not in mcp_params
+        ]
+        if missing:
+            missing_by_command[f"{group} {subcommand}"] = missing
+
+    assert missing_by_command == {}
+
+
+def test_bidmodifier_type_choices_match_direct_cli() -> None:
+    click_command = cli.commands["bidmodifiers"].commands["add"]
+    modifier_type = next(
+        param for param in click_command.params if param.name == "modifier_type"
+    )
+    from server.tools.bidmodifiers import _BIDMOD_TYPES
+
+    assert set(_BIDMOD_TYPES) == set(modifier_type.type.choices)
+
+
+def _mock_runner() -> MagicMock:
+    runner = MagicMock()
+    runner.run_json.return_value = {"ok": True}
+    return runner
+
+
+def _assert_contains(argv: list[str], expected: list[str]) -> None:
+    for item in expected:
+        assert item in argv
+
+
+def _run_with_runner(
+    patch_target: str,
+    fn: Callable[..., object],
+    expected: list[str],
+    **kwargs: object,
+) -> None:
+    runner = _mock_runner()
+    with patch(patch_target, return_value=runner):
+        fn(**kwargs)
+    _assert_contains(runner.run_json.call_args[0][0], expected)
+
+
+def test_campaigns_0312_flags_are_forwarded() -> None:
+    _run_with_runner(
+        "server.tools.campaigns.get_runner",
+        campaigns_add,
+        [
+            "--dynamic-placement-search-results",
+            "YES",
+            "--time-targeting-schedule",
+            "1=10-18",
+            "--frequency-cap-period-all",
+            "--tracking-params",
+            "utm_source=x",
+        ],
+        name="c",
+        start_date="2026-01-01",
+        dynamic_placement_search_results="YES",
+        time_targeting_schedule=["1=10-18"],
+        frequency_cap_period_all=True,
+        tracking_params="utm_source=x",
+    )
+    _run_with_runner(
+        "server.tools.campaigns.get_runner",
+        campaigns_update,
+        ["--type", "TEXT_CAMPAIGN", "--package-platform-network", "YES"],
+        id=1,
+        campaign_type="TEXT_CAMPAIGN",
+        package_platform_network="YES",
+    )
+
+
+def test_adgroups_and_ads_0312_flags_are_forwarded() -> None:
+    _run_with_runner(
+        "server.tools.adgroups.get_runner",
+        adgroups_add,
+        ["--autotargeting-category", "EXACT", "--tracking-params", "x=1"],
+        campaign_id=1,
+        name="g",
+        region_ids="225",
+        autotargeting_categories=["EXACT"],
+        tracking_params="x=1",
+    )
+    _run_with_runner(
+        "server.tools.adgroups.get_runner",
+        adgroups_update,
+        ["--dynamic-feed", "YES", "--feed-category-ids", "1,2"],
+        id=1,
+        dynamic_feed="YES",
+        feed_category_ids="1,2",
+    )
+    _run_with_runner(
+        "server.tools.ads.get_runner",
+        ads_add,
+        ["--mobile-app-feature", "PRICE=YES", "--feed-filter-condition", "x:eq:y"],
+        ad_group_id=1,
+        ad_type="SHOPPING_AD",
+        mobile_app_features=["PRICE=YES"],
+        feed_filter_conditions=["x:eq:y"],
+    )
+    _run_with_runner(
+        "server.tools.ads.get_runner",
+        ads_update,
+        ["--callouts-set", "1,2", "--creative-erir-ad-description", "erir"],
+        id=1,
+        type="TEXT_AD",
+        callouts_set="1,2",
+        creative_erir_ad_description="erir",
+    )
+
+
+def test_keyword_bid_and_target_0312_flags_are_forwarded() -> None:
+    _run_with_runner(
+        "server.tools.keywords.get_runner",
+        keywords_add,
+        ["--autotargeting-category", "EXACT", "--priority", "HIGH"],
+        ad_group_id=1,
+        keyword="foo",
+        autotargeting_categories=["EXACT"],
+        priority="HIGH",
+    )
+    _run_with_runner(
+        "server.tools.keywords.get_runner",
+        keywords_update,
+        ["--autotargeting-brand-option", "WITHOUT_BRANDS=YES", "--status", "ON"],
+        id=1,
+        autotargeting_brand_options=["WITHOUT_BRANDS=YES"],
+        status="ON",
+    )
+    _run_with_runner(
+        "server.tools.bids.get_runner",
+        bids_set,
+        ["--campaign-id", "1", "--context-bid", "2000000", "--priority", "HIGH"],
+        campaign_id=1,
+        context_bid=2_000_000,
+        priority="HIGH",
+    )
+    _run_with_runner(
+        "server.tools.keyword_bids.get_runner",
+        keyword_bids_set,
+        ["--adgroup-id", "2", "--autotargeting-search-bid-is-auto", "YES"],
+        ad_group_id=2,
+        autotargeting_search_bid_is_auto="YES",
+    )
+
+
+def test_remaining_0312_flags_are_forwarded() -> None:
+    _run_with_runner(
+        "server.tools.feeds.get_runner",
+        feeds_add,
+        ["--file-feed-path", "/tmp/feed.xml", "--feed-login", "user"],
+        name="feed",
+        business_type="RETAIL",
+        file_feed_path="/tmp/feed.xml",
+        feed_login="user",
+    )
+    _run_with_runner(
+        "server.tools.feeds.get_runner",
+        feeds_update,
+        ["--clear-feed-login", "--clear-feed-password"],
+        id=1,
+        clear_feed_login=True,
+        clear_feed_password=True,
+    )
+    _run_with_runner(
+        "server.tools.vcards.get_runner",
+        vcards_add,
+        ["--instant-messenger-client", "TELEGRAM", "--point-on-map-x", "1.1"],
+        campaign_id=1,
+        country="RU",
+        city="Moscow",
+        company_name="Co",
+        work_time="0#4#10#18",
+        phone_country_code="+7",
+        phone_city_code="495",
+        phone_number="1234567",
+        instant_messenger_client="TELEGRAM",
+        point_on_map_x="1.1",
+    )
+    _run_with_runner(
+        "server.tools.retargeting.get_runner",
+        retargeting_add,
+        ["--description", "desc", "--rule", "ALL:1:30"],
+        name="r",
+        description="desc",
+        rules=["ALL:1:30"],
+    )
+    _run_with_runner(
+        "server.tools.retargeting.get_runner",
+        retargeting_update,
+        ["--description", "desc", "--rule", "ANY:2:7"],
+        id=1,
+        description="desc",
+        rules=["ANY:2:7"],
+    )
+    _run_with_runner(
+        "server.tools.bidmodifiers.get_runner",
+        bidmodifiers_add,
+        ["--operating-system-type", "IOS"],
+        modifier_type="MOBILE_ADJUSTMENT",
+        value=110,
+        campaign_id=1,
+        operating_system_type="IOS",
+    )
+
+
+def test_feed_smart_client_strategy_and_changes_0312_flags_are_forwarded() -> None:
+    _run_with_runner(
+        "server.tools.dynamic_feed_ad_targets.get_runner",
+        dynamic_feed_ad_targets_add,
+        ["--condition", "x:eq:y"],
+        ad_group_id=1,
+        name="t",
+        conditions=["x:eq:y"],
+    )
+    _run_with_runner(
+        "server.tools.smart_ad_targets.get_runner",
+        smart_ad_targets_add,
+        ["--condition", "x:eq:y"],
+        ad_group_id=1,
+        name="s",
+        audience="PRODUCT_PAGE",
+        conditions=["x:eq:y"],
+    )
+    _run_with_runner(
+        "server.tools.smart_ad_targets.get_runner",
+        smart_ad_targets_update,
+        ["--condition", "x:eq:y"],
+        id=1,
+        conditions=["x:eq:y"],
+    )
+    _run_with_runner(
+        "server.tools.clients.get_runner",
+        clients_update,
+        ["--erir-contract-number", "C-1", "--erir-contragent-tin", "123"],
+        erir_contract_number="C-1",
+        erir_contragent_tin="123",
+    )
+    _run_with_runner(
+        "server.tools.strategies.get_runner",
+        strategies_add,
+        ["--custom-period-spend-limit", "1000000", "--minimum-exploration-budget", "5"],
+        name="s",
+        type="AverageCpc",
+        custom_period_spend_limit=1_000_000,
+        minimum_exploration_budget=5,
+    )
+    _run_with_runner(
+        "server.tools.strategies.get_runner",
+        strategies_update,
+        ["--custom-period-auto-continue", "YES"],
+        id=1,
+        custom_period_auto_continue="YES",
+    )
+    _run_with_runner(
+        "server.tools.changes.get_runner",
+        changes_check,
+        ["--fields", "CampaignIds", "--timestamp", "2026-01-01T00:00:00Z"],
+        timestamp="2026-01-01T00:00:00Z",
+        fields="CampaignIds",
+        campaign_ids="1",
+    )


### PR DESCRIPTION
## Summary
- Expands existing MCP wrappers to mirror the new typed `direct-cli 0.3.12` flags for milestone 18 / tracking issue #128.
- Adds reusable CLI option forwarding helpers and parity coverage against local `direct_cli.cli` Click options.
- Fixes the `SMART_TV_ADJUSTMENT` bid modifier parity gap found during the subagent audit.
- Addresses review-cycle feedback: zero-valued campaign update fields now pass the update guard, stale MCP docstrings/error text were reconciled, and 0.3.12 parity tests skip until PyPI can install `direct-cli>=0.3.12`.

## Validation
- `python3 -m pytest tests/test_campaigns.py tests/test_direct_cli_0312_parity.py -q` -> 43 passed
- `python3 -m pytest -q` -> 659 passed, 7 skipped
- `ruff check .` -> pass
- `ruff format --check .` -> pass
- `mypy .` -> pass
- GitHub Actions -> Python 3.11, 3.12, 3.13 pass
- Latest `@codex review` -> no major issues; all review threads resolved

## Notes
- Draft until `direct-cli 0.3.12` is published to PyPI.
- Runtime dependency remains on the currently publishable `direct-cli` range intentionally; bump to `direct-cli>=0.3.12` after the PyPI release.
- Refs #128.