### PR TITLE
docs: clarify keyword batch bid strategy behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,12 +495,13 @@ all new parameters are optional.
   file) or `keywords_json` (inline JSON array). Mutex with the single
   `keyword` form — passing zero or more than one of the three returns
   `ToolError(error="missing_mode" | "conflicting_modes")` without
-  invoking the CLI. Per-row WSDL CamelCase keys
-  (`AdGroupId`, `Keyword`, `Bid`, `ContextBid`, `UserParam1`,
-  `UserParam2`); top-level `ad_group_id` acts as a default that each row
-  can override. `Bid`/`ContextBid` are documented `Keywords.add` fields,
-  but they are strategy-dependent: omit them for auto-strategy / РСЯ
-  imports because Yandex ignores them and returns warning `10160`.
+  invoking the CLI. Per-row WSDL CamelCase keys: required `Keyword` and
+  `AdGroupId` unless top-level `ad_group_id` provides the default; optional
+  `Bid`, `ContextBid`, `UserParam1`, and `UserParam2`. Per-row `AdGroupId`
+  overrides the default. `Bid`/`ContextBid` are documented `Keywords.add`
+  fields, but they are strategy-dependent: do not set them for auto-strategy /
+  RSYA (РСЯ) JSONL or inline JSON imports because Yandex ignores them and
+  returns warning `10160`.
   CLI 0.3.9 forwards the array as a single Yandex Direct
   API request (up to 1000 keywords per call). The plugin does not read
   `from_file` itself — CLI opens the path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,7 +498,10 @@ all new parameters are optional.
   invoking the CLI. Per-row WSDL CamelCase keys
   (`AdGroupId`, `Keyword`, `Bid`, `ContextBid`, `UserParam1`,
   `UserParam2`); top-level `ad_group_id` acts as a default that each row
-  can override. CLI 0.3.9 forwards the array as a single Yandex Direct
+  can override. `Bid`/`ContextBid` are documented `Keywords.add` fields,
+  but they are strategy-dependent: omit them for auto-strategy / РСЯ
+  imports because Yandex ignores them and returns warning `10160`.
+  CLI 0.3.9 forwards the array as a single Yandex Direct
   API request (up to 1000 keywords per call). The plugin does not read
   `from_file` itself — CLI opens the path.
 - **`campaigns_add`**: 8 new optional fields for CPA strategies and

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -237,18 +237,19 @@ def keywords_add(
 
     1. Single: ad_group_id + keyword (+ optional bid / context_bid / user_params).
     2. JSONL batch: from_file = path to a .jsonl file, one keyword object per line.
-       Per-line schema (WSDL CamelCase): {"AdGroupId": int, "Keyword": str,
-       "Bid": int (micro-RUB), "ContextBid": int, "UserParam1": str,
-       "UserParam2": str}. Per-line AdGroupId overrides the top-level
-       ad_group_id default.
+       Per-line schema uses WSDL CamelCase: required keys are "Keyword" and
+       "AdGroupId" unless a top-level ad_group_id default is provided. Optional
+       keys are "Bid" (micro-RUB), "ContextBid" (micro-RUB), "UserParam1", and
+       "UserParam2". Per-line AdGroupId overrides the top-level ad_group_id
+       default.
     3. Inline JSON: keywords_json = a JSON array of the same objects.
 
     `Bid` and `ContextBid` are documented Yandex Direct `Keywords.add`
     fields, but they are strategy-dependent: `Bid` is only for manual
     strategies, and `ContextBid` is only for manual strategies with
     independent ad-network bid management. For automatic strategies, Yandex
-    ignores these values and returns warning 10160; omit them in
-    auto-strategy / RSYA JSONL inputs.
+    ignores these values and returns warning 10160; do not set them in
+    auto-strategy / RSYA (РСЯ) JSONL or inline JSON inputs.
 
     CLI 0.3.9 forwards the array as a single Yandex Direct API request (up to
     1000 keywords per call).

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -243,6 +243,13 @@ def keywords_add(
        ad_group_id default.
     3. Inline JSON: keywords_json = a JSON array of the same objects.
 
+    `Bid` and `ContextBid` are documented Yandex Direct `Keywords.add`
+    fields, but they are strategy-dependent: `Bid` is only for manual
+    strategies, and `ContextBid` is only for manual strategies with
+    independent ad-network bid management. For automatic strategies, Yandex
+    ignores these values and returns warning 10160; omit them in
+    auto-strategy / RSYA JSONL inputs.
+
     CLI 0.3.9 forwards the array as a single Yandex Direct API request (up to
     1000 keywords per call).
 


### PR DESCRIPTION
Fixes #133.

## Summary
- document that keyword batch Bid and ContextBid mirror Yandex Keywords.add fields but are strategy-dependent
- tell MCP users to omit Bid and ContextBid in auto-strategy / RSYA JSONL inputs because Yandex ignores them and returns warning 10160
- keep behavior aligned with Yandex docs and the upstream direct-cli follow-up in axisrow/direct-cli#377

## Validation
- python -m pytest tests/test_keywords.py
- ruff check .
- mypy .