### PR TITLE
[codex] Pass through adextensions CalloutFieldNames

### DIFF
--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -16,6 +16,7 @@ def adextensions_list(
     limit: int | None = None,
     fetch_all: bool = False,
     fields: str | None = None,
+    callout_field_names: str | None = None,
 ) -> list[dict] | dict:
     """List ad extensions.
 
@@ -28,6 +29,7 @@ def adextensions_list(
         limit: Limit number of results.
         fetch_all: Fetch all pages.
         fields: Comma-separated field names.
+        callout_field_names: Comma-separated CalloutFieldNames.
     """
     cmd = ["adextensions", "get", "--format", "json"]
     normalized_ids = ids.strip() if ids is not None else None
@@ -51,6 +53,8 @@ def adextensions_list(
         cmd.append("--fetch-all")
     if fields is not None:
         cmd.extend(["--fields", fields])
+    if callout_field_names is not None:
+        cmd.extend(["--callout-field-names", callout_field_names])
     return get_runner().run_json(cmd)
 
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -103,6 +103,32 @@ class TestAdextensionsList:
             ]
         )
 
+    def test_list_extensions_with_callout_field_names(self):
+        """Test CalloutFieldNames are passed through 1:1 via the CLI flag."""
+        runner = MagicMock()
+        runner.run_json.return_value = []
+        with patch("server.tools.adextensions.get_runner", return_value=runner):
+            adextensions_list(
+                types="CALLOUT",
+                fields="Id,Type,State,Status",
+                callout_field_names="CalloutText",
+            )
+
+        runner.run_json.assert_called_once_with(
+            [
+                "adextensions",
+                "get",
+                "--format",
+                "json",
+                "--types",
+                "CALLOUT",
+                "--fields",
+                "Id,Type,State,Status",
+                "--callout-field-names",
+                "CalloutText",
+            ]
+        )
+
     def test_list_extensions_empty_result(self):
         """Test empty response returns empty list."""
         with patch(


### PR DESCRIPTION
## Summary

Adds MCP passthrough support for the `direct-cli` `AdExtensions.get` `CalloutFieldNames` CLI flag.

## Changes

- Adds `callout_field_names` to `adextensions_get`.
- Passes it through as `--callout-field-names`, matching the direct-cli contract exactly.
- Adds argv regression coverage for `types`, `fields`, and `callout_field_names` together.

## Validation

- `python3 -m black --check server/tools/adextensions.py tests/test_extensions.py`
- `python3 -m ruff check server/tools/adextensions.py tests/test_extensions.py`
- `python3 -m pytest tests/test_extensions.py -q`
- `python3 -m pytest -q`
- `git diff --check`