### PR TITLE
[codex] guard direct-cli login normalization boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,7 +385,7 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - All money parameters (bids, budgets, CPC/CPA, ceilings) are in **micro-units**: 15 RUB = 15,000,000. CLI 0.2.10+ rejects values `0 < x < 100_000` with a "did you mean × 1_000_000?" hint.
 - API batch limit: max 10 IDs per request
 - OAuth tokens are stored as direct auth profiles, normally in `~/.direct-cli/auth.json`.
-- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.4.0`.
+- CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.4.1`.
 - `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
 

--- a/tests/test_issue_108_regression.py
+++ b/tests/test_issue_108_regression.py
@@ -49,6 +49,12 @@ def test_setup_hook_installs_supported_direct_cli_version() -> None:
     assert "_has_direct_cli_0310" not in setup
 
 
+def test_claude_notes_use_supported_direct_cli_version() -> None:
+    notes = (REPO_ROOT / "CLAUDE.md").read_text()
+    assert "Minimum required: `direct-cli>=0.4.1`" in notes
+    assert "Minimum required: `direct-cli>=0.4.0`" not in notes
+
+
 def test_v4account_runtime_does_not_accept_finance_or_master_tokens() -> None:
     """Issue #120 security policy: finance/master tokens must stay env-only.
 

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -59,6 +59,18 @@ def test_balance_get_with_logins():
     )
 
 
+def test_balance_get_passes_email_shaped_logins_to_direct_unchanged():
+    """Issue #145: Client-Login normalization belongs to direct-cli auth."""
+    runner = _mock_runner({"Accounts": []})
+    with patch("server.tools.balance.get_runner", return_value=runner):
+        result = balance_get(logins=" client@yandex.ru ")
+
+    assert result == {"Accounts": []}
+    runner.run_json.assert_called_once_with(
+        ["balance", "--format", "json", "--logins", "client@yandex.ru"]
+    )
+
+
 def test_v4goals_get_stat_goals():
     runner = _mock_runner({"Goals": []})
     with patch("server.tools.v4goals.get_runner", return_value=runner):

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -105,6 +105,26 @@ def test_v4account_get_accounts_by_logins_argv():
     )
 
 
+def test_v4account_get_accounts_passes_email_shaped_logins_to_direct_unchanged():
+    """Issue #145: do not guess Client-Login from Passport email in MCP."""
+    runner = _mock_runner({"method": "AccountManagement"})
+    with patch("server.tools.v4account.get_runner", return_value=runner):
+        v4account_get_accounts(logins=" client@yandex.ru ", dry_run=True)
+    runner.run_json.assert_called_once_with(
+        [
+            "v4account",
+            "account-management",
+            "--action",
+            "Get",
+            "--logins",
+            "client@yandex.ru",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+
 def test_v4account_get_accounts_by_account_ids_argv():
     runner = _mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):


### PR DESCRIPTION
## Summary

- keep #145 fixed as a direct-cli auth/profile responsibility, not an MCP-side `split("@")` workaround
- update the remaining stale `direct-cli>=0.4.0` note to `direct-cli>=0.4.1`
- add regression tests proving `balance_get` and `v4account_get_accounts` pass email-shaped `logins` through to `direct` unchanged
- add a docs regression check so the stale `0.4.0` minimum does not return

## Why

`direct-cli 0.4.1` resolves the bare Client-Login through v5 `clients.get` during auth and migrates old email-shaped OAuth profiles. The plugin should preserve its `MCP -> direct -> API` boundary and avoid guessing Client-Login from Passport email, which is unsafe for agency and renamed accounts.

## Validation

- `python3 -m pytest tests/test_auth.py tests/test_v4_tools.py tests/test_v4account.py tests/test_cli_runner.py tests/test_issue_108_regression.py` -> `146 passed`
- `python3 -m pytest tests/test_auth_oauth.py::TestClientLoginResolution tests/test_cli.py::TestCLI::test_group_help_does_not_resolve_client_login_over_network tests/test_cli.py::TestCLI::test_get_credentials_skips_login_resolve_when_disallowed -q` in `/Users/axisrow/Projects/direct-cli` -> `8 passed`
- `direct --version` -> `direct, version 0.4.1`
- `python3 -m ruff check .` -> passed
- `python3 -m ruff format --check .` -> passed
- `mypy .` -> passed