### PR TITLE
[codex] fix scalar CLI JSON responses

### DIFF
--- a/server/cli/runner.py
+++ b/server/cli/runner.py
@@ -309,9 +309,13 @@ class DirectCliRunner:
             return []
 
         try:
-            return json.loads(output)
+            parsed = json.loads(output)
         except json.JSONDecodeError as e:
             raise CliError(f"Failed to parse CLI output as JSON: {e}") from e
+
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return {"result": parsed}
 
 
 def _raise_for_status(result: subprocess.CompletedProcess[str]) -> None:

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -753,6 +753,19 @@ class TestRunJson:
             assert len(result) == 1
             assert result[0]["Id"] == 12345
 
+    def test_scalar_json_response_is_wrapped(self, runner):
+        mock_result = MagicMock()
+        mock_result.stdout = "1"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with (
+            patch("server.cli.runner.shutil.which", return_value="/usr/bin/direct"),
+            patch("server.cli.runner.subprocess.run", return_value=mock_result),
+        ):
+            result = runner.run_json(["v4tags", "update-banners", "--format", "json"])
+            assert result == {"result": 1}
+
     def test_auth_error(self, runner):
         """Test 401 response."""
         mock_result = MagicMock()

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -288,6 +288,17 @@ def test_v4tags_update_banners_clear_tags_dry_run():
     )
 
 
+def test_v4tags_update_banners_returns_wrapped_scalar():
+    runner = _mock_runner({"result": 1})
+    with patch("server.tools.v4tags.get_runner", return_value=runner):
+        result = v4tags_update_banners(
+            banner_ids="111,222",
+            tag_ids="10,20",
+        )
+
+    assert result == {"result": 1}
+
+
 def test_v4tags_update_banners_requires_banner_ids():
     result = v4tags_update_banners(banner_ids="   ", tag_ids="10")
     assert result["error"] == "missing_banner_ids"

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-
+from server.cli.runner import DirectCliRunner
 from server.contract import (
     PUBLIC_TOOL_NAMES,
     V4_LIVE_BLOCKED_METHOD_NAMES,
@@ -27,6 +27,14 @@ def _mock_runner(return_value):
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
+
+
+def _completed(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = ""
+    result.returncode = 0
+    return result
 
 
 def test_balance_get_without_logins():
@@ -289,8 +297,15 @@ def test_v4tags_update_banners_clear_tags_dry_run():
 
 
 def test_v4tags_update_banners_returns_wrapped_scalar():
-    runner = _mock_runner({"result": 1})
-    with patch("server.tools.v4tags.get_runner", return_value=runner):
+    runner = DirectCliRunner()
+    with (
+        patch("server.tools.v4tags.get_runner", return_value=runner),
+        patch(
+            "server.cli.runner._resolve_direct_cached",
+            return_value="/usr/bin/direct",
+        ),
+        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+    ):
         result = v4tags_update_banners(
             banner_ids="111,222",
             tag_ids="10,20",

--- a/tests/test_v4forecast.py
+++ b/tests/test_v4forecast.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from server.cli.runner import DirectCliRunner
 from server.tools.v4forecast import (
     v4forecast_create,
     v4forecast_delete,
@@ -14,6 +15,14 @@ def _mock_runner(return_value):
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
+
+
+def _completed(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = ""
+    result.returncode = 0
+    return result
 
 
 def test_v4forecast_create_argv():
@@ -60,8 +69,18 @@ def test_v4forecast_create_dry_run():
 
 
 def test_v4forecast_create_returns_wrapped_scalar():
-    runner = _mock_runner({"result": 987654321})
-    with patch("server.tools.v4forecast.get_runner", return_value=runner):
+    runner = DirectCliRunner()
+    with (
+        patch("server.tools.v4forecast.get_runner", return_value=runner),
+        patch(
+            "server.cli.runner._resolve_direct_cached",
+            return_value="/usr/bin/direct",
+        ),
+        patch(
+            "server.cli.runner.subprocess.run",
+            return_value=_completed("987654321"),
+        ),
+    ):
         result = v4forecast_create(phrases="phrase")
     assert result == {"result": 987654321}
 
@@ -114,7 +133,14 @@ def test_v4forecast_delete_dry_run():
 
 
 def test_v4forecast_delete_returns_wrapped_scalar():
-    runner = _mock_runner({"result": 1})
-    with patch("server.tools.v4forecast.get_runner", return_value=runner):
+    runner = DirectCliRunner()
+    with (
+        patch("server.tools.v4forecast.get_runner", return_value=runner),
+        patch(
+            "server.cli.runner._resolve_direct_cached",
+            return_value="/usr/bin/direct",
+        ),
+        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+    ):
         result = v4forecast_delete(forecast_id=42)
     assert result == {"result": 1}

--- a/tests/test_v4forecast.py
+++ b/tests/test_v4forecast.py
@@ -59,6 +59,13 @@ def test_v4forecast_create_dry_run():
         assert "--dry-run" in argv
 
 
+def test_v4forecast_create_returns_wrapped_scalar():
+    runner = _mock_runner({"result": 987654321})
+    with patch("server.tools.v4forecast.get_runner", return_value=runner):
+        result = v4forecast_create(phrases="phrase")
+    assert result == {"result": 987654321}
+
+
 def test_v4forecast_list_argv():
     runner = _mock_runner([])
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
@@ -104,3 +111,10 @@ def test_v4forecast_delete_dry_run():
         v4forecast_delete(forecast_id=42, dry_run=True)
         argv = runner.run_json.call_args[0][0]
         assert "--dry-run" in argv
+
+
+def test_v4forecast_delete_returns_wrapped_scalar():
+    runner = _mock_runner({"result": 1})
+    with patch("server.tools.v4forecast.get_runner", return_value=runner):
+        result = v4forecast_delete(forecast_id=42)
+    assert result == {"result": 1}

--- a/tests/test_v4wordstat.py
+++ b/tests/test_v4wordstat.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from server.cli.runner import DirectCliRunner
 from server.tools.v4wordstat import (
     v4wordstat_create_report,
     v4wordstat_delete_report,
@@ -14,6 +15,14 @@ def _mock_runner(return_value):
     runner = MagicMock()
     runner.run_json.return_value = return_value
     return runner
+
+
+def _completed(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = ""
+    result.returncode = 0
+    return result
 
 
 def test_v4wordstat_create_report_argv():
@@ -62,8 +71,18 @@ def test_v4wordstat_create_report_dry_run():
 
 
 def test_v4wordstat_create_report_returns_wrapped_scalar():
-    runner = _mock_runner({"result": 1233756017})
-    with patch("server.tools.v4wordstat.get_runner", return_value=runner):
+    runner = DirectCliRunner()
+    with (
+        patch("server.tools.v4wordstat.get_runner", return_value=runner),
+        patch(
+            "server.cli.runner._resolve_direct_cached",
+            return_value="/usr/bin/direct",
+        ),
+        patch(
+            "server.cli.runner.subprocess.run",
+            return_value=_completed("1233756017"),
+        ),
+    ):
         result = v4wordstat_create_report(phrases="phrase")
     assert result == {"result": 1233756017}
 
@@ -131,7 +150,14 @@ def test_v4wordstat_delete_report_dry_run():
 
 
 def test_v4wordstat_delete_report_returns_wrapped_scalar():
-    runner = _mock_runner({"result": 1})
-    with patch("server.tools.v4wordstat.get_runner", return_value=runner):
+    runner = DirectCliRunner()
+    with (
+        patch("server.tools.v4wordstat.get_runner", return_value=runner),
+        patch(
+            "server.cli.runner._resolve_direct_cached",
+            return_value="/usr/bin/direct",
+        ),
+        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+    ):
         result = v4wordstat_delete_report(report_id=42)
     assert result == {"result": 1}

--- a/tests/test_v4wordstat.py
+++ b/tests/test_v4wordstat.py
@@ -61,6 +61,13 @@ def test_v4wordstat_create_report_dry_run():
     assert "--dry-run" in argv
 
 
+def test_v4wordstat_create_report_returns_wrapped_scalar():
+    runner = _mock_runner({"result": 1233756017})
+    with patch("server.tools.v4wordstat.get_runner", return_value=runner):
+        result = v4wordstat_create_report(phrases="phrase")
+    assert result == {"result": 1233756017}
+
+
 def test_v4wordstat_list_reports_argv():
     runner = _mock_runner([])
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
@@ -121,3 +128,10 @@ def test_v4wordstat_delete_report_dry_run():
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_delete_report(report_id=42, dry_run=True)
     assert "--dry-run" in runner.run_json.call_args.args[0]
+
+
+def test_v4wordstat_delete_report_returns_wrapped_scalar():
+    runner = _mock_runner({"result": 1})
+    with patch("server.tools.v4wordstat.get_runner", return_value=runner):
+        result = v4wordstat_delete_report(report_id=42)
+    assert result == {"result": 1}


### PR DESCRIPTION
## Summary

- Wrap scalar JSON responses from `direct` as `{ "result": value }` in the MCP runner.
- Preserve existing object/list JSON responses unchanged.
- Add regressions for scalar-returning v4 Wordstat, Forecast, and Tags tools.

## Root Cause

Some `direct-cli` commands legitimately return JSON scalars such as `1` or a report ID. The plugin runner parsed those values correctly, but MCP tool return annotations expect an object or list, so Pydantic surfaced a successful operation as a validation error.

## Validation

- `pytest tests/test_cli_runner.py tests/test_v4wordstat.py tests/test_v4forecast.py`
- `pytest tests/test_v4_tools.py`
- `pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy .`