### PR TITLE
fix: address audit validation and test findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yandex-direct-mcp-plugin"
 version = "0.2.1.3"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.3.13"]
+dependencies = ["mcp", "direct-cli>=0.3.12"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -2,7 +2,12 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options, check_batch_limit
+from server.tools.helpers import (
+    CliOption,
+    append_cli_options,
+    check_batch_limit,
+    provided_update_value,
+)
 
 MAX_BATCH_SIZE = 10
 
@@ -250,7 +255,11 @@ def adgroups_update(
         dry_run: Show the direct request without sending it.
     """
     values = locals()
-    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
+    if not any(
+        provided_update_value(value)
+        for key, value in values.items()
+        if key not in {"id", "dry_run"}
+    ):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed ad group field to update.",

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options
+from server.tools.helpers import CliOption, append_cli_options, provided_update_value
 
 ERIR_OPTIONS = (
     CliOption("erir_organization_name", "--erir-organization-name"),
@@ -122,7 +122,11 @@ def clients_update(
         dry_run: Show the direct request without sending it.
     """
     values = locals()
-    if not any(value for key, value in values.items() if key not in {"dry_run"}):
+    if not any(
+        provided_update_value(value)
+        for key, value in values.items()
+        if key not in {"dry_run"}
+    ):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed client field to update.",

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options
+from server.tools.helpers import CliOption, append_cli_options, provided_update_value
 
 BUSINESS_TYPES = ("RETAIL", "HOTELS", "REALTY", "AUTOMOBILES", "FLIGHTS", "OTHER")
 
@@ -126,7 +126,11 @@ def feeds_update(
         dry_run: Show the direct request without sending it.
     """
     values = locals()
-    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
+    if not any(
+        provided_update_value(value)
+        for key, value in values.items()
+        if key not in {"id", "dry_run"}
+    ):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed feed field to update.",

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -1,7 +1,7 @@
 """Shared helpers for MCP tool modules."""
 
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from server.cli.runner import (
     CliAuthError,
@@ -69,6 +69,22 @@ def check_batch_limit(ids_str: str, max_size: int = MAX_BATCH_SIZE) -> ToolError
     return None
 
 
+def tool_error_dict(error: ToolError) -> dict:
+    """Return a stable dict representation for MCP error payloads."""
+    return asdict(error)
+
+
+def provided_update_value(value: object) -> bool:
+    """Return whether an optional update value should satisfy update guards."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
 def validate_state(state: str, allowed: tuple[str, ...]) -> ToolError | None:
     """Validate state value against allowed options."""
     if state not in allowed:
@@ -108,14 +124,16 @@ def run_single_id_batch(
     """
     batch_error = check_batch_limit(ids_str)
     if batch_error:
-        return batch_error.__dict__
+        return tool_error_dict(batch_error)
 
     ids = parse_ids(ids_str)
     if not ids:
-        return ToolError(
-            error="missing_ids",
-            message=f"Provide at least one {resource} ID.",
-        ).__dict__
+        return tool_error_dict(
+            ToolError(
+                error="missing_ids",
+                message=f"Provide at least one {resource} ID.",
+            )
+        )
     results = []
     succeeded = []
     failed = []

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options
+from server.tools.helpers import CliOption, append_cli_options, provided_update_value
 
 MAX_BATCH_SIZE = 10
 
@@ -139,8 +139,8 @@ def keywords_update(
     autotargeting_settings_without_brands: str | None = None,
     autotargeting_settings_with_advertiser_brand: str | None = None,
     autotargeting_settings_with_competitors_brand: str | None = None,
-    bid: str | None = None,
-    context_bid: str | None = None,
+    bid: int | None = None,
+    context_bid: int | None = None,
     status: str | None = None,
     dry_run: bool = False,
 ) -> dict:
@@ -165,7 +165,11 @@ def keywords_update(
         dry_run: Show the direct request without sending it.
     """
     values = locals()
-    if not any(value for key, value in values.items() if key not in {"id", "dry_run"}):
+    if not any(
+        provided_update_value(value)
+        for key, value in values.items()
+        if key not in {"id", "dry_run"}
+    ):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed keyword field to update.",
@@ -181,9 +185,9 @@ def keywords_update(
         args.extend(["--user-param-2", user_param_2])
     append_cli_options(args, values, KEYWORD_AUTOTARGETING_OPTIONS)
     if bid is not None:
-        args.extend(["--bid", bid])
+        args.extend(["--bid", str(bid)])
     if context_bid is not None:
-        args.extend(["--context-bid", context_bid])
+        args.extend(["--context-bid", str(context_bid)])
     if status is not None:
         args.extend(["--status", status])
     if dry_run:

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import tool_error_dict
 
 DEFAULT_REPORT_TYPE = "CAMPAIGN_PERFORMANCE_REPORT"
 DEFAULT_REPORT_NAME = "mcp_campaign_performance"
@@ -73,21 +74,45 @@ def _is_goals_filter(filter_expr: str) -> bool:
     return filter_expr.lstrip().lower().startswith("goals:")
 
 
+def _invalid_date_format(field_name: str, value: str) -> ToolError:
+    return ToolError(
+        error="invalid_date_format",
+        message=f"{field_name} must use YYYY-MM-DD format; got {value!r}.",
+    )
+
+
+def _parse_report_date(field_name: str, value: str) -> date | ToolError:
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return _invalid_date_format(field_name, value)
+
+
 def _resolve_report_dates(
     date_from: str | None, date_to: str | None
-) -> tuple[str, str]:
+) -> tuple[str, str] | ToolError:
     """Resolve the reporting window to match Direct's default day range."""
     if date_from and date_to:
+        parsed_from = _parse_report_date("date_from", date_from)
+        if isinstance(parsed_from, ToolError):
+            return parsed_from
+        parsed_to = _parse_report_date("date_to", date_to)
+        if isinstance(parsed_to, ToolError):
+            return parsed_to
         return date_from, date_to
 
     if date_to:
-        resolved_to = date.fromisoformat(date_to)
+        resolved_to = _parse_report_date("date_to", date_to)
+        if isinstance(resolved_to, ToolError):
+            return resolved_to
         resolved_from = resolved_to - timedelta(days=DEFAULT_WINDOW_DAYS)
         return resolved_from.isoformat(), date_to
 
     if date_from:
-        resolved_from = date.fromisoformat(date_from)
-        resolved_to = resolved_from + timedelta(days=DEFAULT_WINDOW_DAYS)
+        parsed_from = _parse_report_date("date_from", date_from)
+        if isinstance(parsed_from, ToolError):
+            return parsed_from
+        resolved_to = parsed_from + timedelta(days=DEFAULT_WINDOW_DAYS)
         return date_from, resolved_to.isoformat()
 
     today = date.today()
@@ -120,7 +145,10 @@ def reports_get(
         date_to: End date (YYYY-MM-DD). Defaults to today.
     """
     runner = get_runner()
-    resolved_from, resolved_to = _resolve_report_dates(date_from, date_to)
+    resolved_dates = _resolve_report_dates(date_from, date_to)
+    if isinstance(resolved_dates, ToolError):
+        return tool_error_dict(resolved_dates)
+    resolved_from, resolved_to = resolved_dates
     args = [
         "reports",
         "get",
@@ -470,17 +498,28 @@ def reports_custom(
         this in advance, run with `dry_run=True`.
     """
     if response_format not in VALID_RESPONSE_FORMATS:
-        raise ValueError(
-            f"unknown response_format {response_format!r}; "
-            f"expected one of {sorted(VALID_RESPONSE_FORMATS)}"
+        return tool_error_dict(
+            ToolError(
+                error="invalid_response_format",
+                message=(
+                    f"response_format must be one of {sorted(VALID_RESPONSE_FORMATS)}; "
+                    f"got {response_format!r}."
+                ),
+            )
         )
     if date_range_type and (date_from or date_to):
-        raise ValueError(
-            "pass either date_range_type OR explicit date_from/date_to, not both"
+        return tool_error_dict(
+            ToolError(
+                error="conflicting_date_inputs",
+                message="Pass either date_range_type OR explicit date_from/date_to, not both.",
+            )
         )
     if not date_range_type and (not date_from or not date_to):
-        raise ValueError(
-            "pass both date_from and date_to, or use date_range_type for a preset range"
+        return tool_error_dict(
+            ToolError(
+                error="missing_date_range",
+                message="Pass both date_from and date_to, or use date_range_type for a preset range.",
+            )
         )
     if processing_mode is not None and processing_mode not in VALID_PROCESSING_MODES:
         return ToolError(
@@ -515,9 +554,14 @@ def reports_custom(
 
     effective_filters: list[str] = list(filters) if filters else []
     if any(_is_goals_filter(f) for f in effective_filters):
-        raise ValueError(
-            "Goals filters are not supported by Reports API Filter.Field; "
-            "pass goal IDs via goal_ids instead"
+        return tool_error_dict(
+            ToolError(
+                error="invalid_goals_filter",
+                message=(
+                    "Goals filters are not supported by Reports API Filter.Field; "
+                    "pass goal IDs via goal_ids instead."
+                ),
+            )
         )
 
     # report_type / date_range_type values are enforced by the direct CLI's
@@ -532,7 +576,10 @@ def reports_custom(
     if date_range_type:
         args.extend(["--date-range-type", date_range_type])
     else:
-        resolved_from, resolved_to = _resolve_report_dates(date_from, date_to)
+        resolved_dates = _resolve_report_dates(date_from, date_to)
+        if isinstance(resolved_dates, ToolError):
+            return tool_error_dict(resolved_dates)
+        resolved_from, resolved_to = resolved_dates
         args.extend(["--from", resolved_from, "--to", resolved_to])
 
     args.extend(["--name", name, "--fields", field_names])
@@ -594,7 +641,12 @@ def reports_custom(
 
     resolved_output_path: Path | None = None
     if output_path and not dry_run:
-        resolved_output_path = _resolve_output_path(output_path)
+        try:
+            resolved_output_path = _resolve_output_path(output_path)
+        except ValueError as e:
+            return tool_error_dict(
+                ToolError(error="invalid_output_path", message=str(e))
+            )
         args.extend(["--output", str(resolved_output_path)])
     args.extend(["--format", response_format])
 

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -522,32 +522,38 @@ def reports_custom(
             )
         )
     if processing_mode is not None and processing_mode not in VALID_PROCESSING_MODES:
-        return ToolError(
-            error="invalid_processing_mode",
-            message=(
-                f"processing_mode must be one of {sorted(VALID_PROCESSING_MODES)}; "
-                f"got {processing_mode!r}."
-            ),
-        ).__dict__
+        return tool_error_dict(
+            ToolError(
+                error="invalid_processing_mode",
+                message=(
+                    f"processing_mode must be one of {sorted(VALID_PROCESSING_MODES)}; "
+                    f"got {processing_mode!r}."
+                ),
+            )
+        )
     if language is not None and language not in VALID_REPORT_LANGUAGES:
-        return ToolError(
-            error="invalid_language",
-            message=(
-                f"language must be one of {sorted(VALID_REPORT_LANGUAGES)}; "
-                f"got {language!r}."
-            ),
-        ).__dict__
+        return tool_error_dict(
+            ToolError(
+                error="invalid_language",
+                message=(
+                    f"language must be one of {sorted(VALID_REPORT_LANGUAGES)}; "
+                    f"got {language!r}."
+                ),
+            )
+        )
     if attribution_models is not None:
         tokens = [t.strip() for t in attribution_models.split(",") if t.strip()]
         unknown = [m for m in tokens if m not in VALID_ATTRIBUTION_MODELS]
         if unknown:
-            return ToolError(
-                error="invalid_attribution_models",
-                message=(
-                    f"Unknown attribution models: {unknown}. "
-                    f"Allowed: {sorted(VALID_ATTRIBUTION_MODELS)}."
-                ),
-            ).__dict__
+            return tool_error_dict(
+                ToolError(
+                    error="invalid_attribution_models",
+                    message=(
+                        f"Unknown attribution models: {unknown}. "
+                        f"Allowed: {sorted(VALID_ATTRIBUTION_MODELS)}."
+                    ),
+                )
+            )
         # Normalize: send a whitespace-clean CSV to the CLI so what we
         # validated is bit-for-bit what reaches the CLI.
         attribution_models = ",".join(tokens)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.cli_recorder import CassetteNotFoundError, CliRecorder
+from tests.cli_recorder import CliRecorder
 
 RECORDINGS_DIR = Path(__file__).parent / "recordings"
 LIVE_MARKERS = {"integration", "live_safe", "live_unsafe"}
@@ -46,6 +46,13 @@ def pytest_collection_modifyitems(config, items):
         elif item.get_closest_marker("live_safe") and not run_live_safe:
             item.add_marker(skip_live_safe)
 
+        if (
+            not _is_live_test(item)
+            and "cli_recorder" not in getattr(item, "fixturenames", ())
+            and not item.get_closest_marker("mocks")
+        ):
+            item.add_marker(pytest.mark.mocks)
+
 
 @pytest.fixture(autouse=True)
 def isolate_env(monkeypatch, tmp_path, request):
@@ -70,16 +77,8 @@ def cli_recorder(monkeypatch, request):
         yield recorder
     else:
         # Replay mode: patch subprocess.run
-        import subprocess
-
-        original_run = subprocess.run
-
         def _patched_run(args, **kwargs):
-            try:
-                return recorder.replay(args)
-            except CassetteNotFoundError:
-                # No cassette found — fall through to real subprocess
-                return original_run(args, **kwargs)
+            return recorder.replay(args)
 
         with patch("subprocess.run", side_effect=_patched_run):
             yield recorder

--- a/tests/test_adgroups.py
+++ b/tests/test_adgroups.py
@@ -114,6 +114,16 @@ class TestAdgroupsUpdate:
         assert "error" in result
         assert result["error"] == "missing_update_fields"
 
+    def test_adgroups_update_accepts_empty_string_field(self):
+        """Empty strings are provided values; CLI owns semantic validation."""
+        runner = _mock_runner({"Id": 123})
+        with patch("server.tools.adgroups.get_runner", return_value=runner):
+            adgroups_update(id=123, name="")
+
+        runner.run_json.assert_called_once_with(
+            ["adgroups", "update", "--id", "123", "--name", ""]
+        )
+
     def test_adgroups_update_with_status(self):
         """Test updating with status."""
         runner = MagicMock()

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -14,7 +14,7 @@ from server.tools.campaigns import (
     campaigns_suspend,
     campaigns_resume,
 )
-from server.cli.runner import CliAuthError
+from server.cli.runner import CliAuthError, CliError
 
 
 @pytest.fixture
@@ -207,7 +207,9 @@ class TestCampaignsUpdate:
     def test_not_found_campaign(self):
         """Test 10: Nonexistent campaign."""
         runner = MagicMock()
-        runner.run_json.side_effect = Exception("Campaign 999 not found")
+        runner.run_json.side_effect = CliError(
+            "Campaign 999 not found", error_code=8800
+        )
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_update(id=999, status="ON")
             assert "error" in result
@@ -290,6 +292,22 @@ class TestCampaignsUpdate:
             ]
         )
         assert result == {"success": True, "id": 12345}
+
+    def test_campaigns_update_passes_notification_and_time_targeting_json(self):
+        """Update supports JSON aliases just like add."""
+        runner = _mock_runner({"Id": 12345})
+        notification = '{"EmailSettings":{"Email":"ops@example.com"}}'
+        time_targeting = '{"ConsiderWorkingWeekends":"YES"}'
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_update(
+                id=12345,
+                notification_json=notification,
+                time_targeting_json=time_targeting,
+            )
+
+        argv = runner.run_json.call_args[0][0]
+        assert argv[argv.index("--notification") + 1] == notification
+        assert argv[argv.index("--time-targeting") + 1] == time_targeting
 
 
 class TestCampaignsCrudOperations:
@@ -470,9 +488,12 @@ class TestCampaignsCrudOperations:
     def test_campaigns_delete_batch_limit(self):
         """Test batch limit validation for delete."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
-        result = campaigns_delete(ids=ids)
+        runner = _mock_runner({"success": True})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_delete(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
+        runner.run_json.assert_not_called()
 
     def test_campaigns_archive_success(self):
         """Test archiving campaigns successfully."""

--- a/tests/test_cli_recorder.py
+++ b/tests/test_cli_recorder.py
@@ -76,6 +76,26 @@ class TestReplay:
         with pytest.raises(CassetteNotFoundError):
             recorder.replay(["direct", "unknown", "command"])
 
+    def test_cli_recorder_fixture_replays_committed_cassette(self, cli_recorder):
+        """Default replay mode must use cassettes instead of the real CLI."""
+        result = subprocess.run(
+            ["direct", "campaigns", "get", "--format", "json"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "TEXT_CAMPAIGN" in result.stdout
+
+    def test_cli_recorder_fixture_fails_closed_on_missing_cassette(self, cli_recorder):
+        """Missing cassettes must not fall through to a live subprocess."""
+        with pytest.raises(CassetteNotFoundError):
+            subprocess.run(
+                ["direct", "unknown", "command"],
+                capture_output=True,
+                text=True,
+            )
+
 
 class TestIsRecording:
     def test_recording_mode_on(self, recorder):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -113,6 +113,17 @@ class TestClientsUpdate:
         result = clients_update()
         assert result["error"] == "missing_update_fields"
 
+    def test_update_client_accepts_empty_string_field(self):
+        """Empty strings are provided values; CLI owns semantic validation."""
+        runner = MagicMock()
+        runner.run_json.return_value = {"Login": "client1"}
+        with patch("server.tools.clients.get_runner", return_value=runner):
+            clients_update(client_info="")
+
+        runner.run_json.assert_called_once_with(
+            ["clients", "update", "--client-info", ""]
+        )
+
     def test_update_client_dry_run(self):
         runner = MagicMock()
         runner.run_json.return_value = {"_dry_run": True}

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -140,6 +140,16 @@ class TestFeedsUpdate:
         assert "error" in result
         assert result["error"] == "missing_update_fields"
 
+    def test_feeds_update_accepts_empty_string_field(self):
+        """Empty strings are provided values; CLI owns semantic validation."""
+        runner = _mock_runner({"id": 1})
+        with patch("server.tools.feeds.get_runner", return_value=runner):
+            feeds_update(id=1, name="")
+
+        runner.run_json.assert_called_once_with(
+            ["feeds", "update", "--id", "1", "--name", ""]
+        )
+
 
 class TestFeedsDelete:
     """Tests for feeds_delete tool."""

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -111,6 +111,26 @@ def test_keywords_update_dry_run():
         assert "--dry-run" in argv
 
 
+def test_keywords_update_accepts_zero_bids():
+    """Zero bid values are provided updates and must be stringified for CLI."""
+    runner = _mock_runner(None)
+    with patch("server.tools.keywords.get_runner", return_value=runner):
+        keywords_update(id=99999, bid=0, context_bid=0)
+
+    runner.run_json.assert_called_once_with(
+        [
+            "keywords",
+            "update",
+            "--id",
+            "99999",
+            "--bid",
+            "0",
+            "--context-bid",
+            "0",
+        ]
+    )
+
+
 def test_keywords_update_requires_changes():
     """Test that empty updates are rejected before CLI call."""
     runner = _mock_runner(None)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -192,6 +192,12 @@ def test_reports_get_auth_error():
         assert result["error"] == "auth_expired"
 
 
+def test_reports_get_invalid_date_format():
+    result = reports_get(date_from="2026/03/30", date_to="2026-04-06")
+    assert result["error"] == "invalid_date_format"
+    assert "date_from" in result["message"]
+
+
 # --- reports_custom -----------------------------------------------------
 
 
@@ -290,7 +296,7 @@ def test_reports_custom_rejects_goals_filter_with_goal_ids():
             filters=["Goals:IN:222"],
         )
 
-    assert result["error"] == "unknown"
+    assert result["error"] == "invalid_goals_filter"
     assert "pass goal IDs via goal_ids instead" in result["message"]
     runner.run_json.assert_not_called()
 
@@ -306,7 +312,7 @@ def test_reports_custom_rejects_goals_filter_without_goal_ids():
             filters=[" goals:IN:111"],
         )
 
-    assert result["error"] == "unknown"
+    assert result["error"] == "invalid_goals_filter"
     assert "Goals filters are not supported" in result["message"]
     runner.run_json.assert_not_called()
 
@@ -357,7 +363,7 @@ def test_reports_custom_output_path_rejects_unsafe_location():
             output_path="/etc/cron.d/direct-report.json",
         )
 
-    assert result["error"] == "unknown"
+    assert result["error"] == "invalid_output_path"
     assert "output_path must be under one of" in result["message"]
     runner.run_json.assert_not_called()
 
@@ -521,20 +527,37 @@ def test_reports_custom_date_range_type_conflict():
         date_from="2026-01-01",
         date_range_type="last_7_days",
     )
-    assert result["error"] == "unknown"
+    assert result["error"] == "conflicting_date_inputs"
     assert "date_range_type OR explicit" in result["message"]
 
 
 def test_reports_custom_requires_complete_explicit_date_range():
     """Custom reports reject partial explicit date ranges."""
-    assert (
-        "pass both date_from and date_to"
-        in reports_custom(field_names="Date,Cost", date_from="2026-01-01")["message"]
+    from_only = reports_custom(field_names="Date,Cost", date_from="2026-01-01")
+    to_only = reports_custom(field_names="Date,Cost", date_to="2026-01-31")
+    assert from_only["error"] == "missing_date_range"
+    assert to_only["error"] == "missing_date_range"
+    assert "Pass both date_from and date_to" in from_only["message"]
+
+
+def test_reports_custom_rejects_invalid_response_format():
+    result = reports_custom(
+        field_names="Date,Cost",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+        response_format="xml",
     )
-    assert (
-        "pass both date_from and date_to"
-        in reports_custom(field_names="Date,Cost", date_to="2026-01-31")["message"]
+    assert result["error"] == "invalid_response_format"
+
+
+def test_reports_custom_rejects_invalid_date_format():
+    result = reports_custom(
+        field_names="Date,Cost",
+        date_from="2026/01/01",
+        date_to="2026-01-31",
     )
+    assert result["error"] == "invalid_date_format"
+    assert "date_from" in result["message"]
 
 
 def test_reports_custom_override_report_type():

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -1,5 +1,7 @@
 """Tests for shared tool decorators and helper functions."""
 
+from unittest.mock import MagicMock
+
 import server.tools as tools
 from server.cli.runner import (
     CliAuthError,
@@ -11,6 +13,11 @@ from server.cli.runner import (
 from server.tools.ads import _check_batch_limit as ads_check_batch_limit
 from server.tools.ads import _parse_ids
 from server.tools.auth_tools import _human_readable_time
+from server.tools.helpers import (
+    provided_update_value,
+    run_single_id_batch,
+    tool_error_dict,
+)
 from server.tools.keywords import _check_batch_limit as keywords_check_batch_limit
 
 
@@ -197,3 +204,35 @@ def test_keywords_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
     result = keywords_check_batch_limit(",".join(str(i) for i in range(11)))
     assert result is not None
     assert result.error == "batch_limit"
+
+
+def test_tool_error_dict_uses_stable_dataclass_conversion() -> None:
+    error = tools.ToolError(error="bad", message="Nope", hint="Try again")
+    assert tool_error_dict(error) == {
+        "error": "bad",
+        "message": "Nope",
+        "auth_url": None,
+        "hint": "Try again",
+    }
+
+
+def test_provided_update_value_matches_cli_forwarding_semantics() -> None:
+    assert provided_update_value(None) is False
+    assert provided_update_value(False) is False
+    assert provided_update_value(True) is True
+    assert provided_update_value(0) is True
+    assert provided_update_value("") is True
+    assert provided_update_value([]) is False
+    assert provided_update_value(["x"]) is True
+
+
+def test_run_single_id_batch_reports_partial_failure() -> None:
+    runner = MagicMock()
+    runner.run_json.side_effect = [{"success": True}, RuntimeError("boom")]
+
+    result = run_single_id_batch(runner, "ads", "delete", "1,2")
+
+    assert result["success"] is False
+    assert result["succeeded"] == ["1"]
+    assert result["failed"] == ["2"]
+    assert result["results"][1] == {"success": False, "id": "2", "error": "boom"}


### PR DESCRIPTION
## Summary

Closes #138.

- Convert report validation failures from generic `unknown` errors into structured `ToolError` responses, including invalid dates, response format, date-range conflicts, goals filters, and unsafe output paths.
- Share update-field presence semantics across wrappers so valid falsy values like `0` and empty strings reach `direct`; align `keywords_update` bid types with integer money parameters.
- Harden test infrastructure by making cassette replay fail closed, auto-marking mock tests for `pytest -m mocks`, and adding targeted regressions for batch partial failures, cassette replay, update guards, and campaign update JSON aliases.

## Audit notes

This PR focuses on the confirmed actionable high/medium items from #138. Low-risk observations such as cache invalidation, environment minimization, broad `_mock_runner` deduplication, and cassette architecture redesign are intentionally left out to avoid a sprawling refactor.

## Test plan

- [x] `python3 -m pytest tests/test_reports.py tests/test_keywords.py tests/test_adgroups.py tests/test_feeds.py tests/test_clients.py tests/test_campaigns.py tests/test_cli_recorder.py tests/test_tool_helpers.py -q` — 177 passed
- [x] `python3 -m pytest -q` — 682 passed, 7 skipped
- [x] `python3 -m pytest -m mocks -q` — 680 passed, 9 deselected
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy .` clean (104 source files)


Made with [Cursor](https://cursor.com)