### PR TITLE
chore: align with direct-cli 0.4.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "yandex-direct",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "source": {
         "source": "local",
         "path": "./plugins/yandex-direct"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,13 +191,13 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (142 total) + 1 Prompt
+## MCP Tools (145 total) + 1 Prompt
 
 The canonical source of truth for tool names is `server/contract.py`.
 Naming follows `service_method` from `tapi-yandex-direct`/`direct-cli`;
 WSDL/reports spec wins when there is drift.
 
-### Direct API tools (125)
+### Direct API tools (128)
 
 | Tool | Purpose |
 |---|---|
@@ -330,6 +330,9 @@ WSDL/reports spec wins when there is drift.
 | `v4wordstat_list_reports` | List v4 Live Wordstat reports |
 | `v4wordstat_get_report` | Get a ready v4 Live Wordstat report |
 | `v4wordstat_delete_report` | Delete v4 Live Wordstat report |
+| `v4keywords_get_suggestion` | Get related keyword suggestions (up to 20 phrases; spends API points) |
+| `v4adimage_get` | Read ad-image associations (AdImageAssociation Get) |
+| `v4adimage_set` | Link/unlink ad images (AdImageAssociation Set) |
 
 ### CLI helper tools (3)
 
@@ -790,3 +793,53 @@ Closes plugin issue tracking the 0.3.16 bump.
     `v4goals` / `v4tags` were already added in earlier releases.
 
 Closes plugin issue tracking the 0.4.0 bump.
+
+## Breaking Changes (CLI 0.4.1 alignment)
+
+- **`direct-cli>=0.4.1` required**: the minimum CLI version was raised
+  from 0.4.0. `MIN_DIRECT_VERSION` in `server/cli/runner.py` moved to
+  `(0, 4, 1)`, and `pyproject.toml`, `README.md`, and `hooks/setup.sh`
+  were resynced. `hooks/setup.sh` had drifted (it still installed
+  `direct-cli>=0.3.11` via `_has_direct_cli_0311`); the probe is now
+  `_has_direct_cli_0401` / `>=0.4.1`, matching the runtime floor.
+
+- **Three new v4 Live MCP tools.** CLI 0.4.1 ships typed subcommands for
+  three v4 Live methods that were previously catalogued in
+  `server/contract.py` → `V4_LIVE_BLOCKED_METHODS` with `_NO_CLI_REASON`
+  ("direct-cli does not expose a typed subcommand"). Two are now exposed
+  as MCP tools; the third stays blocked under the financial policy:
+
+  - `v4keywords get-suggestion` → **`v4keywords_get_suggestion(keywords)`**
+    (GetKeywordsSuggestion). Returns up to 20 related phrases; spends API
+    points (error_code=152 when exhausted). New module
+    `server/tools/v4keywords.py`.
+  - `v4adimage get` / `v4adimage set` → **`v4adimage_get(...)`** /
+    **`v4adimage_set(associations, dry_run=False)`** (AdImageAssociation
+    Get/Set). `get` reads ad↔image links (empty filter ⇒ up to 10000);
+    `set` links (`AD_ID=HASH`) or unlinks (`AD_ID`) up to 10000 per call.
+    New module `server/tools/v4adimage.py`. The single AdImageAssociation
+    method is split into two action-scoped tools, mirroring the CLI's two
+    subcommands (same split pattern as `v4account_*` for AccountManagement).
+  - `v4finance pay-campaigns-by-card` → **stays blocked**. CLI 0.4.1 types
+    the subcommand, so its `V4_LIVE_BLOCKED_METHODS` entry switched from
+    `_NO_CLI_REASON` to `_FINANCIAL_REASON` — like every other `v4finance`
+    method it is a real money movement with no shared-account / dry-run
+    safety net and is intentionally not surfaced via MCP.
+
+  Method support was verified with live calls against the Yandex API
+  (`v4keywords get-suggestion` returned suggestions; `v4adimage get`
+  returned real associations; `v4adimage set --dry-run` built the correct
+  request body); CLI sources carry a `Docs-verified 2026-05-28 against
+  dg-v4/live/AdImageAssociation` marker.
+
+- **Tool count 142 → 145** (Direct API 136 → 139). Updated in
+  `server/contract.py`, `CLAUDE.md`, `README.md`, and `tests/test_server.py`.
+
+- **Other CLI 0.4.1 changes do not touch the MCP surface**: stricter
+  pre-call validation (`bids`/`keywordbids get`, `bids set-auto`,
+  `reports get` empty-field rejection), error-handling consistency, an
+  auth fix that resolves bare Client-Login via the v5 API, and a new
+  Russian-default i18n layer with the `--locale` switch (the plugin uses
+  the CLI default and does not forward it).
+
+Closes plugin issue tracking the 0.4.1 bump.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ direct auth login --client-id "ваш-client-id" --client-secret "ваш-client-
 Это удобство уровня CLI: плагин использует значение по умолчанию и не
 пробрасывает флаг, поэтому на работу MCP-инструментов он не влияет.
 
-## MCP contract (142 tools)
+## MCP contract (145 tools)
 
 The public contract is now defined as:
 
@@ -218,7 +218,7 @@ The machine-readable parity source lives in
 
 ### v4 Live coverage
 
-`direct-cli` 0.3.11 exposes typed v4 Live commands for the methods below. Only
+`direct-cli` 0.4.1 exposes typed v4 Live commands for the methods below. Only
 typed public commands are registered as MCP tools. The single
 ``v4account account-management`` CLI subcommand drives five discrete MCP
 tools (one per ``--action``) so financial mutations get isolated signatures
@@ -246,6 +246,9 @@ and finance/master tokens stay env-only:
 - `direct v4wordstat list-reports` → `v4wordstat_list_reports`
 - `direct v4wordstat get-report` → `v4wordstat_get_report`
 - `direct v4wordstat delete-report` → `v4wordstat_delete_report`
+- `direct v4keywords get-suggestion` → `v4keywords_get_suggestion`
+- `direct v4adimage get` → `v4adimage_get`
+- `direct v4adimage set` → `v4adimage_set`
 
 Other methods from `direct_cli.v4_contracts` are tracked in
 `server/contract.py` as blocked/future metadata and are not exposed until the CLI
@@ -878,7 +881,7 @@ version = "0.2.3"
 requires-python = ">=3.11"
 dependencies = [
     "mcp",
-    "direct-cli>=0.4.0",
+    "direct-cli>=0.4.1",
 ]
 
 [project.optional-dependencies]

--- a/hooks/setup.sh
+++ b/hooks/setup.sh
@@ -11,10 +11,10 @@ _pip_user() {
     true
 }
 
-_has_direct_cli_0311() {
+_has_direct_cli_0401() {
     # Extract the leading X.Y.Z triplet so pre-release / dev suffixes
-    # ("0.3.11rc1", "0.3.11.dev0") don't break int() parsing.
-    "$1" -c "import re, direct_cli; m = re.match(r'^(\d+)\.(\d+)\.(\d+)', direct_cli.__version__); raise SystemExit(1 if not m else (tuple(map(int, m.groups())) < (0, 3, 11)))" 2>/dev/null
+    # ("0.4.1rc1", "0.4.1.dev0") don't break int() parsing.
+    "$1" -c "import re, direct_cli; m = re.match(r'^(\d+)\.(\d+)\.(\d+)', direct_cli.__version__); raise SystemExit(1 if not m else (tuple(map(int, m.groups())) < (0, 4, 1)))" 2>/dev/null
 }
 
 # Try plugin venv first (Debian/Docker friendly)
@@ -24,16 +24,16 @@ fi
 
 if [ -f "$VENV/bin/python3" ]; then
     # Venv available — install into it
-    if ! _has_direct_cli_0311 "$VENV/bin/python3"; then
-        "$VENV/bin/pip" install --quiet --disable-pip-version-check 'direct-cli>=0.3.11' 2>/dev/null || true
+    if ! _has_direct_cli_0401 "$VENV/bin/python3"; then
+        "$VENV/bin/pip" install --quiet --disable-pip-version-check 'direct-cli>=0.4.1' 2>/dev/null || true
     fi
     if ! "$VENV/bin/python3" -c "import mcp" 2>/dev/null; then
         "$VENV/bin/pip" install --quiet --disable-pip-version-check mcp 2>/dev/null || true
     fi
 else
     # No venv — fallback to system install (macOS)
-    if ! command -v direct &>/dev/null || ! _has_direct_cli_0311 python3; then
-        _pip_user 'direct-cli>=0.3.11'
+    if ! command -v direct &>/dev/null || ! _has_direct_cli_0401 python3; then
+        _pip_user 'direct-cli>=0.4.1'
     fi
     if ! python3 -c "import mcp" 2>/dev/null; then
         _pip_user mcp

--- a/plugins/yandex-direct/.codex-plugin/plugin.json
+++ b/plugins/yandex-direct/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow",

--- a/plugins/yandex-direct/server/main.py
+++ b/plugins/yandex-direct/server/main.py
@@ -45,9 +45,11 @@ import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.strategies  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
 import server.tools.v4account  # noqa: E402, F401
+import server.tools.v4adimage  # noqa: E402, F401
 import server.tools.v4events  # noqa: E402, F401
 import server.tools.v4forecast  # noqa: E402, F401
 import server.tools.v4goals  # noqa: E402, F401
+import server.tools.v4keywords  # noqa: E402, F401
 import server.tools.v4tags  # noqa: E402, F401
 import server.tools.v4wordstat  # noqa: E402, F401
 import server.tools.vcards  # noqa: E402, F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "yandex-direct-mcp-plugin"
-version = "0.2.3"
+version = "0.2.4"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.4.0"]
+dependencies = ["mcp", "direct-cli>=0.4.1"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/server/cli/runner.py
+++ b/server/cli/runner.py
@@ -27,7 +27,7 @@ _VERSION_RE = re.compile(
     re.IGNORECASE,
 )
 
-MIN_DIRECT_VERSION: tuple[int, int, int] = (0, 4, 0)
+MIN_DIRECT_VERSION: tuple[int, int, int] = (0, 4, 1)
 
 
 def _strip_ansi(text: str) -> str:

--- a/server/contract.py
+++ b/server/contract.py
@@ -1,10 +1,10 @@
 """Public MCP contract metadata aligned to the `direct` CLI surface.
 
 Tool count (derived from the structures below):
-- Direct API tools: 136
+- Direct API tools: 139
 - CLI helper tools:   3
 - Plugin tools:       3
-Total:              142
+Total:              145
 """
 
 from __future__ import annotations
@@ -407,6 +407,36 @@ V4_LIVE_CLI_TOOLS: tuple[ContractTool, ...] = (
         classification="direct_api",
         tapi_name="DeleteWordstatReport",
     ),
+    ContractTool(
+        public_name="v4keywords_get_suggestion",
+        cli_service="v4keywords",
+        cli_method="get_suggestion",
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="GetKeywordsSuggestion",
+    ),
+    # AdImageAssociation is a multi-action v4 Live method. direct-cli 0.4.1
+    # surfaces it as two typed CLI subcommands (``v4adimage get`` for
+    # Action=Get, ``v4adimage set`` for Action=Set); the plugin mirrors that
+    # split with two discrete MCP tools, each owning its single action.
+    ContractTool(
+        public_name="v4adimage_get",
+        cli_service="v4adimage",
+        cli_method="get",
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="AdImageAssociation",
+        supported_actions=("Get",),
+    ),
+    ContractTool(
+        public_name="v4adimage_set",
+        cli_service="v4adimage",
+        cli_method="set",
+        authority="v4-live",
+        classification="direct_api",
+        tapi_name="AdImageAssociation",
+        supported_actions=("Set",),
+    ),
 )
 
 # Methods either not yet typed by direct-cli OR typed but intentionally not
@@ -458,7 +488,7 @@ V4_LIVE_BLOCKED_METHODS: tuple[BlockedV4Method, ...] = (
         "finance",
         "v4finance",
         "pay-campaigns-by-card",
-        _NO_CLI_REASON,
+        _FINANCIAL_REASON,
     ),
     BlockedV4Method(
         "CheckPayment",
@@ -486,20 +516,6 @@ V4_LIVE_BLOCKED_METHODS: tuple[BlockedV4Method, ...] = (
         "offline_reports",
         None,
         "delete-report",
-        _NO_CLI_REASON,
-    ),
-    BlockedV4Method(
-        "AdImageAssociation",
-        "ad_image",
-        None,
-        "ad-image-association",
-        _NO_CLI_REASON,
-    ),
-    BlockedV4Method(
-        "GetKeywordsSuggestion",
-        "keywords",
-        None,
-        "get-keywords-suggestion",
         _NO_CLI_REASON,
     ),
     BlockedV4Method("PingAPI", "meta", "v4meta", "ping-api", _NO_CLI_REASON),

--- a/server/main.py
+++ b/server/main.py
@@ -45,9 +45,11 @@ import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.strategies  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
 import server.tools.v4account  # noqa: E402, F401
+import server.tools.v4adimage  # noqa: E402, F401
 import server.tools.v4events  # noqa: E402, F401
 import server.tools.v4forecast  # noqa: E402, F401
 import server.tools.v4goals  # noqa: E402, F401
+import server.tools.v4keywords  # noqa: E402, F401
 import server.tools.v4tags  # noqa: E402, F401
 import server.tools.v4wordstat  # noqa: E402, F401
 import server.tools.vcards  # noqa: E402, F401

--- a/server/tools/v4adimage.py
+++ b/server/tools/v4adimage.py
@@ -1,0 +1,110 @@
+"""MCP tools for Yandex Direct v4 Live ad-image association commands."""
+
+from server.main import mcp
+from server.tools import ToolError, get_runner, handle_cli_errors
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalize_associations(associations: list[str] | None) -> list[str]:
+    if not associations:
+        return []
+    return [item.strip() for item in associations if item.strip()]
+
+
+@mcp.tool(name="v4adimage_get")
+@handle_cli_errors
+def v4adimage_get(
+    logins: str | None = None,
+    ad_image_hashes: str | None = None,
+    status_moderate: list[str] | None = None,
+    ad_ids: str | None = None,
+    campaign_ids: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+    dry_run: bool = False,
+) -> dict | list[dict]:
+    """Read ad-image associations via v4 Live AdImageAssociation (Action=Get).
+
+    An empty filter returns up to 10000 associations.
+
+    Args:
+        logins: Comma-separated client logins.
+        ad_image_hashes: Comma-separated ad image hashes.
+        status_moderate: Moderation status filter values (yes/no/ready/sending);
+            repeat for several.
+        ad_ids: Comma-separated ad IDs.
+        campaign_ids: Comma-separated campaign IDs.
+        limit: Page size (1-10000).
+        offset: Page offset (>=0).
+        dry_run: Show the direct request without sending it.
+    """
+    args = ["v4adimage", "get"]
+
+    normalized_logins = _normalize_optional(logins)
+    if normalized_logins:
+        args.extend(["--logins", normalized_logins])
+
+    normalized_hashes = _normalize_optional(ad_image_hashes)
+    if normalized_hashes:
+        args.extend(["--ad-image-hashes", normalized_hashes])
+
+    for status in status_moderate or []:
+        normalized_status = status.strip()
+        if normalized_status:
+            args.extend(["--status-moderate", normalized_status])
+
+    normalized_ad_ids = _normalize_optional(ad_ids)
+    if normalized_ad_ids:
+        args.extend(["--ad-ids", normalized_ad_ids])
+
+    normalized_campaign_ids = _normalize_optional(campaign_ids)
+    if normalized_campaign_ids:
+        args.extend(["--campaign-ids", normalized_campaign_ids])
+
+    if limit is not None:
+        args.extend(["--limit", str(limit)])
+    if offset is not None:
+        args.extend(["--offset", str(offset)])
+    if dry_run:
+        args.append("--dry-run")
+    args.extend(["--format", "json"])
+
+    return get_runner().run_json(args)
+
+
+@mcp.tool(name="v4adimage_set")
+@handle_cli_errors
+def v4adimage_set(
+    associations: list[str],
+    dry_run: bool = False,
+) -> dict | list[dict]:
+    """Link or unlink ad images via v4 Live AdImageAssociation (Action=Set).
+
+    Up to 10000 associations per call.
+
+    Args:
+        associations: Each item is ``AD_ID`` to unlink an image, or
+            ``AD_ID=HASH`` to link an image. At least one is required.
+        dry_run: Show the direct request without sending it.
+    """
+    normalized = _normalize_associations(associations)
+    if not normalized:
+        return ToolError(
+            error="missing_associations",
+            message="Provide at least one association (AD_ID or AD_ID=HASH).",
+        ).__dict__
+
+    args = ["v4adimage", "set"]
+    for item in normalized:
+        args.extend(["--association", item])
+    if dry_run:
+        args.append("--dry-run")
+    args.extend(["--format", "json"])
+
+    return get_runner().run_json(args)

--- a/server/tools/v4keywords.py
+++ b/server/tools/v4keywords.py
@@ -1,0 +1,36 @@
+"""MCP tools for Yandex Direct v4 Live keyword-suggestion commands."""
+
+from server.main import mcp
+from server.tools import ToolError, get_runner, handle_cli_errors
+
+
+def _normalize_keywords(keywords: list[str] | None) -> list[str]:
+    if not keywords:
+        return []
+    return [keyword.strip() for keyword in keywords if keyword.strip()]
+
+
+@mcp.tool(name="v4keywords_get_suggestion")
+@handle_cli_errors
+def v4keywords_get_suggestion(keywords: list[str]) -> dict | list[dict]:
+    """Get related keyword suggestions via v4 Live GetKeywordsSuggestion.
+
+    Returns up to 20 suggested phrases per call. Spends API points
+    (error_code=152 when the account runs out).
+
+    Args:
+        keywords: Source phrases to expand. At least one is required.
+    """
+    normalized = _normalize_keywords(keywords)
+    if not normalized:
+        return ToolError(
+            error="missing_keywords",
+            message="Provide at least one keyword.",
+        ).__dict__
+
+    args = ["v4keywords", "get-suggestion"]
+    for keyword in normalized:
+        args.extend(["--keyword", keyword])
+    args.extend(["--format", "json"])
+
+    return get_runner().run_json(args)

--- a/tests/test_issue_108_regression.py
+++ b/tests/test_issue_108_regression.py
@@ -40,10 +40,12 @@ def test_runtime_code_does_not_reintroduce_freeform_json_transport() -> None:
 
 def test_setup_hook_installs_supported_direct_cli_version() -> None:
     setup = (REPO_ROOT / "hooks" / "setup.sh").read_text()
-    assert "direct-cli>=0.3.11" in setup
+    assert "direct-cli>=0.4.1" in setup
+    assert "direct-cli>=0.3.11" not in setup
     assert "direct-cli>=0.3.4" not in setup
     assert "direct-cli>=0.3.10" not in setup
-    assert "_has_direct_cli_0311" in setup
+    assert "_has_direct_cli_0401" in setup
+    assert "_has_direct_cli_0311" not in setup
     assert "_has_direct_cli_0310" not in setup
 
 
@@ -90,6 +92,7 @@ def test_blocked_v4_methods_have_explicit_non_stale_reasons() -> None:
         "GetCreditLimits",
         "TransferMoney",
         "PayCampaigns",
+        "PayCampaignsByCard",
         "CheckPayment",
         "CreateInvoice",
     ):

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -11,10 +11,12 @@ from server.contract import (
     V4_LIVE_TOOL_NAMES,
 )
 from server.tools.balance import balance_get
+from server.tools.v4adimage import v4adimage_get, v4adimage_set
 from server.tools.v4goals import (
     v4goals_get_retargeting_goals,
     v4goals_get_stat_goals,
 )
+from server.tools.v4keywords import v4keywords_get_suggestion
 from server.tools.v4tags import (
     v4tags_get_banners,
     v4tags_get_campaigns,
@@ -364,6 +366,9 @@ def test_v4_contract_exposes_only_cli_backed_tools():
         "v4wordstat_list_reports",
         "v4wordstat_get_report",
         "v4wordstat_delete_report",
+        "v4keywords_get_suggestion",
+        "v4adimage_get",
+        "v4adimage_set",
     }
     assert V4_LIVE_TOOL_NAMES <= PUBLIC_TOOL_NAMES
     assert {"GetClientsUnits", "PingAPI"} <= V4_LIVE_BLOCKED_METHOD_NAMES
@@ -401,7 +406,111 @@ def test_v4_contract_exposes_only_cli_backed_tools():
         "GetWordstatReportList",
         "GetWordstatReport",
         "DeleteWordstatReport",
+        # CLI 0.4.1 typed these two v4 Live methods and the plugin now exposes
+        # them as MCP tools, so they must no longer be in the blocked set.
+        "AdImageAssociation",
+        "GetKeywordsSuggestion",
     }.isdisjoint(V4_LIVE_BLOCKED_METHOD_NAMES)
+    # PayCampaignsByCard stays blocked despite being typed in CLI 0.4.1 —
+    # it is a real money movement gated behind the financial policy.
+    assert "PayCampaignsByCard" in V4_LIVE_BLOCKED_METHOD_NAMES
     assert "v4finance_get_clients_units" not in PUBLIC_TOOL_NAMES
     assert "v4finance_transfer_money" not in PUBLIC_TOOL_NAMES
+    assert "v4finance_pay_campaigns_by_card" not in PUBLIC_TOOL_NAMES
     assert "v4meta_ping_api" not in PUBLIC_TOOL_NAMES
+
+
+def test_v4keywords_get_suggestion() -> None:
+    runner = _mock_runner(["мебельные ручки", "ручка мебельная"])
+    with patch("server.tools.v4keywords.get_runner", return_value=runner):
+        result = v4keywords_get_suggestion(keywords=[" ручки для шкафа ", "стол"])
+
+    assert result == ["мебельные ручки", "ручка мебельная"]
+    runner.run_json.assert_called_once_with(
+        [
+            "v4keywords",
+            "get-suggestion",
+            "--keyword",
+            "ручки для шкафа",
+            "--keyword",
+            "стол",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_v4keywords_get_suggestion_requires_keywords() -> None:
+    result = v4keywords_get_suggestion(keywords=["   "])
+    assert result["error"] == "missing_keywords"
+
+
+def test_v4adimage_get_without_filters() -> None:
+    runner = _mock_runner({"AdImageAssociations": [], "TotalObjectsCount": "0"})
+    with patch("server.tools.v4adimage.get_runner", return_value=runner):
+        result = v4adimage_get()
+
+    assert result == {"AdImageAssociations": [], "TotalObjectsCount": "0"}
+    runner.run_json.assert_called_once_with(["v4adimage", "get", "--format", "json"])
+
+
+def test_v4adimage_get_with_filters() -> None:
+    runner = _mock_runner({"AdImageAssociations": []})
+    with patch("server.tools.v4adimage.get_runner", return_value=runner):
+        result = v4adimage_get(
+            campaign_ids=" 123,456 ",
+            status_moderate=[" yes ", "ready"],
+            limit=3,
+            offset=10,
+            dry_run=True,
+        )
+
+    assert result == {"AdImageAssociations": []}
+    runner.run_json.assert_called_once_with(
+        [
+            "v4adimage",
+            "get",
+            "--status-moderate",
+            "yes",
+            "--status-moderate",
+            "ready",
+            "--campaign-ids",
+            "123,456",
+            "--limit",
+            "3",
+            "--offset",
+            "10",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_v4adimage_set() -> None:
+    runner = _mock_runner({"AdImageAssociations": []})
+    with patch("server.tools.v4adimage.get_runner", return_value=runner):
+        result = v4adimage_set(
+            associations=[" 15552664629=aX63TKm1t_G4hJ93AKlAxg ", "16344915985"],
+            dry_run=True,
+        )
+
+    assert result == {"AdImageAssociations": []}
+    runner.run_json.assert_called_once_with(
+        [
+            "v4adimage",
+            "set",
+            "--association",
+            "15552664629=aX63TKm1t_G4hJ93AKlAxg",
+            "--association",
+            "16344915985",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def test_v4adimage_set_requires_associations() -> None:
+    result = v4adimage_set(associations=["   "])
+    assert result["error"] == "missing_associations"


### PR DESCRIPTION
## Summary

Aligns the plugin with **direct-cli 0.4.1**, following the established alignment pattern (cf. #144 for 0.4.0): raise the version floor, expose newly typed v4 Live methods as MCP tools, refresh the contract and docs, and bump the plugin version.

CLI 0.4.1 ships typed subcommands for three v4 Live methods that were previously catalogued in `server/contract.py` → `V4_LIVE_BLOCKED_METHODS` with `_NO_CLI_REASON`. Two are now exposed as MCP tools; the third stays blocked under the financial policy.

### New MCP tools (142 → 145)

| Tool | CLI | tapi method |
|---|---|---|
| `v4keywords_get_suggestion(keywords)` | `v4keywords get-suggestion` | `GetKeywordsSuggestion` — up to 20 phrases, spends API points (error_code=152) |
| `v4adimage_get(...)` | `v4adimage get` | `AdImageAssociation` (Action=Get) — empty filter ⇒ up to 10000 |
| `v4adimage_set(associations, dry_run)` | `v4adimage set` | `AdImageAssociation` (Action=Set) — `AD_ID=HASH` to link, `AD_ID` to unlink, up to 10000 |

New modules `server/tools/v4keywords.py` and `server/tools/v4adimage.py`, registered in both `server/main.py` and the bundled `plugins/yandex-direct/server/main.py`. AdImageAssociation is split into two action-scoped tools mirroring the CLI's two subcommands (same pattern as `v4account_*` for AccountManagement).

### Stays blocked

`PayCampaignsByCard` (`v4finance pay-campaigns-by-card`) is typed in CLI 0.4.1, but its `V4_LIVE_BLOCKED_METHODS` reason switches `_NO_CLI_REASON` → `_FINANCIAL_REASON`: like every other `v4finance` method it is a real money movement with no shared-account / dry-run safety net and is intentionally not surfaced via MCP.

### Version floor → 0.4.1

`MIN_DIRECT_VERSION`, `pyproject.toml`, `README.md`, and `hooks/setup.sh`. The hook had drifted (still `direct-cli>=0.3.11` via `_has_direct_cli_0311`); it's now `_has_direct_cli_0401` / `>=0.4.1`, matching the runtime floor.

### Other

- Plugin version 0.2.3 → 0.2.4 (local manifests only — external marketplace not pushed).
- CLAUDE.md "Breaking Changes (CLI 0.4.1 alignment)" section + tool counts; README v4 coverage list.
- Other CLI 0.4.1 changes (stricter pre-call validation, error-handling consistency, auth Client-Login fix, Russian-default i18n / `--locale`) do not touch the MCP surface.

### Method-support verification

Confirmed with live calls against the Yandex API (profile `bolgaria-nedvizh`):
- `v4keywords get-suggestion` → returned suggestions
- `v4adimage get` → returned real ad↔image associations
- `v4adimage set --dry-run` → built the correct request body

CLI sources carry a `Docs-verified 2026-05-28 against dg-v4/live/AdImageAssociation` marker.

## Test plan

- [x] `pytest` → 689 passed, 7 skipped
- [x] `ruff check .` → All checks passed
- [x] `ruff format --check .` → clean
- [x] `mypy .` → Success, no issues
- [x] MCP server registers 145 tools (== contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)