### PR TITLE
chore: align with direct-cli 0.4.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "yandex-direct",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "source": {
         "source": "local",
         "path": "./plugins/yandex-direct"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - All money parameters (bids, budgets, CPC/CPA, ceilings) are in **micro-units**: 15 RUB = 15,000,000. CLI 0.2.10+ rejects values `0 < x < 100_000` with a "did you mean × 1_000_000?" hint.
 - API batch limit: max 10 IDs per request
 - OAuth tokens are stored as direct auth profiles, normally in `~/.direct-cli/auth.json`.
-- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.3.15`.
+- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.4.0`.
 - `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
 
@@ -728,3 +728,59 @@ Closes plugin issue tracking the 0.3.15 bump.
   issuance through the Direct UI rather than an LLM tool call.
 
 Closes plugin issue tracking the 0.3.16 bump.
+
+## Breaking Changes (CLI 0.4.0 alignment)
+
+- **`direct-cli>=0.4.0` required**: the minimum CLI version was raised
+  from 0.3.15 to 0.4.0. `MIN_DIRECT_VERSION` in `server/cli/runner.py`
+  moved to `(0, 4, 0)`. This also unifies the runtime floor with the
+  documented one — the 0.3.16 doc bump left `MIN_DIRECT_VERSION`,
+  `pyproject.toml`, and `README.md` at `0.3.15` (only `CLAUDE.md`
+  advanced), so this release resyncs all four. Installs running CLI
+  0.3.x or below will be rejected by the version probe.
+
+- **No plugin signature changes**: CLI 0.4.0 is a large release —
+  rewritten auth, ~hundreds of typed bidding-strategy / ad-type flags,
+  and a new `--locale` switch — but every change either was already
+  proxied ahead of time in the 0.3.x alignments or does not touch the
+  MCP surface:
+
+  - **Auth contract already implemented.** CLI 0.4.0 makes
+    `direct auth login` canonical (`--profile`, `--oauth-token`,
+    `--code -` / `--code-stdin`, OAuth refresh tokens), removes
+    `direct auth setup`, and makes the deprecated `direct-cli`
+    entrypoint exit with an error. `server/tools/auth_tools.py` already
+    drives `direct auth login --profile … --oauth-token …` and
+    `--code -` / `--code-stdin` — it never called `auth setup`. The
+    `~/.direct-cli/auth.json` shape the plugin reads (`profiles`,
+    `active_profile`, per-profile `token` / `login` / `expires_at` /
+    `refresh_token` / `source`) matches CLI 0.4.0 exactly. The MCP
+    tools `auth_status` / `auth_setup` / `auth_login` are unchanged.
+
+  - **All typed flags already proxied.** Every CLI 0.4.0 typed flag for
+    the mutating commands (`ads add/update`, `adgroups add/update`,
+    `campaigns add/update` — all 218 add/update flags build from the
+    plugin — `bidmodifiers add`, `bids`, `keywordbids`, `keywords`,
+    `vcards`, `clients` ERIR, `agencyclients`, `strategies`,
+    `retargeting`, `sitelinks`, `adimages`, `advideos`) was already
+    wired through MCP in the 0.3.9–0.3.16 alignments. No tool signature
+    needed to change.
+
+  - **New global `--locale ru|en`** (env `YANDEX_DIRECT_CLI_LOCALE`)
+    switches CLI help/message language. It is read-only ergonomics; the
+    plugin uses the CLI default and does not forward it, so it does not
+    affect any tool.
+
+  - **`v4finance` stays blocked.** CLI 0.4.0 keeps the six v4finance
+    subcommands (`get-clients-units`, `check-payment`, `create-invoice`,
+    `transfer-money`, `pay-campaigns`, `get-credit-limits`); they remain
+    catalogued in `server/contract.py` → `V4_LIVE_BLOCKED_METHODS` with
+    `_FINANCIAL_REASON` / `_NO_CLI_REASON` and are intentionally not
+    surfaced as MCP tools (real money movements with no shared-account /
+    dry-run safety net; master-token issuance through the Direct UI).
+
+  - **All CLI 0.4.0 groups/subcommands are covered** by existing tools;
+    no new API service appeared that would require a new tool.
+    `v4goals` / `v4tags` were already added in earlier releases.
+
+Closes plugin issue tracking the 0.4.0 bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -695,10 +695,16 @@ Closes plugin issue tracking the 0.3.15 bump.
 
 ## Breaking Changes (CLI 0.3.16 alignment)
 
-- **`direct-cli>=0.3.16` required**: the minimum CLI version was raised
-  from 0.3.15. `MIN_DIRECT_VERSION` in `server/cli/runner.py` moved to
-  `(0, 3, 16)`. Installs running CLI 0.3.15 or below will be rejected by
-  the version probe.
+- **`direct-cli>=0.3.16` documented**: CLI 0.3.16 was the alignment
+  target. Historical note: this doc bump only updated `CLAUDE.md` — the
+  runtime floor (`MIN_DIRECT_VERSION` in `server/cli/runner.py`,
+  `pyproject.toml`, `README.md`) was *not* moved and stayed at
+  `(0, 3, 15)` / `>=0.3.15`. The intended `(0, 3, 16)` / `>=0.3.16`
+  bump never landed in code; the runtime floor was next raised directly
+  to `(0, 4, 0)` / `>=0.4.0` in the CLI 0.4.0 alignment below, which
+  resynced all four locations. Because 0.3.16 was a v4finance-only
+  regression fix with no MCP-surface impact, the stale runtime floor had
+  no functional effect.
 
 - **No plugin signature changes**: CLI 0.3.16 is a regression-fix that
   reverts the 0.3.15 wire-shape changes (PRs #441/#442/#443), confined

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ OAuth-приложение само по себе не даёт доступ к 
 direct auth login --client-id "ваш-client-id" --client-secret "ваш-client-secret"
 ```
 
+### Язык вывода CLI (`--locale`)
+
+`direct-cli` 0.4.0+ поддерживает глобальный флаг `--locale ru|en` (или
+переменную окружения `YANDEX_DIRECT_CLI_LOCALE`) для языка справки и сообщений.
+Это удобство уровня CLI: плагин использует значение по умолчанию и не
+пробрасывает флаг, поэтому на работу MCP-инструментов он не влияет.
+
 ## MCP contract (142 tools)
 
 The public contract is now defined as:
@@ -867,11 +874,11 @@ direct auth login
 ```toml
 [project]
 name = "yandex-direct-mcp-plugin"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.11"
 dependencies = [
     "mcp",
-    "direct-cli>=0.3.15",
+    "direct-cli>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/plugins/yandex-direct/.codex-plugin/plugin.json
+++ b/plugins/yandex-direct/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "yandex-direct-mcp-plugin"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.3.15"]
+dependencies = ["mcp", "direct-cli>=0.4.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/cli/runner.py
+++ b/server/cli/runner.py
@@ -27,7 +27,7 @@ _VERSION_RE = re.compile(
     re.IGNORECASE,
 )
 
-MIN_DIRECT_VERSION: tuple[int, int, int] = (0, 3, 15)
+MIN_DIRECT_VERSION: tuple[int, int, int] = (0, 4, 0)
 
 
 def _strip_ansi(text: str) -> str:


### PR DESCRIPTION
## Что сделано

Синхронизация плагина с релизом `direct-cli` 0.4.0. Главный вывод анализа: **плагин уже функционально совместим с 0.4.0** — все breaking changes CLI либо были опережающе реализованы в релизах 0.3.x, либо не затрагивают MCP-поверхность. Синхронизация свелась к подъёму floor'а версии + документации, **без правок сигнатур инструментов**.

### Изменения

1. **Floor CLI → 0.4.0** в 4 местах: `MIN_DIRECT_VERSION = (0, 4, 0)` в `server/cli/runner.py`, `pyproject.toml`, `README.md`, `CLAUDE.md`. Заодно унифицирован рассинхрон: коммит 0.3.16 поднял только `CLAUDE.md`, а runtime-floor оставался на 0.3.15.
2. **Версия плагина → 0.2.3** (patch-bump) через `scripts/update-version.sh` — `pyproject.toml`, `.claude-plugin/plugin.json`, `plugins/yandex-direct/.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`.
3. **Новая секция** `## Breaking Changes (CLI 0.4.0 alignment)` в `CLAUDE.md` с обоснованием «No plugin signature changes».
4. **Заметка про `--locale ru|en`** в `README.md` (non-breaking новинка CLI).

### Почему не нужно менять код инструментов

- `auth_tools.py` уже вызывает `direct auth login --profile/--oauth-token/--code -`, а не удалённый в 0.4.0 `auth setup`; формат `~/.direct-cli/auth.json` совпадает.
- Все типизированные флаги мутирующих команд уже проброшены (`ads`, `adgroups`, `campaigns` — все 218 add/update-флагов строятся плагином, `bidmodifiers`, `bids`, `keywords`, `vcards`, `clients` ERIR, `strategies` и др.).
- `v4finance` остаётся заблокированным по политике master-token; `v4goals`/`v4tags` уже реализованы.

## Проверка

- Установлен `direct-cli==0.4.0`; version-probe резолвит её как known-good.
- `pytest`: **683 passed, 7 skipped** (skipped — integration/live с токеном).
- `ruff check` / `ruff format --check` / `mypy`: чисто.
- Прицельно: `test_direct_cli_0312_parity.py`, `test_cli_runner.py`, `test_auth.py` — 79 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)