### PR TITLE
refactor: extract shared tool and test helpers to cut duplication

### DIFF
--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -45,11 +45,6 @@ ADGROUP_EXTRA_OPTIONS = (
 )
 
 
-def _check_batch_limit(ids_str: str) -> ToolError | None:
-    """Validate batch size of comma-separated IDs."""
-    return check_batch_limit(ids_str, MAX_BATCH_SIZE)
-
-
 @mcp.tool(name="adgroups_get")
 @handle_cli_errors
 def adgroups_list(
@@ -87,13 +82,13 @@ def adgroups_list(
     args = ["adgroups", "get", "--format", "json"]
     normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
-        batch_error = _check_batch_limit(normalized_campaign_ids)
+        batch_error = check_batch_limit(normalized_campaign_ids, MAX_BATCH_SIZE)
         if batch_error:
             return batch_error.__dict__
         args.extend(["--campaign-ids", normalized_campaign_ids])
     normalized_ids = ids.strip() if ids is not None else None
     if normalized_ids:
-        batch_error = _check_batch_limit(normalized_ids)
+        batch_error = check_batch_limit(normalized_ids, MAX_BATCH_SIZE)
         if batch_error:
             return batch_error.__dict__
         args.extend(["--ids", normalized_ids])

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options
+from server.tools.helpers import CliOption, append_cli_options, check_batch_limit
 
 MAX_BATCH_SIZE = 10
 MOBILE_VALUES = ("YES", "NO")
@@ -62,22 +62,6 @@ ADS_UPDATE_EXTRA_OPTIONS = (
 )
 
 
-def _parse_ids(ids_str: str) -> list[str]:
-    """Parse and clean comma-separated IDs."""
-    return [id.strip() for id in ids_str.split(",") if id.strip()]
-
-
-def _check_batch_limit(ids_str: str) -> ToolError | None:
-    """Validate batch size of comma-separated IDs."""
-    ids = _parse_ids(ids_str)
-    if len(ids) > MAX_BATCH_SIZE:
-        return ToolError(
-            error="batch_limit",
-            message=f"Maximum {MAX_BATCH_SIZE} IDs per request. Got: {len(ids)}",
-        )
-    return None
-
-
 @mcp.tool(name="ads_get")
 @handle_cli_errors
 def ads_list(
@@ -126,7 +110,7 @@ def ads_list(
     """
     normalized_campaign_ids = campaign_ids.strip() if campaign_ids is not None else None
     if normalized_campaign_ids:
-        batch_error = _check_batch_limit(normalized_campaign_ids)
+        batch_error = check_batch_limit(normalized_campaign_ids, MAX_BATCH_SIZE)
         if batch_error:
             return batch_error.__dict__
 
@@ -135,13 +119,13 @@ def ads_list(
         args.extend(["--campaign-ids", normalized_campaign_ids])
     normalized_ids = ids.strip() if ids is not None else None
     if normalized_ids:
-        batch_error = _check_batch_limit(normalized_ids)
+        batch_error = check_batch_limit(normalized_ids, MAX_BATCH_SIZE)
         if batch_error:
             return batch_error.__dict__
         args.extend(["--ids", normalized_ids])
     normalized_ad_group_ids = ad_group_ids.strip() if ad_group_ids is not None else None
     if normalized_ad_group_ids:
-        batch_error = _check_batch_limit(normalized_ad_group_ids)
+        batch_error = check_batch_limit(normalized_ad_group_ids, MAX_BATCH_SIZE)
         if batch_error:
             return batch_error.__dict__
         args.extend(["--adgroup-ids", normalized_ad_group_ids])

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit, run_single_id_batch
+from server.tools.helpers import check_batch_limit, run_set_bids, run_single_id_batch
 
 
 @mcp.tool(name="audiencetargets_get")
@@ -180,30 +180,13 @@ def audience_targets_set_bids(
             rejects values 0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         priority: Strategy priority.
     """
-    if id is None and ad_group_id is None and campaign_id is None:
-        return ToolError(
-            error="missing_target_scope",
-            message="Provide at least one of: id, ad_group_id, campaign_id",
-        ).__dict__
-    if context_bid is None and priority is None:
-        return ToolError(
-            error="missing_update_fields",
-            message="Provide at least one of: context_bid, priority",
-        ).__dict__
-
-    args = ["audiencetargets", "set-bids"]
-    if id is not None:
-        args.extend(["--id", str(id)])
-    if ad_group_id is not None:
-        args.extend(["--adgroup-id", str(ad_group_id)])
-    if campaign_id is not None:
-        args.extend(["--campaign-id", str(campaign_id)])
-    if context_bid is not None:
-        args.extend(["--context-bid", str(context_bid)])
-    if priority is not None:
-        args.extend(["--priority", priority])
-    if dry_run:
-        args.append("--dry-run")
-
-    runner = get_runner()
-    return runner.run_json(args)
+    return run_set_bids(
+        get_runner(),
+        "audiencetargets",
+        id=id,
+        ad_group_id=ad_group_id,
+        campaign_id=campaign_id,
+        bid_fields=(("--context-bid", context_bid), ("--priority", priority)),
+        missing_update_message="Provide at least one of: context_bid, priority",
+        dry_run=dry_run,
+    )

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -3,7 +3,12 @@
 from server.cli.runner import CliAuthError, CliNotFoundError
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options, check_batch_limit
+from server.tools.helpers import (
+    CliOption,
+    append_cli_options,
+    check_batch_limit,
+    provided_update_value,
+)
 
 CAMPAIGN_GET_SELECTOR_FLAGS = (
     ("text_campaign_fields", "--text-campaign-fields"),
@@ -400,17 +405,6 @@ CAMPAIGN_UPDATE_ONLY_OPTIONS = (
 )
 
 
-def _provided_update_value(value: object) -> bool:
-    """Return whether an optional update value should satisfy the update guard."""
-    if value is None:
-        return False
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (list, tuple, set, dict)):
-        return bool(value)
-    return True
-
-
 @mcp.tool(name="campaigns_get")
 @handle_cli_errors
 def campaigns_list(
@@ -788,7 +782,7 @@ def campaigns_update(
         for key, value in values.items()
         if key not in {"id", "dry_run", "notification_json", "time_targeting_json"}
     ]
-    if not any(_provided_update_value(value) for value in optional_values):
+    if not any(provided_update_value(value) for value in optional_values):
         return ToolError(
             error="missing_update_fields",
             message="Provide at least one typed campaign field to update.",

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -1,8 +1,8 @@
 """MCP tools for dynamic ad (webpage) management."""
 
 from server.main import mcp
-from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import run_single_id_batch
+from server.tools import get_runner, handle_cli_errors
+from server.tools.helpers import run_set_bids, run_single_id_batch
 
 
 @mcp.tool(name="dynamicads_get")
@@ -153,32 +153,17 @@ def dynamic_ads_set_bids(
         context_bid: Optional context bid in micro-units (same rules as `bid`).
         priority: Strategy priority.
     """
-    if id is None and ad_group_id is None and campaign_id is None:
-        return ToolError(
-            error="missing_target_scope",
-            message="Provide at least one of: id, ad_group_id, campaign_id",
-        ).__dict__
-    if bid is None and context_bid is None and priority is None:
-        return ToolError(
-            error="missing_update_fields",
-            message="Provide at least one of: bid, context_bid, priority",
-        ).__dict__
-
-    args = ["dynamicads", "set-bids"]
-    if id is not None:
-        args.extend(["--id", str(id)])
-    if ad_group_id is not None:
-        args.extend(["--adgroup-id", str(ad_group_id)])
-    if campaign_id is not None:
-        args.extend(["--campaign-id", str(campaign_id)])
-    if bid is not None:
-        args.extend(["--bid", str(bid)])
-    if context_bid is not None:
-        args.extend(["--context-bid", str(context_bid)])
-    if priority is not None:
-        args.extend(["--priority", priority])
-    if dry_run:
-        args.append("--dry-run")
-
-    runner = get_runner()
-    return runner.run_json(args)
+    return run_set_bids(
+        get_runner(),
+        "dynamicads",
+        id=id,
+        ad_group_id=ad_group_id,
+        campaign_id=campaign_id,
+        bid_fields=(
+            ("--bid", bid),
+            ("--context-bid", context_bid),
+            ("--priority", priority),
+        ),
+        missing_update_message="Provide at least one of: bid, context_bid, priority",
+        dry_run=dry_run,
+    )

--- a/server/tools/dynamic_feed_ad_targets.py
+++ b/server/tools/dynamic_feed_ad_targets.py
@@ -2,7 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit, run_single_id_batch
+from server.tools.helpers import check_batch_limit, run_set_bids, run_single_id_batch
 
 
 @mcp.tool(name="dynamicfeedadtargets_get")
@@ -179,29 +179,13 @@ def dynamic_feed_ad_targets_set_bids(
             rejects values 0 < x < 100_000 with a "did you mean × 1_000_000" hint.
         context_bid: Optional context bid in micro-units (same rules as `bid`).
     """
-    if id is None and ad_group_id is None and campaign_id is None:
-        return ToolError(
-            error="missing_target_scope",
-            message="Provide at least one of: id, ad_group_id, campaign_id",
-        ).__dict__
-    if bid is None and context_bid is None:
-        return ToolError(
-            error="missing_update_fields",
-            message="Provide at least one of: bid, context_bid",
-        ).__dict__
-
-    args = ["dynamicfeedadtargets", "set-bids"]
-    if id is not None:
-        args.extend(["--id", str(id)])
-    if ad_group_id is not None:
-        args.extend(["--adgroup-id", str(ad_group_id)])
-    if campaign_id is not None:
-        args.extend(["--campaign-id", str(campaign_id)])
-    if bid is not None:
-        args.extend(["--bid", str(bid)])
-    if context_bid is not None:
-        args.extend(["--context-bid", str(context_bid)])
-    if dry_run:
-        args.append("--dry-run")
-    runner = get_runner()
-    return runner.run_json(args)
+    return run_set_bids(
+        get_runner(),
+        "dynamicfeedadtargets",
+        id=id,
+        ad_group_id=ad_group_id,
+        campaign_id=campaign_id,
+        bid_fields=(("--bid", bid), ("--context-bid", context_bid)),
+        missing_update_message="Provide at least one of: bid, context_bid",
+        dry_run=dry_run,
+    )

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -85,6 +85,29 @@ def provided_update_value(value: object) -> bool:
     return True
 
 
+def normalize_optional_str(value: str | None) -> str | None:
+    """Strip an optional string and collapse blanks to None."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def normalize_str_list(values: list[str] | None) -> list[str]:
+    """Strip list items and drop blanks."""
+    if not values:
+        return []
+    return [value.strip() for value in values if value.strip()]
+
+
+def finalize_json_args(args: list[str], dry_run: bool) -> list[str]:
+    """Append optional dry-run and JSON output flags."""
+    if dry_run:
+        args.append("--dry-run")
+    args.extend(["--format", "json"])
+    return args
+
+
 def validate_state(state: str, allowed: tuple[str, ...]) -> ToolError | None:
     """Validate state value against allowed options."""
     if state not in allowed:
@@ -159,3 +182,45 @@ def run_single_id_batch(
         "failed": failed,
         "results": results,
     }
+
+
+def run_set_bids(
+    runner,
+    resource: str,
+    *,
+    id: int | None = None,
+    ad_group_id: int | None = None,
+    campaign_id: int | None = None,
+    bid_fields: Sequence[tuple[str, object | None]],
+    missing_update_message: str,
+    dry_run: bool = False,
+) -> dict:
+    """Run a target set-bids command with shared scope/update guards."""
+    if id is None and ad_group_id is None and campaign_id is None:
+        return tool_error_dict(
+            ToolError(
+                error="missing_target_scope",
+                message="Provide at least one of: id, ad_group_id, campaign_id",
+            )
+        )
+    if not any(value is not None for _, value in bid_fields):
+        return tool_error_dict(
+            ToolError(
+                error="missing_update_fields",
+                message=missing_update_message,
+            )
+        )
+
+    args = [resource, "set-bids"]
+    if id is not None:
+        args.extend(["--id", str(id)])
+    if ad_group_id is not None:
+        args.extend(["--adgroup-id", str(ad_group_id)])
+    if campaign_id is not None:
+        args.extend(["--campaign-id", str(campaign_id)])
+    for flag, value in bid_fields:
+        if value is not None:
+            args.extend([flag, str(value)])
+    if dry_run:
+        args.append("--dry-run")
+    return runner.run_json(args)

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -2,7 +2,12 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import CliOption, append_cli_options, provided_update_value
+from server.tools.helpers import (
+    CliOption,
+    append_cli_options,
+    check_batch_limit,
+    provided_update_value,
+)
 
 MAX_BATCH_SIZE = 10
 
@@ -32,17 +37,6 @@ KEYWORD_AUTOTARGETING_OPTIONS = (
         "--autotargeting-settings-with-competitors-brand",
     ),
 )
-
-
-def _check_batch_limit(ids_str: str) -> ToolError | None:
-    """Validate batch size of comma-separated IDs."""
-    ids = [id.strip() for id in ids_str.split(",") if id.strip()]
-    if len(ids) > MAX_BATCH_SIZE:
-        return ToolError(
-            error="batch_limit",
-            message=f"Maximum {MAX_BATCH_SIZE} IDs per request. Got: {len(ids)}",
-        )
-    return None
 
 
 @mcp.tool(name="keywords_get")
@@ -88,7 +82,7 @@ def keywords_list(
         if not normalized:
             continue
         if batch:
-            batch_error = _check_batch_limit(normalized)
+            batch_error = check_batch_limit(normalized, MAX_BATCH_SIZE)
             if batch_error:
                 return batch_error.__dict__
         args.extend([flag, normalized])

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -2,9 +2,10 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import run_single_id_batch
+from server.tools.helpers import CliOption, append_cli_options, run_single_id_batch
 
 _LIST_TYPES = ("RETARGETING", "AUDIENCE")
+RETARGETING_RULE_OPTIONS = (CliOption("rules", "--rule", repeat=True),)
 
 
 @mcp.tool(name="retargeting_get")
@@ -85,9 +86,7 @@ def retargeting_add(
         args.extend(["--rule", rule])
     if description is not None:
         args.extend(["--description", description])
-    if rules:
-        for spec in rules:
-            args.extend(["--rule", spec])
+    append_cli_options(args, locals(), RETARGETING_RULE_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)
@@ -154,9 +153,7 @@ def retargeting_update(
         args.extend(["--type", list_type])
     if rule is not None:
         args.extend(["--rule", rule])
-    if rules:
-        for spec in rules:
-            args.extend(["--rule", spec])
+    append_cli_options(args, locals(), RETARGETING_RULE_OPTIONS)
     if dry_run:
         args.append("--dry-run")
     return get_runner().run_json(args)

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -2,9 +2,15 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import run_single_id_batch
+from server.tools.helpers import (
+    CliOption,
+    append_cli_options,
+    run_set_bids,
+    run_single_id_batch,
+)
 
 _YES_NO = ("YES", "NO")
+SMART_TARGET_CONDITION_OPTIONS = (CliOption("conditions", "--condition", repeat=True),)
 
 
 @mcp.tool(name="smartadtargets_get")
@@ -98,9 +104,7 @@ def smart_ad_targets_add(
     ]
     if condition is not None:
         args.extend(["--condition", condition])
-    if conditions:
-        for spec in conditions:
-            args.extend(["--condition", spec])
+    append_cli_options(args, locals(), SMART_TARGET_CONDITION_OPTIONS)
     if average_cpc is not None:
         args.extend(["--average-cpc", str(average_cpc)])
     if average_cpa is not None:
@@ -180,9 +184,7 @@ def smart_ad_targets_update(
         args.extend(["--audience", audience])
     if condition is not None:
         args.extend(["--condition", condition])
-    if conditions:
-        for spec in conditions:
-            args.extend(["--condition", spec])
+    append_cli_options(args, locals(), SMART_TARGET_CONDITION_OPTIONS)
     if average_cpc is not None:
         args.extend(["--average-cpc", str(average_cpc)])
     if average_cpa is not None:
@@ -259,32 +261,19 @@ def smart_ad_targets_set_bids(
         average_cpa: Optional average CPA in micro-units (same rules as `average_cpc`).
         priority: Strategy priority.
     """
-    if id is None and ad_group_id is None and campaign_id is None:
-        return ToolError(
-            error="missing_target_scope",
-            message="Provide at least one of: id, ad_group_id, campaign_id",
-        ).__dict__
-    if average_cpc is None and average_cpa is None and priority is None:
-        return ToolError(
-            error="missing_update_fields",
-            message="Provide at least one of: average_cpc, average_cpa, priority",
-        ).__dict__
-
-    args = ["smartadtargets", "set-bids"]
-    if id is not None:
-        args.extend(["--id", str(id)])
-    if ad_group_id is not None:
-        args.extend(["--adgroup-id", str(ad_group_id)])
-    if campaign_id is not None:
-        args.extend(["--campaign-id", str(campaign_id)])
-    if average_cpc is not None:
-        args.extend(["--average-cpc", str(average_cpc)])
-    if average_cpa is not None:
-        args.extend(["--average-cpa", str(average_cpa)])
-    if priority is not None:
-        args.extend(["--priority", priority])
-    if dry_run:
-        args.append("--dry-run")
-
-    runner = get_runner()
-    return runner.run_json(args)
+    return run_set_bids(
+        get_runner(),
+        "smartadtargets",
+        id=id,
+        ad_group_id=ad_group_id,
+        campaign_id=campaign_id,
+        bid_fields=(
+            ("--average-cpc", average_cpc),
+            ("--average-cpa", average_cpa),
+            ("--priority", priority),
+        ),
+        missing_update_message=(
+            "Provide at least one of: average_cpc, average_cpa, priority"
+        ),
+        dry_run=dry_run,
+    )

--- a/server/tools/v4account.py
+++ b/server/tools/v4account.py
@@ -2,6 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import finalize_json_args
 
 
 def _base_args(*, sandbox: bool) -> list[str]:
@@ -110,10 +111,7 @@ def v4account_enable_shared_account(
 
     args = _base_args(sandbox=sandbox)
     args.extend(["enable-shared-account", "--client-login", normalized_login])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4account_get_accounts")
@@ -175,10 +173,7 @@ def v4account_get_accounts(
         args.extend(["--logins", normalized_logins])
     if normalized_account_ids:
         args.extend(["--account-ids", normalized_account_ids])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4account_update_account")
@@ -241,10 +236,7 @@ def v4account_update_account(
     _append_optional(args, "--money-warning-value", money_warning_value)
     _append_optional_text(args, "--paused-by-day-budget", paused_by_day_budget)
 
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4account_deposit")
@@ -298,10 +290,7 @@ def v4account_deposit(
     _append_optional_text(args, "--contract", contract)
     _append_optional(args, "--operation-num", operation_num)
 
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4account_invoice")
@@ -345,10 +334,7 @@ def v4account_invoice(
     args.extend(["--currency", normalized_currency])
     _append_optional(args, "--operation-num", operation_num)
 
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4account_transfer_money")
@@ -409,7 +395,4 @@ def v4account_transfer_money(
     )
     _append_optional(args, "--operation-num", operation_num)
 
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/server/tools/v4adimage.py
+++ b/server/tools/v4adimage.py
@@ -2,19 +2,11 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-
-
-def _normalize_optional(value: str | None) -> str | None:
-    if value is None:
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _normalize_associations(associations: list[str] | None) -> list[str]:
-    if not associations:
-        return []
-    return [item.strip() for item in associations if item.strip()]
+from server.tools.helpers import (
+    finalize_json_args,
+    normalize_optional_str,
+    normalize_str_list,
+)
 
 
 @mcp.tool(name="v4adimage_get")
@@ -46,24 +38,22 @@ def v4adimage_get(
     """
     args = ["v4adimage", "get"]
 
-    normalized_logins = _normalize_optional(logins)
+    normalized_logins = normalize_optional_str(logins)
     if normalized_logins:
         args.extend(["--logins", normalized_logins])
 
-    normalized_hashes = _normalize_optional(ad_image_hashes)
+    normalized_hashes = normalize_optional_str(ad_image_hashes)
     if normalized_hashes:
         args.extend(["--ad-image-hashes", normalized_hashes])
 
-    for status in status_moderate or []:
-        normalized_status = status.strip()
-        if normalized_status:
-            args.extend(["--status-moderate", normalized_status])
+    for status in normalize_str_list(status_moderate):
+        args.extend(["--status-moderate", status])
 
-    normalized_ad_ids = _normalize_optional(ad_ids)
+    normalized_ad_ids = normalize_optional_str(ad_ids)
     if normalized_ad_ids:
         args.extend(["--ad-ids", normalized_ad_ids])
 
-    normalized_campaign_ids = _normalize_optional(campaign_ids)
+    normalized_campaign_ids = normalize_optional_str(campaign_ids)
     if normalized_campaign_ids:
         args.extend(["--campaign-ids", normalized_campaign_ids])
 
@@ -71,11 +61,8 @@ def v4adimage_get(
         args.extend(["--limit", str(limit)])
     if offset is not None:
         args.extend(["--offset", str(offset)])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4adimage_set")
@@ -93,7 +80,7 @@ def v4adimage_set(
             ``AD_ID=HASH`` to link an image. At least one is required.
         dry_run: Show the direct request without sending it.
     """
-    normalized = _normalize_associations(associations)
+    normalized = normalize_str_list(associations)
     if not normalized:
         return ToolError(
             error="missing_associations",
@@ -103,8 +90,5 @@ def v4adimage_set(
     args = ["v4adimage", "set"]
     for item in normalized:
         args.extend(["--association", item])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/server/tools/v4events.py
+++ b/server/tools/v4events.py
@@ -2,6 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import finalize_json_args
 
 
 @mcp.tool(name="v4events_get_events_log")
@@ -46,7 +47,4 @@ def v4events_get_events_log(
         args.extend(["--limit", str(limit)])
     if offset is not None:
         args.extend(["--offset", str(offset)])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/server/tools/v4forecast.py
+++ b/server/tools/v4forecast.py
@@ -2,6 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import finalize_json_args
 
 MAX_PHRASES = 100
 
@@ -42,11 +43,8 @@ def v4forecast_create(
             args.extend(["--geo-ids", normalized_geo])
     if currency:
         args.extend(["--currency", currency])
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4forecast_list")
@@ -86,8 +84,5 @@ def v4forecast_delete(forecast_id: int, dry_run: bool = False) -> dict | list[di
         dry_run: Show the direct request without sending it.
     """
     args = ["v4forecast", "delete", "--forecast-id", str(forecast_id)]
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/server/tools/v4keywords.py
+++ b/server/tools/v4keywords.py
@@ -2,12 +2,7 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-
-
-def _normalize_keywords(keywords: list[str] | None) -> list[str]:
-    if not keywords:
-        return []
-    return [keyword.strip() for keyword in keywords if keyword.strip()]
+from server.tools.helpers import normalize_str_list
 
 
 @mcp.tool(name="v4keywords_get_suggestion")
@@ -21,7 +16,7 @@ def v4keywords_get_suggestion(keywords: list[str]) -> dict | list[dict]:
     Args:
         keywords: Source phrases to expand. At least one is required.
     """
-    normalized = _normalize_keywords(keywords)
+    normalized = normalize_str_list(keywords)
     if not normalized:
         return ToolError(
             error="missing_keywords",

--- a/server/tools/v4tags.py
+++ b/server/tools/v4tags.py
@@ -2,20 +2,12 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
-from server.tools.helpers import check_batch_limit
-
-
-def _normalize_optional(value: str | None) -> str | None:
-    if value is None:
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _normalize_tags(tags: list[str] | None) -> list[str]:
-    if not tags:
-        return []
-    return [tag.strip() for tag in tags if tag.strip()]
+from server.tools.helpers import (
+    check_batch_limit,
+    finalize_json_args,
+    normalize_optional_str,
+    normalize_str_list,
+)
 
 
 @mcp.tool(name="v4tags_get_campaigns")
@@ -56,8 +48,8 @@ def v4tags_get_banners(
         campaign_ids: Comma-separated campaign IDs, up to 10.
         banner_ids: Comma-separated banner IDs, up to 2000.
     """
-    normalized_campaign_ids = _normalize_optional(campaign_ids)
-    normalized_banner_ids = _normalize_optional(banner_ids)
+    normalized_campaign_ids = normalize_optional_str(campaign_ids)
+    normalized_banner_ids = normalize_optional_str(banner_ids)
     if normalized_campaign_ids and normalized_banner_ids:
         return ToolError(
             error="conflicting_selectors",
@@ -104,7 +96,7 @@ def v4tags_update_campaigns(
         clear_tags: Remove all campaign tags.
         dry_run: Show the direct request without sending it.
     """
-    normalized_tags = _normalize_tags(tags)
+    normalized_tags = normalize_str_list(tags)
     if normalized_tags and clear_tags:
         return ToolError(
             error="conflicting_tag_actions",
@@ -121,11 +113,8 @@ def v4tags_update_campaigns(
         args.extend(["--tag", tag])
     if clear_tags:
         args.append("--clear-tags")
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4tags_update_banners")
@@ -151,7 +140,7 @@ def v4tags_update_banners(
             message="Provide at least one banner ID.",
         ).__dict__
 
-    normalized_tag_ids = _normalize_optional(tag_ids)
+    normalized_tag_ids = normalize_optional_str(tag_ids)
     if normalized_tag_ids and clear_tags:
         return ToolError(
             error="conflicting_tag_actions",
@@ -172,8 +161,5 @@ def v4tags_update_banners(
         args.extend(["--tag-ids", normalized_tag_ids])
     if clear_tags:
         args.append("--clear-tags")
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
 
-    return get_runner().run_json(args)
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/server/tools/v4wordstat.py
+++ b/server/tools/v4wordstat.py
@@ -2,15 +2,9 @@
 
 from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
+from server.tools.helpers import finalize_json_args
 
 MAX_WORDSTAT_PHRASES = 10
-
-
-def _append_dry_run_and_format(args: list[str], dry_run: bool) -> list[str]:
-    if dry_run:
-        args.append("--dry-run")
-    args.extend(["--format", "json"])
-    return args
 
 
 @mcp.tool(name="v4wordstat_create_report")
@@ -52,7 +46,7 @@ def v4wordstat_create_report(
         normalized_geo = geo_ids.strip()
         if normalized_geo:
             args.extend(["--geo-ids", normalized_geo])
-    return get_runner().run_json(_append_dry_run_and_format(args, dry_run))
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4wordstat_list_reports")
@@ -60,7 +54,7 @@ def v4wordstat_create_report(
 def v4wordstat_list_reports(dry_run: bool = False) -> dict | list[dict]:
     """List v4 Live Wordstat reports via GetWordstatReportList."""
     args = ["v4wordstat", "list-reports"]
-    return get_runner().run_json(_append_dry_run_and_format(args, dry_run))
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4wordstat_get_report")
@@ -73,7 +67,7 @@ def v4wordstat_get_report(report_id: int, dry_run: bool = False) -> dict | list[
         dry_run: Show the direct request without sending it.
     """
     args = ["v4wordstat", "get-report", "--report-id", str(report_id)]
-    return get_runner().run_json(_append_dry_run_and_format(args, dry_run))
+    return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
 @mcp.tool(name="v4wordstat_delete_report")
@@ -88,4 +82,4 @@ def v4wordstat_delete_report(
         dry_run: Show the direct request without sending it.
     """
     args = ["v4wordstat", "delete-report", "--report-id", str(report_id)]
-    return get_runner().run_json(_append_dry_run_and_format(args, dry_run))
+    return get_runner().run_json(finalize_json_args(args, dry_run))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,32 @@
+"""Shared test helpers."""
+
+import subprocess
+from unittest.mock import MagicMock
+
+
+def completed(
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess:
+    """Return a subprocess result matching DirectCliRunner expectations."""
+    return subprocess.CompletedProcess(
+        args=["direct"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def mock_runner(
+    return_value=None,
+    *,
+    checked_return_value: subprocess.CompletedProcess | None = None,
+) -> MagicMock:
+    """Return a mock runner with configurable JSON and checked results."""
+    runner = MagicMock()
+    runner.run_json.return_value = return_value
+    runner.run_checked.return_value = (
+        checked_return_value if checked_return_value is not None else completed()
+    )
+    return runner

--- a/tests/test_adgroups.py
+++ b/tests/test_adgroups.py
@@ -1,7 +1,6 @@
 """Tests for ad group MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.adgroups import (
     adgroups_list,
@@ -10,18 +9,12 @@ from server.tools.adgroups import (
     adgroups_delete,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_ADGROUPS = [
     {"Id": 1, "Name": "Ad Group 1", "CampaignId": 12345},
     {"Id": 2, "Name": "Ad Group 2", "CampaignId": 12345},
 ]
-
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
 
 
 class TestAdgroupsList:
@@ -31,7 +24,7 @@ class TestAdgroupsList:
         """Test listing ad groups by campaign."""
         with patch(
             "server.tools.adgroups.get_runner",
-            return_value=_mock_runner(SAMPLE_ADGROUPS),
+            return_value=mock_runner(SAMPLE_ADGROUPS),
         ):
             result = adgroups_list(campaign_ids="12345")
             assert len(result) == 2
@@ -39,8 +32,7 @@ class TestAdgroupsList:
 
     def test_adgroups_list_ignores_blank_campaign_ids(self):
         """Test blank campaign IDs behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = SAMPLE_ADGROUPS
+        runner = mock_runner(SAMPLE_ADGROUPS)
         with patch("server.tools.adgroups.get_runner", return_value=runner):
             result = adgroups_list(campaign_ids="   ")
             assert len(result) == 2
@@ -51,7 +43,7 @@ class TestAdgroupsList:
         """Test empty ad groups list."""
         with patch(
             "server.tools.adgroups.get_runner",
-            return_value=_mock_runner([]),
+            return_value=mock_runner([]),
         ):
             result = adgroups_list(campaign_ids="12345")
             assert result == []
@@ -72,15 +64,14 @@ class TestAdgroupsAdd:
         mock_result = {"Id": 123, "Name": "New Ad Group"}
         with patch(
             "server.tools.adgroups.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = adgroups_add(campaign_id=12345, name="New Ad Group")
             assert result["Id"] == 123
 
     def test_adgroups_add_with_type(self):
         """Test adding ad group with type parameter."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 124}
+        runner = mock_runner({"Id": 124})
         with patch(
             "server.tools.adgroups.get_runner",
             return_value=runner,
@@ -103,7 +94,7 @@ class TestAdgroupsUpdate:
         mock_result = {"Id": 123, "Name": "Updated Name"}
         with patch(
             "server.tools.adgroups.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = adgroups_update(id=123, name="Updated Name")
             assert result["Id"] == 123
@@ -116,7 +107,7 @@ class TestAdgroupsUpdate:
 
     def test_adgroups_update_accepts_empty_string_field(self):
         """Empty strings are provided values; CLI owns semantic validation."""
-        runner = _mock_runner({"Id": 123})
+        runner = mock_runner({"Id": 123})
         with patch("server.tools.adgroups.get_runner", return_value=runner):
             adgroups_update(id=123, name="")
 
@@ -126,8 +117,7 @@ class TestAdgroupsUpdate:
 
     def test_adgroups_update_with_status(self):
         """Test updating with status."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 123}
+        runner = mock_runner({"Id": 123})
         with patch(
             "server.tools.adgroups.get_runner",
             return_value=runner,
@@ -146,7 +136,7 @@ class TestAdgroupsDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.adgroups.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = adgroups_delete(ids="1")
             assert result["success"] is True

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -1,7 +1,6 @@
 """Tests for ads MCP tool."""
 
-from unittest.mock import MagicMock, call, patch
-
+from unittest.mock import call, patch
 
 from server.tools.ads import (
     ads_list,
@@ -15,6 +14,7 @@ from server.tools.ads import (
     ads_unarchive,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_ADS = [
     {
@@ -27,24 +27,16 @@ SAMPLE_ADS = [
 ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_ads_list_success():
     """Test 11: List ads in a campaign."""
-    with patch("server.tools.ads.get_runner", return_value=_mock_runner(SAMPLE_ADS)):
+    with patch("server.tools.ads.get_runner", return_value=mock_runner(SAMPLE_ADS)):
         result = ads_list(campaign_ids="12345")
         assert len(result) == 2
 
 
 def test_ads_list_ignores_blank_filters():
     """Test blank filters behave like no filter."""
-    runner = MagicMock()
-    runner.run_json.return_value = SAMPLE_ADS
+    runner = mock_runner(SAMPLE_ADS)
     with patch("server.tools.ads.get_runner", return_value=runner):
         result = ads_list(campaign_ids="   ", ad_group_ids="   ", ids="   ")
         assert len(result) == 2
@@ -64,7 +56,7 @@ def test_ads_batch_limit():
 
 def test_ads_empty():
     """Empty result."""
-    with patch("server.tools.ads.get_runner", return_value=_mock_runner([])):
+    with patch("server.tools.ads.get_runner", return_value=mock_runner([])):
         result = ads_list(campaign_ids="12345")
         assert result == []
 
@@ -75,7 +67,7 @@ class TestAdsCrudOperations:
     def test_ads_add(self):
         """Test adding a new ad."""
         mock_result = {"Id": 999, "Text": "New ad text"}
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_add(
                 ad_group_id=1,
@@ -104,7 +96,7 @@ class TestAdsCrudOperations:
 
     def test_ads_add_mobile_app(self):
         """MOBILE_APP_AD: tracking_url, action, age_label, image_hash pass through."""
-        runner = _mock_runner({"Id": 9999})
+        runner = mock_runner({"Id": 9999})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -141,7 +133,7 @@ class TestAdsCrudOperations:
 
     def test_ads_add_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(ad_group_id=1, ad_type="TEXT_AD", title="t", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -151,14 +143,14 @@ class TestAdsCrudOperations:
         """Test updating an ad with new required type parameter."""
         mock_result = {"Id": 111}
         with patch(
-            "server.tools.ads.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.ads.get_runner", return_value=mock_runner(mock_result)
         ):
             result = ads_update(id=111, type="TEXT_AD", title="New title")
             assert result["Id"] == 111
 
     def test_ads_update_argv_composition(self):
         """Test that update passes --type and field flags correctly."""
-        runner = _mock_runner({"Id": 111})
+        runner = mock_runner({"Id": 111})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_update(
                 id=111,
@@ -186,7 +178,7 @@ class TestAdsCrudOperations:
 
     def test_ads_update_mobile_app_argv(self):
         """MOBILE_APP_AD update accepts tracking_url / action / age_label / image_hash."""
-        runner = _mock_runner({"Id": 222})
+        runner = mock_runner({"Id": 222})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_update(
                 id=222,
@@ -204,7 +196,7 @@ class TestAdsCrudOperations:
 
     def test_ads_update_requires_changes(self):
         """Test that empty updates (type only) are rejected before CLI call."""
-        runner = _mock_runner({"Id": 111})
+        runner = mock_runner({"Id": 111})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_update(id=111, type="TEXT_AD")
             assert result["error"] == "missing_update_fields"
@@ -212,7 +204,7 @@ class TestAdsCrudOperations:
 
     def test_ads_update_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_update(id=111, type="TEXT_AD", title="x", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -220,7 +212,7 @@ class TestAdsCrudOperations:
 
     def test_ads_delete_success(self):
         """Test deleting ads successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_delete(ids="111,222")
             assert result["success"] is True
@@ -240,7 +232,7 @@ class TestAdsCrudOperations:
 
     def test_ads_moderate_success(self):
         """Test submitting ads for moderation."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_moderate(ids="111,222")
             assert result["success"] is True
@@ -260,7 +252,7 @@ class TestAdsCrudOperations:
 
     def test_ads_suspend_success(self):
         """Test suspending ads."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_suspend(ids="111,222")
             assert result["success"] is True
@@ -280,7 +272,7 @@ class TestAdsCrudOperations:
 
     def test_ads_resume_success(self):
         """Test resuming suspended ads."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_resume(ids="111,222")
             assert result["success"] is True
@@ -300,7 +292,7 @@ class TestAdsCrudOperations:
 
     def test_ads_archive_success(self):
         """Test archiving ads."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_archive(ids="111,222")
             assert result["success"] is True
@@ -320,7 +312,7 @@ class TestAdsCrudOperations:
 
     def test_ads_unarchive_success(self):
         """Test unarchiving ads."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_unarchive(ids="111,222")
             assert result["success"] is True
@@ -343,7 +335,7 @@ class TestAdsTypedTextAdFields:
     """CLI 0.3.9: typed TextAd fields (title2, sitelinks, ad_extensions, etc)."""
 
     def test_ads_add_passes_title2(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -358,7 +350,7 @@ class TestAdsTypedTextAdFields:
         assert "Second headline" in argv
 
     def test_ads_add_passes_display_url_path(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -373,7 +365,7 @@ class TestAdsTypedTextAdFields:
         assert "catalog/items" in argv
 
     def test_ads_add_passes_mobile_yes(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -388,7 +380,7 @@ class TestAdsTypedTextAdFields:
         assert "YES" in argv
 
     def test_ads_add_rejects_mobile_invalid_value(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_add(
                 ad_group_id=1,
@@ -401,7 +393,7 @@ class TestAdsTypedTextAdFields:
         runner.run_json.assert_not_called()
 
     def test_ads_add_passes_vcard_id(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -416,7 +408,7 @@ class TestAdsTypedTextAdFields:
         assert "42" in argv
 
     def test_ads_add_passes_sitelink_set_id(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -431,7 +423,7 @@ class TestAdsTypedTextAdFields:
         assert "7" in argv
 
     def test_ads_add_passes_turbo_page_id(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -446,7 +438,7 @@ class TestAdsTypedTextAdFields:
         assert "12345" in argv
 
     def test_ads_add_passes_ad_extensions(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_add(
                 ad_group_id=1,
@@ -461,7 +453,7 @@ class TestAdsTypedTextAdFields:
         assert "111,222,333" in argv
 
     def test_ads_update_passes_typed_text_ad_fields(self):
-        runner = _mock_runner({"Id": 555})
+        runner = mock_runner({"Id": 555})
         with patch("server.tools.ads.get_runner", return_value=runner):
             ads_update(
                 id=555,
@@ -488,7 +480,7 @@ class TestAdsTypedTextAdFields:
             assert value in argv, f"{value} missing from argv"
 
     def test_ads_update_rejects_mobile_invalid_value(self):
-        runner = _mock_runner({"Id": 555})
+        runner = mock_runner({"Id": 555})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_update(id=555, type="TEXT_AD", mobile="FOO")
         assert isinstance(result, dict)
@@ -497,7 +489,7 @@ class TestAdsTypedTextAdFields:
 
     def test_ads_update_typed_field_alone_satisfies_change_check(self):
         """title2 alone counts as a meaningful update — not 'missing_update_fields'."""
-        runner = _mock_runner({"Id": 555})
+        runner = mock_runner({"Id": 555})
         with patch("server.tools.ads.get_runner", return_value=runner):
             result = ads_update(id=555, type="TEXT_AD", title2="b")
         assert result["Id"] == 555

--- a/tests/test_advideos.py
+++ b/tests/test_advideos.py
@@ -1,19 +1,14 @@
 """Tests for advideos MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.advideos import advideos_add, advideos_get
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 def test_advideos_get():
-    runner = _mock_runner({"Videos": []})
+    runner = mock_runner({"Videos": []})
     with patch("server.tools.advideos.get_runner", return_value=runner):
         result = advideos_get(ids="1,2")
 
@@ -24,7 +19,7 @@ def test_advideos_get():
 
 
 def test_advideos_add_url():
-    runner = _mock_runner({"Id": 10})
+    runner = mock_runner({"Id": 10})
     with patch("server.tools.advideos.get_runner", return_value=runner):
         result = advideos_add(url="https://example.com/video.mp4", name="Promo")
 

--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -1,7 +1,6 @@
 """Tests for agency MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.agency import (
     agency_clients_list,
@@ -12,12 +11,7 @@ from server.tools.agency import (
     agency_clients_update,
 )
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestAgencyClientsList:
@@ -33,7 +27,7 @@ class TestAgencyClientsList:
         }
         with patch(
             "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = agency_clients_list()
             assert result == mock_result
@@ -41,8 +35,7 @@ class TestAgencyClientsList:
     def test_list_agency_clients_with_ids(self):
         """Test listing agency clients filtered by IDs."""
         mock_result = {"Clients": [{"Login": "client1", "FirstName": "John"}]}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_list(logins="login1,login2")
@@ -57,15 +50,14 @@ class TestAgencyClientsList:
         mock_result = {"Clients": []}
         with patch(
             "server.tools.agency.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = agency_clients_list()
             assert result == mock_result
 
     def test_list_agency_clients_trims_ids_before_cli(self):
         """Test client IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Clients": []}
+        runner = mock_runner({"Clients": []})
         with patch("server.tools.agency.get_runner", return_value=runner):
             agency_clients_list(logins=" login1,login2 ")
 
@@ -80,7 +72,7 @@ class TestAgencyClientsAdd:
     def test_add_client_typed(self):
         """Test adding a client with typed flags."""
         mock_result = {"Login": "new_client"}
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_add(
                 login="new_client",
@@ -112,7 +104,7 @@ class TestAgencyClientsAdd:
             )
 
     def test_add_client_dry_run(self):
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.agency.get_runner", return_value=runner):
             agency_clients_add(
                 login="c", first_name="F", last_name="L", currency="RUB", dry_run=True
@@ -126,8 +118,7 @@ class TestAgencyClientsDelete:
     def test_delete_client_from_agency(self):
         """Test removing a client from an agency."""
         mock_result = {"Success": True}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_delete(id=123)
             assert result == mock_result
@@ -140,7 +131,7 @@ class TestAgencyClientsUpdate:
     """Test scenarios for agency_clients_update (CLI 0.3.8)."""
 
     def test_update_client(self):
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_update(
                 client_id=123,
@@ -162,7 +153,7 @@ class TestAgencyClientsUpdate:
         )
 
     def test_update_client_grants_list(self):
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.agency.get_runner", return_value=runner):
             agency_clients_update(
                 client_id=123,
@@ -189,8 +180,7 @@ class TestAgencyClientsPassportOrganization:
     """Test passport organization helper wrappers."""
 
     def test_add_passport_organization(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_add_passport_organization(
                 name="Org",
@@ -214,8 +204,7 @@ class TestAgencyClientsPassportOrganization:
         )
 
     def test_add_passport_organization_member(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.agency.get_runner", return_value=runner):
             result = agency_clients_add_passport_organization_member(
                 passport_organization_login="org-login",

--- a/tests/test_audience.py
+++ b/tests/test_audience.py
@@ -1,6 +1,6 @@
 """Tests for audience MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +12,8 @@ from server.tools.audience import (
     audience_targets_set_bids,
     audience_targets_suspend,
 )
+
+from tests.helpers import mock_runner
 
 
 @pytest.fixture
@@ -33,13 +35,6 @@ def mock_audience_targets():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestAudienceTargetsList:
     """Tests for audience_targets_list."""
 
@@ -47,15 +42,14 @@ class TestAudienceTargetsList:
         """Test listing audience targets by campaign IDs."""
         with patch(
             "server.tools.audience.get_runner",
-            return_value=_mock_runner(mock_audience_targets),
+            return_value=mock_runner(mock_audience_targets),
         ):
             result = audience_targets_list(campaign_ids="12345")
             assert len(result) == 2
 
     def test_list_audience_targets_by_ad_group(self):
         """Test listing audience targets by ad group IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.audience.get_runner",
             return_value=runner,
@@ -66,8 +60,7 @@ class TestAudienceTargetsList:
 
     def test_list_audience_targets_by_ids(self):
         """Test listing audience targets by IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.audience.get_runner",
             return_value=runner,
@@ -78,8 +71,7 @@ class TestAudienceTargetsList:
 
     def test_list_audience_targets_ignores_blank_ids(self, mock_audience_targets):
         """Test blank filters behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_audience_targets
+        runner = mock_runner(mock_audience_targets)
         with patch("server.tools.audience.get_runner", return_value=runner):
             result = audience_targets_list(
                 campaign_ids="   ", ad_group_ids="   ", ids="   "
@@ -109,8 +101,7 @@ class TestAudienceTargetsAdd:
             "RetargetingListId": 557,
             "State": "ON",
         }
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch(
             "server.tools.audience.get_runner",
             return_value=runner,
@@ -126,8 +117,7 @@ class TestAudienceTargetsAdd:
 
     def test_add_audience_target_with_bid(self):
         """Test adding with bid parameter."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 104}
+        runner = mock_runner({"Id": 104})
         with patch(
             "server.tools.audience.get_runner",
             return_value=runner,
@@ -150,7 +140,7 @@ class TestAudienceTargetsDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.audience.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = audience_targets_delete(ids="101")
             assert result["success"] is True
@@ -171,7 +161,7 @@ class TestAudienceTargetsSuspend:
         mock_result = {"success": True}
         with patch(
             "server.tools.audience.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = audience_targets_suspend(ids="101")
             assert result["success"] is True
@@ -192,7 +182,7 @@ class TestAudienceTargetsResume:
         mock_result = {"success": True}
         with patch(
             "server.tools.audience.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = audience_targets_resume(ids="101")
             assert result["success"] is True
@@ -209,8 +199,7 @@ class TestAudienceTargetsSetBids:
     """Tests for audience_targets_set_bids."""
 
     def test_set_bids_success(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.audience.get_runner", return_value=runner):
             result = audience_targets_set_bids(
                 id=101,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import subprocess
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from server.cli.runner import CliError, CliNotFoundError, CliTimeoutError
@@ -18,21 +17,14 @@ from server.tools.auth_tools import (
     oauth_login_prompt,
 )
 
-
-def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
-    return subprocess.CompletedProcess(
-        args=["direct"],
-        returncode=returncode,
-        stdout=stdout,
-        stderr=stderr,
-    )
+from tests.helpers import completed
 
 
 class TestAuthStatus:
     def test_auth_status_returns_invalid_without_credentials(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(
+            return_value=completed(
                 json.dumps(
                     {
                         "profile": None,
@@ -55,7 +47,7 @@ class TestAuthStatus:
     def test_auth_status_normalizes_legacy_no_active_profile_text(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed("ℹ Нет активного профиля.\n"),
+            return_value=completed("ℹ Нет активного профиля.\n"),
         ):
             result = auth_status()
 
@@ -68,7 +60,7 @@ class TestAuthStatus:
     def test_auth_status_reads_direct_cli_status(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(
+            return_value=completed(
                 json.dumps(
                     {
                         "profile": "default",
@@ -94,7 +86,7 @@ class TestAuthStatus:
     def test_auth_status_explicit_profile_delegates_to_direct(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(
+            return_value=completed(
                 json.dumps(
                     {
                         "profile": "legacy",
@@ -117,7 +109,7 @@ class TestAuthStatus:
     def test_auth_status_reports_env_source_from_direct(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(
+            return_value=completed(
                 json.dumps(
                     {
                         "profile": None,
@@ -138,7 +130,7 @@ class TestAuthStatus:
     def test_auth_status_marks_expired_profile_invalid(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(
+            return_value=completed(
                 json.dumps(
                     {
                         "profile": "default",
@@ -176,8 +168,8 @@ class TestAuthSetup:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
             side_effect=[
-                _completed("✓ Profile 'default' is saved and active.\n"),
-                _completed(
+                completed("✓ Profile 'default' is saved and active.\n"),
+                completed(
                     json.dumps(
                         {
                             "profile": "default",
@@ -218,8 +210,8 @@ class TestAuthSetup:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
             side_effect=[
-                _completed("ok"),
-                _completed(
+                completed("ok"),
+                completed(
                     json.dumps(
                         {
                             "profile": "default",
@@ -246,8 +238,8 @@ class TestAuthSetup:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
             side_effect=[
-                _completed("ok"),
-                _completed(
+                completed("ok"),
+                completed(
                     json.dumps(
                         {
                             "profile": "default",
@@ -325,7 +317,7 @@ class TestAuthSetup:
     def test_auth_setup_rejects_browser_oauth_code_without_cli_call(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed("✓ Profile 'custom' is saved and active.\n"),
+            return_value=completed("✓ Profile 'custom' is saved and active.\n"),
         ) as mock_run:
             result = auth_setup("abc123", profile="custom")
 
@@ -346,7 +338,7 @@ class TestAuthSetup:
     def test_auth_setup_reports_cli_failure(self) -> None:
         with patch(
             "server.tools.auth_tools.DirectCliRunner.run",
-            return_value=_completed(stderr="Error: bad code", returncode=1),
+            return_value=completed(stderr="Error: bad code", returncode=1),
         ):
             result = auth_setup("y0_bad")
         assert result["success"] is False
@@ -387,7 +379,7 @@ class TestAuthLogin:
     def test_auth_login_force_reauth_when_already_valid(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
-        mock_run.return_value = _completed(
+        mock_run.return_value = completed(
             json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
         )
         mock_ctx = MagicMock()
@@ -418,7 +410,7 @@ class TestAuthLogin:
     def test_auth_login_cancelled(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
-        mock_run.return_value = _completed(
+        mock_run.return_value = completed(
             json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
         )
 
@@ -443,7 +435,7 @@ class TestAuthLogin:
     def test_auth_login_start_cli_failure(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
-        mock_run.return_value = _completed(stderr="\x1b[31mboom\x1b[0m", returncode=2)
+        mock_run.return_value = completed(stderr="\x1b[31mboom\x1b[0m", returncode=2)
 
         result = asyncio.run(auth_login(MagicMock()))
 
@@ -460,7 +452,7 @@ class TestAuthLogin:
     def test_auth_login_start_invalid_json(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
-        mock_run.return_value = _completed("not json")
+        mock_run.return_value = completed("not json")
 
         result = asyncio.run(auth_login(MagicMock()))
 
@@ -475,7 +467,7 @@ class TestAuthLogin:
     def test_auth_login_start_missing_authorize_url(
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
-        mock_run.return_value = _completed(json.dumps({"status": "pending"}))
+        mock_run.return_value = completed(json.dumps({"status": "pending"}))
 
         result = asyncio.run(auth_login(MagicMock()))
 
@@ -517,10 +509,10 @@ class TestAuthLogin:
             },
         ]
         mock_run.side_effect = [
-            _completed(
+            completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
-            _completed("saved"),
+            completed("saved"),
         ]
 
         result = asyncio.run(auth_login(self._accepted_ctx()))
@@ -564,10 +556,10 @@ class TestAuthLogin:
         monkeypatch.delenv("YANDEX_DIRECT_CLIENT_ID", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_CLIENT_SECRET", raising=False)
         mock_run.side_effect = [
-            _completed(
+            completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
-            _completed("saved"),
+            completed("saved"),
         ]
 
         result = asyncio.run(
@@ -621,11 +613,11 @@ class TestAuthLogin:
         # No saved profile and no login parameter → response login is "".
         monkeypatch.setenv("HOME", str(tmp_path))
         mock_run.side_effect = [
-            _completed(
+            completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
-            _completed(stderr="invalid authorization code", returncode=1),
-            _completed("saved"),
+            completed(stderr="invalid authorization code", returncode=1),
+            completed("saved"),
         ]
 
         result = asyncio.run(auth_login(self._accepted_ctx(), profile="custom"))
@@ -670,11 +662,11 @@ class TestAuthLogin:
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
         mock_run.side_effect = [
-            _completed(
+            completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
-            _completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
-            _completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
+            completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
+            completed(stderr="\x1b[31mbad code\x1b[0m", returncode=1),
         ]
 
         result = asyncio.run(auth_login(self._accepted_ctx(), profile="custom"))
@@ -694,7 +686,7 @@ class TestAuthLogin:
         self, mock_run, _mock_resolve, _mock_find, _mock_status
     ) -> None:
         mock_run.side_effect = [
-            _completed(
+            completed(
                 json.dumps({"authorize_url": "https://oauth.yandex.ru/authorize?x=1"})
             ),
             CliError("direct failed"),

--- a/tests/test_bidmodifiers.py
+++ b/tests/test_bidmodifiers.py
@@ -1,7 +1,6 @@
 """Tests for bid modifier MCP tools."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import patch
 
 from server.tools.bidmodifiers import (
     bidmodifiers_add,
@@ -10,17 +9,11 @@ from server.tools.bidmodifiers import (
     bidmodifiers_delete,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_BIDMODIFIERS = [
     {"Id": 1, "CampaignId": 12345, "Type": "DEMOGRAPHICS", "Value": 100},
 ]
-
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
 
 
 class TestBidModifiersList:
@@ -30,7 +23,7 @@ class TestBidModifiersList:
         """Test listing bid modifiers for campaigns."""
         with patch(
             "server.tools.bidmodifiers.get_runner",
-            return_value=_mock_runner(SAMPLE_BIDMODIFIERS),
+            return_value=mock_runner(SAMPLE_BIDMODIFIERS),
         ):
             result = bidmodifiers_list(campaign_ids="12345")
             assert len(result) == 1
@@ -38,8 +31,7 @@ class TestBidModifiersList:
 
     def test_bidmodifiers_list_by_ad_group(self):
         """Test listing bid modifiers by ad group IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.bidmodifiers.get_runner",
             return_value=runner,
@@ -50,8 +42,7 @@ class TestBidModifiersList:
 
     def test_bidmodifiers_list_ignores_blank_ids(self):
         """Test blank filters behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = SAMPLE_BIDMODIFIERS
+        runner = mock_runner(SAMPLE_BIDMODIFIERS)
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             result = bidmodifiers_list(campaign_ids="   ", ad_group_ids="   ")
             assert len(result) == 1
@@ -68,8 +59,7 @@ class TestBidModifiersList:
 
     def test_bidmodifiers_list_with_levels(self):
         """Test listing bid modifiers with levels filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = SAMPLE_BIDMODIFIERS
+        runner = mock_runner(SAMPLE_BIDMODIFIERS)
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             bidmodifiers_list(campaign_ids="12345", levels="CAMPAIGN")
             call_args = runner.run_json.call_args[0][0]
@@ -89,23 +79,21 @@ class TestBidModifiersSet:
         mock_result = {"success": True}
         with patch(
             "server.tools.bidmodifiers.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = bidmodifiers_set(id=12345, value=150)
             assert result["success"] is True
 
     def test_bidmodifiers_set_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             bidmodifiers_set(id=12345, value=150, dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
 
     def test_bidmodifiers_set_argv_composition(self):
         """Test set passes correct argv to CLI."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             bidmodifiers_set(id=67890, value=120)
 
@@ -125,8 +113,7 @@ class TestBidModifiersAdd:
     """Tests for bidmodifiers_add tool."""
 
     def test_bidmodifiers_add_success(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             result = bidmodifiers_add(
                 campaign_id=12345,
@@ -153,8 +140,7 @@ class TestBidModifiersAdd:
 
     def test_bidmodifiers_add_accepts_smart_tv_adjustment(self):
         """direct-cli 0.3.12 exposes SMART_TV_ADJUSTMENT."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.bidmodifiers.get_runner", return_value=runner):
             result = bidmodifiers_add(
                 campaign_id=12345,
@@ -189,7 +175,7 @@ class TestBidModifiersDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.bidmodifiers.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = bidmodifiers_delete(ids="1")
             assert result["success"] is True

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -1,21 +1,14 @@
 """Tests for bid MCP tools."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import patch
 
 from server.tools.bids import bids_list, bids_set, bids_set_auto
 
+from tests.helpers import mock_runner
 
 SAMPLE_BIDS = [
     {"CampaignId": 12345, "Bid": 15000000},
 ]
-
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
 
 
 class TestBidsList:
@@ -25,7 +18,7 @@ class TestBidsList:
         """Test listing bids for campaigns."""
         with patch(
             "server.tools.bids.get_runner",
-            return_value=_mock_runner(SAMPLE_BIDS),
+            return_value=mock_runner(SAMPLE_BIDS),
         ):
             result = bids_list(campaign_ids="12345")
             assert len(result) == 1
@@ -33,8 +26,7 @@ class TestBidsList:
 
     def test_bids_list_by_ad_group(self):
         """Test listing bids by ad group IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.bids.get_runner",
             return_value=runner,
@@ -45,8 +37,7 @@ class TestBidsList:
 
     def test_bids_list_by_keyword(self):
         """Test listing bids by keyword IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.bids.get_runner",
             return_value=runner,
@@ -57,8 +48,7 @@ class TestBidsList:
 
     def test_bids_list_ignores_blank_filters(self):
         """Test blank filters behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = SAMPLE_BIDS
+        runner = mock_runner(SAMPLE_BIDS)
         with patch("server.tools.bids.get_runner", return_value=runner):
             result = bids_list(
                 campaign_ids="   ", ad_group_ids="   ", keyword_ids="   "
@@ -83,8 +73,7 @@ class TestBidsSet:
     def test_bids_set_success(self):
         """Test setting bid for a keyword successfully."""
         mock_result = {"success": True}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch("server.tools.bids.get_runner", return_value=runner):
             result = bids_set(keyword_id=99999, bid=15000000)
             assert result["success"] is True
@@ -93,8 +82,7 @@ class TestBidsSet:
             )
 
     def test_bids_set_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.bids.get_runner", return_value=runner):
             bids_set(keyword_id=99999, bid=15000000, dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -118,8 +106,7 @@ class TestBidsSetAuto:
     """Tests for bids_set_auto tool."""
 
     def test_bids_set_auto_success(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.bids.get_runner", return_value=runner):
             result = bids_set_auto(
                 campaign_id=12345,

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -1,27 +1,20 @@
 """Tests for businesses MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.businesses import businesses_list
 
+from tests.helpers import mock_runner
 
 SAMPLE_BUSINESSES = [
     {"Id": 100, "Name": "Test Business", "Url": "https://example.com"},
 ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_businesses_list_success():
     with patch(
         "server.tools.businesses.get_runner",
-        return_value=_mock_runner(SAMPLE_BUSINESSES),
+        return_value=mock_runner(SAMPLE_BUSINESSES),
     ):
         result = businesses_list()
         assert len(result) == 1
@@ -31,15 +24,14 @@ def test_businesses_list_success():
 def test_businesses_list_with_ids():
     with patch(
         "server.tools.businesses.get_runner",
-        return_value=_mock_runner(SAMPLE_BUSINESSES),
+        return_value=mock_runner(SAMPLE_BUSINESSES),
     ):
         result = businesses_list(ids="100")
         assert len(result) == 1
 
 
 def test_businesses_list_trims_ids():
-    runner = MagicMock()
-    runner.run_json.return_value = SAMPLE_BUSINESSES
+    runner = mock_runner(SAMPLE_BUSINESSES)
     with patch("server.tools.businesses.get_runner", return_value=runner):
         businesses_list(ids=" 100 ")
 
@@ -51,7 +43,7 @@ def test_businesses_list_trims_ids():
 def test_businesses_list_empty():
     with patch(
         "server.tools.businesses.get_runner",
-        return_value=_mock_runner([]),
+        return_value=mock_runner([]),
     ):
         result = businesses_list()
         assert result == []
@@ -59,8 +51,7 @@ def test_businesses_list_empty():
 
 def test_businesses_list_ignores_blank_ids():
     """Test blank ids behave like no filter."""
-    runner = MagicMock()
-    runner.run_json.return_value = SAMPLE_BUSINESSES
+    runner = mock_runner(SAMPLE_BUSINESSES)
     with patch("server.tools.businesses.get_runner", return_value=runner):
         result = businesses_list(ids="   ")
         assert len(result) == 1
@@ -70,8 +61,7 @@ def test_businesses_list_ignores_blank_ids():
 
 def test_businesses_list_empty_ids():
     """Test empty ids string treated like no filter."""
-    runner = MagicMock()
-    runner.run_json.return_value = []
+    runner = mock_runner([])
     with patch("server.tools.businesses.get_runner", return_value=runner):
         businesses_list(ids="")
 

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -16,6 +16,8 @@ from server.tools.campaigns import (
 )
 from server.cli.runner import CliAuthError, CliError
 
+from tests.helpers import mock_runner
+
 
 @pytest.fixture
 def mock_campaigns():
@@ -27,13 +29,6 @@ def mock_campaigns():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestCampaignsList:
     """Test scenarios 7-8."""
 
@@ -41,7 +36,7 @@ class TestCampaignsList:
         """Test 7: List all campaigns."""
         with patch(
             "server.tools.campaigns.get_runner",
-            return_value=_mock_runner(mock_campaigns),
+            return_value=mock_runner(mock_campaigns),
         ):
             result = campaigns_list()
             assert len(result) == 3
@@ -50,7 +45,7 @@ class TestCampaignsList:
         """Test 8: Filter by state=ON."""
         with patch(
             "server.tools.campaigns.get_runner",
-            return_value=_mock_runner(mock_campaigns),
+            return_value=mock_runner(mock_campaigns),
         ):
             result = campaigns_list(state="ON")
             assert len(result) == 2
@@ -58,7 +53,7 @@ class TestCampaignsList:
 
     def test_list_empty_result(self):
         """Empty response returns empty list."""
-        with patch("server.tools.campaigns.get_runner", return_value=_mock_runner([])):
+        with patch("server.tools.campaigns.get_runner", return_value=mock_runner([])):
             result = campaigns_list()
             assert result == []
 
@@ -70,8 +65,7 @@ class TestCampaignsList:
 
     def test_list_campaigns_trims_ids_before_cli(self, mock_campaigns):
         """Test campaign IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_campaigns
+        runner = mock_runner(mock_campaigns)
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_list(ids=" 12345,67890 ")
 
@@ -81,8 +75,7 @@ class TestCampaignsList:
 
     def test_list_campaigns_text_campaign_fields_argv(self, mock_campaigns):
         """Test campaign type-specific fields are forwarded to the CLI."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_campaigns
+        runner = mock_runner(mock_campaigns)
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_list(
                 ids="103258204",
@@ -109,8 +102,7 @@ class TestCampaignsList:
         self, mock_campaigns
     ):
         """Test filters and campaign-specific selectors compose in CLI argv."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_campaigns
+        runner = mock_runner(mock_campaigns)
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_list(
                 ids="12345,67890",
@@ -172,8 +164,7 @@ class TestCampaignsList:
 
     def test_list_campaigns_legacy_argv_unchanged(self, mock_campaigns):
         """Test old campaigns_get() calls do not add selector flags."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_campaigns
+        runner = mock_runner(mock_campaigns)
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_list()
 
@@ -189,7 +180,7 @@ class TestCampaignsUpdate:
         """Test 9: Enable a campaign."""
         with patch(
             "server.tools.campaigns.get_runner",
-            return_value=_mock_runner({"Id": 67890, "State": "ON"}),
+            return_value=mock_runner({"Id": 67890, "State": "ON"}),
         ):
             result = campaigns_update(id=67890, status="ON")
             assert result["success"] is True
@@ -199,7 +190,7 @@ class TestCampaignsUpdate:
         """Test 9: Disable a campaign."""
         with patch(
             "server.tools.campaigns.get_runner",
-            return_value=_mock_runner({"Id": 12345, "State": "OFF"}),
+            return_value=mock_runner({"Id": 12345, "State": "OFF"}),
         ):
             result = campaigns_update(id=12345, status="OFF")
             assert result["success"] is True
@@ -225,7 +216,7 @@ class TestCampaignsUpdate:
 
     def test_campaigns_update_argv_composition(self):
         """Test that update passes the typed CLI surface (no --json in 0.3.8)."""
-        runner = _mock_runner({"Id": 12345})
+        runner = mock_runner({"Id": 12345})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_update(
                 id=12345,
@@ -260,7 +251,7 @@ class TestCampaignsUpdate:
 
     def test_campaigns_update_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = _mock_runner({"Id": 12345})
+        runner = mock_runner({"Id": 12345})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_update(id=12345, name="x", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -268,7 +259,7 @@ class TestCampaignsUpdate:
 
     def test_campaigns_update_requires_changes(self):
         """Test that empty updates are rejected before CLI call."""
-        runner = _mock_runner({"Id": 12345})
+        runner = mock_runner({"Id": 12345})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_update(id=12345)
 
@@ -277,7 +268,7 @@ class TestCampaignsUpdate:
 
     def test_campaigns_update_accepts_zero_values(self):
         """Zero-valued typed fields are valid updates and must reach the CLI."""
-        runner = _mock_runner({"Id": 12345})
+        runner = mock_runner({"Id": 12345})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_update(id=12345, holidays_start_hour=0)
 
@@ -295,7 +286,7 @@ class TestCampaignsUpdate:
 
     def test_campaigns_update_passes_notification_and_time_targeting_json(self):
         """Update supports JSON aliases just like add."""
-        runner = _mock_runner({"Id": 12345})
+        runner = mock_runner({"Id": 12345})
         notification = '{"EmailSettings":{"Email":"ops@example.com"}}'
         time_targeting = '{"ConsiderWorkingWeekends":"YES"}'
         with patch("server.tools.campaigns.get_runner", return_value=runner):
@@ -316,7 +307,7 @@ class TestCampaignsCrudOperations:
     def test_campaigns_add(self):
         """Test adding a new campaign with typed strategy/settings flags."""
         mock_result = {"Id": 99999, "Name": "New Campaign"}
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_add(
                 name="New Campaign",
@@ -359,7 +350,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_add_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = _mock_runner({"Id": 99999})
+        runner = mock_runner({"Id": 99999})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(name="x", start_date="2026-01-01", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -367,7 +358,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_add_passes_counter_ids(self):
         """CLI 0.3.9: --counter-ids for TextCampaign/DynamicText."""
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -380,7 +371,7 @@ class TestCampaignsCrudOperations:
         assert "111,222" in argv
 
     def test_campaigns_add_passes_goal_id(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -393,7 +384,7 @@ class TestCampaignsCrudOperations:
         assert "12345" in argv
 
     def test_campaigns_add_passes_priority_goals(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -406,7 +397,7 @@ class TestCampaignsCrudOperations:
         assert "123:50,456:30" in argv
 
     def test_campaigns_add_passes_average_cpa(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -419,7 +410,7 @@ class TestCampaignsCrudOperations:
         assert "500000000" in argv
 
     def test_campaigns_add_passes_crr(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -432,7 +423,7 @@ class TestCampaignsCrudOperations:
         assert "15" in argv
 
     def test_campaigns_add_passes_bid_ceiling(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
                 name="c",
@@ -445,7 +436,7 @@ class TestCampaignsCrudOperations:
         assert "200000000" in argv
 
     def test_campaigns_add_passes_notification_json(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         payload = '{"SmsSettings":{"Events":["FINISHED"]}}'
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
@@ -459,7 +450,7 @@ class TestCampaignsCrudOperations:
         assert payload in argv
 
     def test_campaigns_add_passes_time_targeting_json(self):
-        runner = _mock_runner({"Id": 1})
+        runner = mock_runner({"Id": 1})
         payload = '{"ConsiderWorkingWeekends":"YES"}'
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             campaigns_add(
@@ -474,7 +465,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_delete_success(self):
         """Test deleting campaigns successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_delete(ids="12345,67890")
             assert result["success"] is True
@@ -488,7 +479,7 @@ class TestCampaignsCrudOperations:
     def test_campaigns_delete_batch_limit(self):
         """Test batch limit validation for delete."""
         ids = ",".join(str(i) for i in range(1, 12))  # 11 IDs
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_delete(ids=ids)
         assert "error" in result
@@ -497,7 +488,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_archive_success(self):
         """Test archiving campaigns successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_archive(ids="12345,67890")
             assert result["success"] is True
@@ -517,7 +508,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_unarchive_success(self):
         """Test unarchiving campaigns successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_unarchive(ids="12345,67890")
             assert result["success"] is True
@@ -537,7 +528,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_suspend_success(self):
         """Test suspending campaigns successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_suspend(ids="12345")
             assert result["success"] is True
@@ -554,7 +545,7 @@ class TestCampaignsCrudOperations:
 
     def test_campaigns_resume_success(self):
         """Test resuming campaigns successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.campaigns.get_runner", return_value=runner):
             result = campaigns_resume(ids="12345")
             assert result["success"] is True

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from server.tools.changes import (
     changes_check,
     changes_checkcamp,
@@ -10,11 +9,7 @@ from server.tools.changes import (
 )
 from server.contract import EXPLICIT_TIMEZONE_TIMESTAMP_TOOLS
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 def _argv_for(runner: MagicMock) -> list[str]:
@@ -26,7 +21,7 @@ class TestChangesCheck:
 
     def test_check_with_campaign_ids(self):
         mock_result = {"Campaigns": [{"Id": 12345}]}
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_check(
                 field_names="CampaignIds,AdGroupIds",
@@ -50,7 +45,7 @@ class TestChangesCheck:
         )
 
     def test_check_with_ad_group_ids(self):
-        runner = _mock_runner({"AdGroupIds": [11]})
+        runner = mock_runner({"AdGroupIds": [11]})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_check(
                 field_names="AdGroupIds",
@@ -61,7 +56,7 @@ class TestChangesCheck:
         assert argv[2:4] == ["--ad-group-ids", "111,222"]
 
     def test_check_with_ad_ids(self):
-        runner = _mock_runner({"AdIds": [55]})
+        runner = mock_runner({"AdIds": [55]})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_check(
                 field_names="AdIds",
@@ -112,7 +107,7 @@ class TestChangesCheck:
         assert result["error"] == "invalid_field_names"
 
     def test_campaign_ids_limit_3000(self):
-        runner = _mock_runner({"Campaigns": []})
+        runner = mock_runner({"Campaigns": []})
         ids_3000 = ",".join(str(i) for i in range(3000))
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_check(
@@ -165,7 +160,7 @@ class TestChangesCheck:
 
     def test_comma_only_id_filter_does_not_mask_real_filter(self):
         """Comma-only campaign_ids must not block a real ad_ids filter."""
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_check(
                 field_names="AdIds",
@@ -178,7 +173,7 @@ class TestChangesCheck:
         assert argv[2:4] == ["--ad-ids", "42"]
 
     def test_rejects_timestamp_without_timezone(self):
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_check(
                 field_names="CampaignIds",
@@ -190,7 +185,7 @@ class TestChangesCheck:
         runner.run_json.assert_not_called()
 
     def test_keeps_existing_z(self):
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_check(
                 field_names="CampaignIds",
@@ -202,7 +197,7 @@ class TestChangesCheck:
         assert argv[ts_idx + 1] == "2026-01-01T00:00:00Z"
 
     def test_keeps_explicit_offset(self):
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_check(
                 field_names="CampaignIds",
@@ -214,7 +209,7 @@ class TestChangesCheck:
         assert argv[ts_idx + 1] == "2026-01-01T00:00:00+03:00"
 
     def test_rejects_trailing_space_without_timezone(self):
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_check(
                 field_names="CampaignIds",
@@ -228,7 +223,7 @@ class TestChangesCheck:
         """Trailing '\\n' must be stripped — Python's ``$`` would otherwise
         match before the newline, mask the missing zone and forward a value
         with a literal newline to the CLI."""
-        runner = _mock_runner({})
+        runner = mock_runner({})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_check(
                 field_names="CampaignIds",
@@ -244,7 +239,7 @@ class TestChangesCheckCamp:
     """Tests for changes_checkcamp (only --timestamp)."""
 
     def test_check_campaign_changes(self):
-        runner = _mock_runner({"Campaigns": []})
+        runner = mock_runner({"Campaigns": []})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_checkcamp(timestamp="2026-01-01T00:00:00Z")
         runner.run_json.assert_called_once_with(
@@ -259,7 +254,7 @@ class TestChangesCheckCamp:
         )
 
     def test_check_campaign_changes_rejects_timestamp_without_timezone(self):
-        runner = _mock_runner({"Campaigns": []})
+        runner = mock_runner({"Campaigns": []})
         with patch("server.tools.changes.get_runner", return_value=runner):
             result = changes_checkcamp(timestamp="2026-01-01T00:00:00")
         assert result["error"] == "invalid_timestamp"
@@ -267,7 +262,7 @@ class TestChangesCheckCamp:
         runner.run_json.assert_not_called()
 
     def test_check_campaign_changes_keeps_explicit_offset(self):
-        runner = _mock_runner({"Campaigns": []})
+        runner = mock_runner({"Campaigns": []})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_checkcamp(timestamp="2026-01-01T00:00:00+03:00")
         argv = _argv_for(runner)
@@ -279,7 +274,7 @@ class TestChangesCheckDict:
     """Tests for changes_checkdict (no arguments)."""
 
     def test_check_dictionary_changes(self):
-        runner = _mock_runner({"Dictionaries": []})
+        runner = mock_runner({"Dictionaries": []})
         with patch("server.tools.changes.get_runner", return_value=runner):
             changes_checkdict()
         runner.run_json.assert_called_once_with(

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,16 +1,10 @@
 """Tests for clients MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.clients import clients_get, clients_update
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestClientsGet:
@@ -26,7 +20,7 @@ class TestClientsGet:
         }
         with patch(
             "server.tools.clients.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = clients_get()
             assert result == mock_result
@@ -34,8 +28,7 @@ class TestClientsGet:
     def test_get_client_by_ids(self):
         """Test getting specific client by IDs."""
         mock_result = {"Clients": [{"Login": "client1", "FirstName": "John"}]}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.clients.get_runner", return_value=runner):
             result = clients_get(ids="123")
@@ -47,8 +40,7 @@ class TestClientsGet:
 
     def test_get_client_trims_ids(self):
         """Test client IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Clients": []}
+        runner = mock_runner({"Clients": []})
 
         with patch("server.tools.clients.get_runner", return_value=runner):
             clients_get(ids=" 123 ")
@@ -62,7 +54,7 @@ class TestClientsGet:
         mock_result = {"Clients": []}
         with patch(
             "server.tools.clients.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = clients_get()
             assert result == mock_result
@@ -74,8 +66,7 @@ class TestClientsUpdate:
     def test_update_client(self):
         """Test updating client information."""
         mock_result = {"Login": "client1"}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch("server.tools.clients.get_runner", return_value=runner):
             result = clients_update(
                 client_info="John Smith",
@@ -98,8 +89,7 @@ class TestClientsUpdate:
 
     def test_update_client_settings_repeated(self):
         """List parameters produce repeated CLI flags."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Login": "client1"}
+        runner = mock_runner({"Login": "client1"})
         with patch("server.tools.clients.get_runner", return_value=runner):
             clients_update(
                 settings=["AccountNews=YES", "Warnings=NO"],
@@ -115,8 +105,7 @@ class TestClientsUpdate:
 
     def test_update_client_accepts_empty_string_field(self):
         """Empty strings are provided values; CLI owns semantic validation."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Login": "client1"}
+        runner = mock_runner({"Login": "client1"})
         with patch("server.tools.clients.get_runner", return_value=runner):
             clients_update(client_info="")
 
@@ -125,16 +114,14 @@ class TestClientsUpdate:
         )
 
     def test_update_client_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.clients.get_runner", return_value=runner):
             clients_update(phone="+1", dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
 
     def test_get_client_ignores_blank_ids(self):
         """Test blank ids behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Clients": []}
+        runner = mock_runner({"Clients": []})
         with patch("server.tools.clients.get_runner", return_value=runner):
             clients_get(ids="   ")
             call_args = runner.run_json.call_args[0][0]

--- a/tests/test_creatives.py
+++ b/tests/test_creatives.py
@@ -1,16 +1,10 @@
 """Tests for creatives MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.creatives import creatives_add, creatives_list
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestCreativesList:
@@ -21,15 +15,14 @@ class TestCreativesList:
         mock_result = {"creatives": [{"id": 1, "name": "Creative 1"}]}
         with patch(
             "server.tools.creatives.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = creatives_list(ids="1")
             assert "creatives" in result
 
     def test_creatives_list_by_types(self):
         """Test listing creatives filtered by types."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.creatives.get_runner", return_value=runner):
             creatives_list(types="VIDEO_EXTENSION_CREATIVE")
             call_args = runner.run_json.call_args[0][0]
@@ -38,8 +31,7 @@ class TestCreativesList:
 
     def test_creatives_list_trims_filters(self):
         """Test creative filters are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.creatives.get_runner", return_value=runner):
             creatives_list(ids=" 1 ", types="VIDEO_EXTENSION_CREATIVE")
 
@@ -60,15 +52,14 @@ class TestCreativesList:
         """Test empty response returns empty list."""
         with patch(
             "server.tools.creatives.get_runner",
-            return_value=_mock_runner([]),
+            return_value=mock_runner([]),
         ):
             result = creatives_list()
             assert result == []
 
     def test_creatives_list_ignores_blank_ids(self):
         """Test blank ids behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.creatives.get_runner", return_value=runner):
             creatives_list(ids="   ")
             call_args = runner.run_json.call_args[0][0]
@@ -79,8 +70,7 @@ class TestCreativesAdd:
     """Tests for creatives_add tool."""
 
     def test_creatives_add(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 10}
+        runner = mock_runner({"Id": 10})
         with patch("server.tools.creatives.get_runner", return_value=runner):
             result = creatives_add(video_id="video-1")
 

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -1,7 +1,6 @@
 """Tests for dictionaries MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.dictionaries import (
     dictionaries_get,
@@ -9,12 +8,7 @@ from server.tools.dictionaries import (
     dictionaries_list_names,
 )
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestDictionariesGet:
@@ -25,7 +19,7 @@ class TestDictionariesGet:
         mock_result = {"Regions": [{"Id": 1, "Name": "Moscow"}]}
         with patch(
             "server.tools.dictionaries.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = dictionaries_get(names="GeoRegions")
             assert result == mock_result
@@ -35,7 +29,7 @@ class TestDictionariesGet:
         mock_result = {"TimeZones": [{"Id": "Europe/Moscow", "Name": "Moscow"}]}
         with patch(
             "server.tools.dictionaries.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = dictionaries_get(names="TimeZones")
             assert result == mock_result
@@ -45,7 +39,7 @@ class TestDictionariesGet:
         mock_result = {"Currencies": [{"Currency": "RUB", "Name": "Russian Ruble"}]}
         with patch(
             "server.tools.dictionaries.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = dictionaries_get(names="Currencies")
             assert result == mock_result
@@ -55,7 +49,7 @@ class TestDictionariesGet:
         mock_result = {"Constants": {"MaxAds": 50}}
         with patch(
             "server.tools.dictionaries.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = dictionaries_get(names="Constants")
             assert result == mock_result
@@ -63,8 +57,7 @@ class TestDictionariesGet:
     def test_get_multiple_dictionaries(self):
         """Test getting multiple dictionaries at once."""
         mock_result = {"Currencies": [], "GeoRegions": []}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.dictionaries.get_runner", return_value=runner):
             result = dictionaries_get(names="Currencies,GeoRegions")
@@ -75,8 +68,7 @@ class TestDictionariesGet:
 
     def test_passes_names_flag(self):
         """Verify the CLI flag --names is used."""
-        runner = MagicMock()
-        runner.run_json.return_value = {}
+        runner = mock_runner({})
 
         with patch("server.tools.dictionaries.get_runner", return_value=runner):
             dictionaries_get(names="Currencies")
@@ -100,8 +92,7 @@ class TestDictionariesGetGeoRegions:
     """Test scenarios for dictionaries_get_geo_regions."""
 
     def test_passes_geo_region_args(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"GeoRegions": []}
+        runner = mock_runner({"GeoRegions": []})
         with patch("server.tools.dictionaries.get_runner", return_value=runner):
             result = dictionaries_get_geo_regions(
                 fields="Id,Name",

--- a/tests/test_direct_cli_0312_parity.py
+++ b/tests/test_direct_cli_0312_parity.py
@@ -8,7 +8,7 @@ import re
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import direct_cli  # type: ignore[import-not-found, import-untyped]
@@ -31,6 +31,7 @@ from server.tools.smart_ad_targets import smart_ad_targets_add, smart_ad_targets
 from server.tools.strategies import strategies_add, strategies_update
 from server.tools.vcards import vcards_add
 
+from tests.helpers import mock_runner
 
 TARGET_COMMANDS: tuple[tuple[str, str, str, str], ...] = (
     ("campaigns", "add", "server.tools.campaigns", "campaigns_add"),
@@ -166,12 +167,6 @@ def test_bidmodifier_type_choices_match_direct_cli() -> None:
     assert set(_BIDMOD_TYPES) == set(modifier_type.type.choices)
 
 
-def _mock_runner() -> MagicMock:
-    runner = MagicMock()
-    runner.run_json.return_value = {"ok": True}
-    return runner
-
-
 def _assert_contains(argv: list[str], expected: list[str]) -> None:
     for item in expected:
         assert item in argv
@@ -183,7 +178,7 @@ def _run_with_runner(
     expected: list[str],
     **kwargs: object,
 ) -> None:
-    runner = _mock_runner()
+    runner = mock_runner({"ok": True})
     with patch(patch_target, return_value=runner):
         fn(**kwargs)
     _assert_contains(runner.run_json.call_args[0][0], expected)

--- a/tests/test_dynamic_ads.py
+++ b/tests/test_dynamic_ads.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch, MagicMock
 
-
 from server.tools.dynamic_ads import (
     dynamic_ads_list,
     dynamic_ads_add,
@@ -12,6 +11,7 @@ from server.tools.dynamic_ads import (
     dynamic_ads_suspend,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_TARGETS = [
     {
@@ -24,22 +24,16 @@ SAMPLE_TARGETS = [
 ]
 
 
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_dynamic_ads_list():
     with patch(
-        "server.tools.dynamic_ads.get_runner", return_value=_mock_runner(SAMPLE_TARGETS)
+        "server.tools.dynamic_ads.get_runner", return_value=mock_runner(SAMPLE_TARGETS)
     ):
         result = dynamic_ads_list(ad_group_ids="200")
         assert len(result) == 1
 
 
 def test_dynamic_ads_list_trims_ids():
-    runner = _mock_runner(SAMPLE_TARGETS)
+    runner = mock_runner(SAMPLE_TARGETS)
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         dynamic_ads_list(ad_group_ids=" 200 ")
 
@@ -50,7 +44,7 @@ def test_dynamic_ads_list_trims_ids():
 
 def test_dynamic_ads_list_no_filters():
     """Blank ad_group_ids behaves like no filter (CLI returns everything)."""
-    runner = _mock_runner(SAMPLE_TARGETS)
+    runner = mock_runner(SAMPLE_TARGETS)
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         dynamic_ads_list(ad_group_ids="   ")
     argv = runner.run_json.call_args[0][0]
@@ -58,14 +52,14 @@ def test_dynamic_ads_list_no_filters():
 
 
 def test_dynamic_ads_list_empty():
-    with patch("server.tools.dynamic_ads.get_runner", return_value=_mock_runner([])):
+    with patch("server.tools.dynamic_ads.get_runner", return_value=mock_runner([])):
         result = dynamic_ads_list(ad_group_ids="200")
         assert result == []
 
 
 def test_dynamic_ads_add():
     mock_result = {"Id": 300}
-    runner = _mock_runner(mock_result)
+    runner = mock_runner(mock_result)
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         result = dynamic_ads_add(
             ad_group_id=200,
@@ -97,14 +91,14 @@ def test_dynamic_ads_add():
 
 
 def test_dynamic_ads_add_dry_run():
-    runner = _mock_runner({"_dry_run": True})
+    runner = mock_runner({"_dry_run": True})
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         dynamic_ads_add(ad_group_id=200, name="x", dry_run=True)
         assert "--dry-run" in runner.run_json.call_args[0][0]
 
 
 def test_dynamic_ads_delete():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         result = dynamic_ads_delete(id=100)
         assert result["success"] is True
@@ -112,7 +106,7 @@ def test_dynamic_ads_delete():
 
 
 def test_dynamic_ads_suspend_batches_ids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         result = dynamic_ads_suspend(ids="100,101")
 
@@ -121,7 +115,7 @@ def test_dynamic_ads_suspend_batches_ids():
 
 
 def test_dynamic_ads_resume_batches_ids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         result = dynamic_ads_resume(ids="100,101")
 
@@ -130,7 +124,7 @@ def test_dynamic_ads_resume_batches_ids():
 
 
 def test_dynamic_ads_set_bids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.dynamic_ads.get_runner", return_value=runner):
         result = dynamic_ads_set_bids(
             id=100,

--- a/tests/test_dynamic_feed_ad_targets.py
+++ b/tests/test_dynamic_feed_ad_targets.py
@@ -1,7 +1,6 @@
 """Tests for dynamic feed ad target MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.dynamic_feed_ad_targets import (
     dynamic_feed_ad_targets_add,
@@ -12,12 +11,7 @@ from server.tools.dynamic_feed_ad_targets import (
     dynamic_feed_ad_targets_suspend,
 )
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestDynamicFeedAdTargetsList:
@@ -29,8 +23,7 @@ class TestDynamicFeedAdTargetsList:
             {"Id": 10, "AdGroupId": 200, "Name": "Target A"},
             {"Id": 11, "AdGroupId": 200, "Name": "Target B"},
         ]
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
             return_value=runner,
@@ -62,8 +55,7 @@ class TestDynamicFeedAdTargetsAdd:
     def test_dynamic_feed_ad_targets_add(self):
         """Test adding a dynamic feed ad target."""
         mock_result = {"Id": 20, "AdGroupId": 200, "Name": "Test"}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
             return_value=runner,
@@ -96,7 +88,7 @@ class TestDynamicFeedAdTargetsDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = dynamic_feed_ad_targets_delete(id=100)
             assert result["success"] is True
@@ -107,8 +99,7 @@ class TestDynamicFeedAdTargetsSuspend:
 
     def test_dynamic_feed_ad_targets_suspend(self):
         """Test batch suspending dynamic feed ad targets."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
             return_value=runner,
@@ -126,8 +117,7 @@ class TestDynamicFeedAdTargetsResume:
 
     def test_dynamic_feed_ad_targets_resume(self):
         """Test batch resuming dynamic feed ad targets."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
             return_value=runner,
@@ -145,8 +135,7 @@ class TestDynamicFeedAdTargetsSetBids:
 
     def test_dynamic_feed_ad_targets_set_bids(self):
         """Test setting bids for a dynamic feed ad target."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch(
             "server.tools.dynamic_feed_ad_targets.get_runner",
             return_value=runner,

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,6 +1,6 @@
 """Tests for ad extensions MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +9,8 @@ from server.tools.adextensions import (
     adextensions_add,
     adextensions_delete,
 )
+
+from tests.helpers import mock_runner
 
 
 @pytest.fixture
@@ -28,13 +30,6 @@ def mock_extensions():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestAdextensionsList:
     """Tests for adextensions_list tool."""
 
@@ -42,7 +37,7 @@ class TestAdextensionsList:
         """Test listing extensions successfully."""
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner(mock_extensions),
+            return_value=mock_runner(mock_extensions),
         ):
             result = adextensions_list(ids="1,2")
             assert len(result) == 2
@@ -52,15 +47,14 @@ class TestAdextensionsList:
         """Test listing all extensions with no ids."""
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner(mock_extensions),
+            return_value=mock_runner(mock_extensions),
         ):
             result = adextensions_list()
             assert len(result) == 2
 
     def test_list_extensions_empty_ids_treated_as_missing_filter(self, mock_extensions):
         """Test empty ids behaves like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_extensions
+        runner = mock_runner(mock_extensions)
         with patch(
             "server.tools.adextensions.get_runner",
             return_value=runner,
@@ -72,8 +66,7 @@ class TestAdextensionsList:
 
     def test_list_extensions_with_types(self):
         """Test listing extensions filtered by types."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.adextensions.get_runner",
             return_value=runner,
@@ -85,8 +78,7 @@ class TestAdextensionsList:
 
     def test_list_extensions_trims_ids_and_types(self):
         """Test list filters are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.adextensions.get_runner", return_value=runner):
             adextensions_list(ids=" 1,2 ", types=" CALLOUT,SITELINK ")
 
@@ -105,8 +97,7 @@ class TestAdextensionsList:
 
     def test_list_extensions_with_callout_field_names(self):
         """Test CalloutFieldNames are passed through 1:1 via the CLI flag."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.adextensions.get_runner", return_value=runner):
             adextensions_list(
                 types="CALLOUT",
@@ -133,7 +124,7 @@ class TestAdextensionsList:
         """Test empty response returns empty list."""
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner([]),
+            return_value=mock_runner([]),
         ):
             result = adextensions_list(ids="999")
             assert result == []
@@ -152,8 +143,7 @@ class TestAdextensionsAdd:
     def test_add_callout_extension_success(self):
         """Test adding a callout extension successfully."""
         mock_result = {"Id": 123}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.adextensions.get_runner", return_value=runner):
             result = adextensions_add(callout_text="Free shipping")
@@ -163,8 +153,7 @@ class TestAdextensionsAdd:
             )
 
     def test_add_callout_extension_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.adextensions.get_runner", return_value=runner):
             adextensions_add(callout_text="X", dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -179,7 +168,7 @@ class TestAdextensionsDelete:
 
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = adextensions_delete(ids="1")
             assert result["success"] is True
@@ -188,7 +177,7 @@ class TestAdextensionsDelete:
         """Test deleting extensions rejects empty ids."""
         with patch(
             "server.tools.adextensions.get_runner",
-            return_value=_mock_runner({"success": True}),
+            return_value=mock_runner({"success": True}),
         ):
             result = adextensions_delete(ids="   ")
             assert result["error"] == "missing_ids"

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,16 +1,10 @@
 """Tests for feeds MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.feeds import feeds_list, feeds_add, feeds_update, feeds_delete
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestFeedsList:
@@ -21,15 +15,14 @@ class TestFeedsList:
         mock_result = {"feeds": [{"id": 1, "name": "Feed 1"}]}
         with patch(
             "server.tools.feeds.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = feeds_list(ids="1")
             assert "feeds" in result
 
     def test_feeds_list_trims_ids_before_cli(self):
         """Test feed IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"feeds": []}
+        runner = mock_runner({"feeds": []})
 
         with patch("server.tools.feeds.get_runner", return_value=runner):
             feeds_list(ids=" 1 ")
@@ -40,8 +33,7 @@ class TestFeedsList:
 
     def test_feeds_list_no_ids(self):
         """Test listing all feeds without IDs."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"feeds": []}
+        runner = mock_runner({"feeds": []})
 
         with patch("server.tools.feeds.get_runner", return_value=runner):
             feeds_list()
@@ -59,7 +51,7 @@ class TestFeedsAdd:
             "name": "New Feed",
             "url": "https://example.com/feed.xml",
         }
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.feeds.get_runner", return_value=runner):
             result = feeds_add(
                 name="New Feed",
@@ -89,8 +81,7 @@ class TestFeedsAdd:
 
     def test_feeds_add_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.feeds.get_runner", return_value=runner):
             feeds_add(
                 name="Test",
@@ -110,7 +101,7 @@ class TestFeedsUpdate:
         mock_result = {"id": 1, "name": "Updated Feed"}
         with patch(
             "server.tools.feeds.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = feeds_update(id=1, name="Updated Feed")
             assert result["name"] == "Updated Feed"
@@ -120,15 +111,14 @@ class TestFeedsUpdate:
         mock_result = {"id": 1, "url": "https://example.com/new.xml"}
         with patch(
             "server.tools.feeds.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = feeds_update(id=1, url="https://example.com/new.xml")
             assert result["url"] == "https://example.com/new.xml"
 
     def test_feeds_update_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"id": 1}
+        runner = mock_runner({"id": 1})
         with patch("server.tools.feeds.get_runner", return_value=runner):
             feeds_update(id=1, name="x", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -142,7 +132,7 @@ class TestFeedsUpdate:
 
     def test_feeds_update_accepts_empty_string_field(self):
         """Empty strings are provided values; CLI owns semantic validation."""
-        runner = _mock_runner({"id": 1})
+        runner = mock_runner({"id": 1})
         with patch("server.tools.feeds.get_runner", return_value=runner):
             feeds_update(id=1, name="")
 
@@ -159,7 +149,7 @@ class TestFeedsDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.feeds.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = feeds_delete(ids="1")
             assert result["success"] is True

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,10 +1,12 @@
 """Tests for ad images MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from server.tools.images import adimages_list, adimages_add, adimages_delete
+
+from tests.helpers import mock_runner
 
 
 @pytest.fixture
@@ -28,13 +30,6 @@ def mock_images():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestAdimagesList:
     """Tests for adimages_list tool."""
 
@@ -42,7 +37,7 @@ class TestAdimagesList:
         """Test listing images successfully."""
         with patch(
             "server.tools.images.get_runner",
-            return_value=_mock_runner(mock_images),
+            return_value=mock_runner(mock_images),
         ):
             result = adimages_list(ids="1,2")
             assert len(result) == 2
@@ -52,15 +47,14 @@ class TestAdimagesList:
         """Test listing all images with no ids."""
         with patch(
             "server.tools.images.get_runner",
-            return_value=_mock_runner(mock_images),
+            return_value=mock_runner(mock_images),
         ):
             result = adimages_list()
             assert len(result) == 2
 
     def test_list_images_empty_ids_treated_as_missing_filter(self, mock_images):
         """Test empty ids behaves like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_images
+        runner = mock_runner(mock_images)
         with patch("server.tools.images.get_runner", return_value=runner):
             result = adimages_list(ids="   ")
             assert len(result) == 2
@@ -69,14 +63,13 @@ class TestAdimagesList:
 
     def test_list_images_empty_result(self):
         """Test empty response returns empty list."""
-        with patch("server.tools.images.get_runner", return_value=_mock_runner([])):
+        with patch("server.tools.images.get_runner", return_value=mock_runner([])):
             result = adimages_list(ids="999")
             assert result == []
 
     def test_list_images_trims_ids_before_cli(self, mock_images):
         """Test image IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_images
+        runner = mock_runner(mock_images)
         with patch("server.tools.images.get_runner", return_value=runner):
             adimages_list(ids=" 1,2 ")
 
@@ -91,8 +84,7 @@ class TestAdimagesAdd:
     def test_add_image_with_data(self):
         """Test adding image with base64 image_data."""
         mock_result = {"Id": 123, "Name": "new_image.jpg"}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.images.get_runner", return_value=runner):
             result = adimages_add(name="new_image.jpg", image_data="base64data")
@@ -110,8 +102,7 @@ class TestAdimagesAdd:
 
     def test_add_image_with_file(self):
         """Test adding image with file path."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 124}
+        runner = mock_runner({"Id": 124})
         with patch("server.tools.images.get_runner", return_value=runner):
             adimages_add(name="img", image_file="/tmp/img.jpg", type="REGULAR")
         argv = runner.run_json.call_args[0][0]
@@ -134,8 +125,7 @@ class TestAdimagesDelete:
     def test_delete_image_by_hash(self):
         """Test deleting an image by hash."""
         mock_result = {"success": True}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.images.get_runner", return_value=runner):
             result = adimages_delete(hash_value="abc123")

--- a/tests/test_keyword_bids.py
+++ b/tests/test_keyword_bids.py
@@ -1,7 +1,6 @@
 """Tests for keyword_bids MCP tools."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import patch
 
 from server.tools.keyword_bids import (
     keyword_bids_list,
@@ -9,6 +8,7 @@ from server.tools.keyword_bids import (
     keyword_bids_set_auto,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_BIDS = [
     {
@@ -21,13 +21,6 @@ SAMPLE_BIDS = [
 ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestKeywordBidsList:
     """Tests for keyword_bids_list tool."""
 
@@ -35,7 +28,7 @@ class TestKeywordBidsList:
         """Test listing keyword bids by campaign."""
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(SAMPLE_BIDS),
+            return_value=mock_runner(SAMPLE_BIDS),
         ):
             result = keyword_bids_list(campaign_ids="333")
             assert len(result) == 1
@@ -45,7 +38,7 @@ class TestKeywordBidsList:
         """Test listing keyword bids with empty result."""
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner([]),
+            return_value=mock_runner([]),
         ):
             result = keyword_bids_list()
             assert result == []
@@ -54,7 +47,7 @@ class TestKeywordBidsList:
         """Test listing keyword bids by keyword IDs."""
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(SAMPLE_BIDS),
+            return_value=mock_runner(SAMPLE_BIDS),
         ) as mock:
             result = keyword_bids_list(keyword_ids="111")
             assert len(result) == 1
@@ -66,7 +59,7 @@ class TestKeywordBidsList:
         """Test listing keyword bids by ad group IDs."""
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(SAMPLE_BIDS),
+            return_value=mock_runner(SAMPLE_BIDS),
         ) as mock:
             result = keyword_bids_list(ad_group_ids="222")
             assert len(result) == 1
@@ -76,8 +69,7 @@ class TestKeywordBidsList:
 
     def test_keyword_bids_list_trims_filters(self):
         """Test keyword bid filters are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.keyword_bids.get_runner", return_value=runner):
             keyword_bids_list(
                 campaign_ids=" 333 ",
@@ -102,8 +94,7 @@ class TestKeywordBidsList:
 
     def test_keyword_bids_list_ignores_blank_filters(self):
         """Test blank filters behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = SAMPLE_BIDS
+        runner = mock_runner(SAMPLE_BIDS)
         with patch("server.tools.keyword_bids.get_runner", return_value=runner):
             result = keyword_bids_list(
                 campaign_ids="   ", ad_group_ids="   ", keyword_ids="   "
@@ -123,7 +114,7 @@ class TestKeywordBidsSet:
         mock_result = {"success": True}
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = keyword_bids_set(keyword_id=111, search_bid=10000000)
             assert result["success"] is True
@@ -133,7 +124,7 @@ class TestKeywordBidsSet:
         mock_result = {"success": True}
         with patch(
             "server.tools.keyword_bids.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ) as mock:
             result = keyword_bids_set(
                 keyword_id=111, search_bid=10000000, network_bid=5000000
@@ -148,7 +139,7 @@ class TestKeywordBidsSet:
 
     def test_keyword_bids_set_requires_changes(self):
         """Reject no-op updates before calling CLI."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keyword_bids.get_runner", return_value=runner):
             result = keyword_bids_set(keyword_id=111)
             assert result["error"] == "missing_update_fields"
@@ -156,7 +147,7 @@ class TestKeywordBidsSet:
 
     def test_keyword_bids_set_argv_with_search_bid(self):
         """Test argv composition for search bid."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keyword_bids.get_runner", return_value=runner):
             keyword_bids_set(keyword_id=111, search_bid=10000000)
 
@@ -169,7 +160,7 @@ class TestKeywordBidsSetAuto:
     """Tests for keyword_bids_set_auto tool."""
 
     def test_keyword_bids_set_auto(self):
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keyword_bids.get_runner", return_value=runner):
             result = keyword_bids_set_auto(
                 keyword_id=111,

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,7 +1,6 @@
 """Tests for keyword MCP tools."""
 
-from unittest.mock import MagicMock, call, patch
-
+from unittest.mock import call, patch
 
 from server.tools.keywords import (
     keywords_list,
@@ -12,23 +11,17 @@ from server.tools.keywords import (
     keywords_resume,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_KEYWORDS = [
     {"Id": 99999, "Keyword": "keyword_99999", "Bid": 12000000},
 ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_keywords_list():
     """Test 14: List keywords."""
     with patch(
-        "server.tools.keywords.get_runner", return_value=_mock_runner(SAMPLE_KEYWORDS)
+        "server.tools.keywords.get_runner", return_value=mock_runner(SAMPLE_KEYWORDS)
     ):
         result = keywords_list(campaign_ids="12345")
         assert len(result) == 1
@@ -37,7 +30,7 @@ def test_keywords_list():
 
 def test_keywords_list_trims_campaign_ids():
     """Test campaign IDs are normalized before argv construction."""
-    runner = _mock_runner(SAMPLE_KEYWORDS)
+    runner = mock_runner(SAMPLE_KEYWORDS)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         keywords_list(campaign_ids=" 12345 ")
 
@@ -48,7 +41,7 @@ def test_keywords_list_trims_campaign_ids():
 
 def test_keywords_list_blank_selector_rejected():
     """Blank/missing selectors must NOT silently widen to an account-wide query."""
-    runner = _mock_runner(SAMPLE_KEYWORDS)
+    runner = mock_runner(SAMPLE_KEYWORDS)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         result = keywords_list(campaign_ids="   ")
     assert isinstance(result, dict)
@@ -58,7 +51,7 @@ def test_keywords_list_blank_selector_rejected():
 
 def test_keywords_list_fetch_all_allows_no_selector():
     """fetch_all=True is an explicit opt-in for unscoped enumeration."""
-    runner = _mock_runner(SAMPLE_KEYWORDS)
+    runner = mock_runner(SAMPLE_KEYWORDS)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         keywords_list(fetch_all=True)
     argv = runner.run_json.call_args[0][0]
@@ -68,7 +61,7 @@ def test_keywords_list_fetch_all_allows_no_selector():
 
 def test_keywords_update():
     """Test updating keyword text."""
-    with patch("server.tools.keywords.get_runner", return_value=_mock_runner(None)):
+    with patch("server.tools.keywords.get_runner", return_value=mock_runner(None)):
         result = keywords_update(id=99999, keyword="new keyword text")
         assert result["success"] is True
         assert result["keyword"] == "new keyword text"
@@ -76,7 +69,7 @@ def test_keywords_update():
 
 def test_keywords_update_argv_composition():
     """Test that update passes the expanded CLI surface (no --json in 0.3.8)."""
-    runner = _mock_runner(None)
+    runner = mock_runner(None)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         result = keywords_update(
             id=99999,
@@ -104,7 +97,7 @@ def test_keywords_update_argv_composition():
 
 def test_keywords_update_dry_run():
     """dry_run=True appends --dry-run to argv."""
-    runner = _mock_runner(None)
+    runner = mock_runner(None)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         keywords_update(id=99999, keyword="x", dry_run=True)
         argv = runner.run_json.call_args[0][0]
@@ -113,7 +106,7 @@ def test_keywords_update_dry_run():
 
 def test_keywords_update_accepts_zero_bids():
     """Zero bid values are provided updates and must be stringified for CLI."""
-    runner = _mock_runner(None)
+    runner = mock_runner(None)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         keywords_update(id=99999, bid=0, context_bid=0)
 
@@ -133,7 +126,7 @@ def test_keywords_update_accepts_zero_bids():
 
 def test_keywords_update_requires_changes():
     """Test that empty updates are rejected before CLI call."""
-    runner = _mock_runner(None)
+    runner = mock_runner(None)
     with patch("server.tools.keywords.get_runner", return_value=runner):
         result = keywords_update(id=99999)
 
@@ -146,7 +139,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add(self):
         """Test adding a keyword to an ad group (no --json in CLI 0.3.8)."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_add(
                 ad_group_id=1,
@@ -178,7 +171,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_dry_run(self):
         """dry_run=True appends --dry-run to argv."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             keywords_add(ad_group_id=1, keyword="x", dry_run=True)
             argv = runner.run_json.call_args[0][0]
@@ -186,7 +179,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_passes_from_file(self):
         """CLI 0.3.9: JSONL batch via --from-file."""
-        runner = _mock_runner({"AddResults": [{"Id": 1}, {"Id": 2}]})
+        runner = mock_runner({"AddResults": [{"Id": 1}, {"Id": 2}]})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             keywords_add(from_file="/tmp/k.jsonl")
             argv = runner.run_json.call_args[0][0]
@@ -197,7 +190,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_passes_keywords_json(self):
         """CLI 0.3.9: inline JSON batch via --keywords-json."""
-        runner = _mock_runner({"AddResults": [{"Id": 1}]})
+        runner = mock_runner({"AddResults": [{"Id": 1}]})
         payload = '[{"AdGroupId":1,"Keyword":"foo"}]'
         with patch("server.tools.keywords.get_runner", return_value=runner):
             keywords_add(keywords_json=payload)
@@ -207,7 +200,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_batch_with_default_adgroup_id(self):
         """ad_group_id is forwarded as default in batch mode."""
-        runner = _mock_runner({"AddResults": []})
+        runner = mock_runner({"AddResults": []})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             keywords_add(
                 ad_group_id=42,
@@ -220,7 +213,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_rejects_no_mode(self):
         """Neither keyword nor batch flag → missing_mode, runner not invoked."""
-        runner = _mock_runner({"AddResults": []})
+        runner = mock_runner({"AddResults": []})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_add(ad_group_id=1)
         assert isinstance(result, dict)
@@ -229,7 +222,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_rejects_conflicting_modes(self):
         """keyword + from_file → conflicting_modes, runner not invoked."""
-        runner = _mock_runner({"AddResults": []})
+        runner = mock_runner({"AddResults": []})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_add(keyword="x", from_file="/tmp/k.jsonl")
         assert isinstance(result, dict)
@@ -238,7 +231,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_add_rejects_all_three_modes(self):
         """All three modes set → conflicting_modes."""
-        runner = _mock_runner({"AddResults": []})
+        runner = mock_runner({"AddResults": []})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_add(
                 keyword="x",
@@ -250,7 +243,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_delete_success(self):
         """Test deleting keywords successfully."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_delete(ids="111,222")
             assert result["success"] is True
@@ -270,7 +263,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_suspend_success(self):
         """Test suspending keywords."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_suspend(ids="111,222")
             assert result["success"] is True
@@ -290,7 +283,7 @@ class TestKeywordsCrudOperations:
 
     def test_keywords_resume_success(self):
         """Test resuming suspended keywords."""
-        runner = _mock_runner({"success": True})
+        runner = mock_runner({"success": True})
         with patch("server.tools.keywords.get_runner", return_value=runner):
             result = keywords_resume(ids="111,222")
             assert result["success"] is True

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -1,15 +1,10 @@
 """Tests for leads MCP tools (CLI 0.3.8 — --turbo-page-ids required)."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.leads import leads_list
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestLeadsList:
@@ -17,7 +12,7 @@ class TestLeadsList:
 
     def test_leads_list_basic(self):
         mock_result = {"leads": [{"id": 1}]}
-        runner = _mock_runner(mock_result)
+        runner = mock_runner(mock_result)
         with patch("server.tools.leads.get_runner", return_value=runner):
             result = leads_list(turbo_page_ids="42")
             assert "leads" in result
@@ -26,8 +21,7 @@ class TestLeadsList:
             )
 
     def test_leads_list_trims_ids(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"leads": []}
+        runner = mock_runner({"leads": []})
         with patch("server.tools.leads.get_runner", return_value=runner):
             leads_list(turbo_page_ids=" 1,2 ")
         runner.run_json.assert_called_once_with(
@@ -39,8 +33,7 @@ class TestLeadsList:
         assert result["error"] == "missing_turbo_page_ids"
 
     def test_leads_list_full_argv(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"leads": []}
+        runner = mock_runner({"leads": []})
         with patch("server.tools.leads.get_runner", return_value=runner):
             leads_list(
                 turbo_page_ids="42",

--- a/tests/test_negative_keyword_shared_sets.py
+++ b/tests/test_negative_keyword_shared_sets.py
@@ -1,7 +1,6 @@
 """Tests for negative_keyword_shared_sets MCP tools."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import patch
 
 from server.tools.negative_keyword_shared_sets import (
     negative_keyword_shared_sets_list,
@@ -10,22 +9,17 @@ from server.tools.negative_keyword_shared_sets import (
     negative_keyword_shared_sets_delete,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_SETS = [
     {"Id": 100, "Name": "Block list", "NegativeKeywords": ["free", "cheap"]},
 ]
 
 
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_nkss_list():
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
-        return_value=_mock_runner(SAMPLE_SETS),
+        return_value=mock_runner(SAMPLE_SETS),
     ):
         result = negative_keyword_shared_sets_list()
         assert len(result) == 1
@@ -34,14 +28,14 @@ def test_nkss_list():
 def test_nkss_list_with_ids():
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
-        return_value=_mock_runner(SAMPLE_SETS),
+        return_value=mock_runner(SAMPLE_SETS),
     ):
         result = negative_keyword_shared_sets_list(ids="100")
         assert len(result) == 1
 
 
 def test_nkss_list_trims_ids():
-    runner = _mock_runner(SAMPLE_SETS)
+    runner = mock_runner(SAMPLE_SETS)
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
         return_value=runner,
@@ -63,7 +57,7 @@ def test_nkss_list_trims_ids():
 def test_nkss_list_empty():
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
-        return_value=_mock_runner([]),
+        return_value=mock_runner([]),
     ):
         result = negative_keyword_shared_sets_list()
         assert result == []
@@ -73,7 +67,7 @@ def test_nkss_add():
     mock_result = {"Id": 200}
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
-        return_value=_mock_runner(mock_result),
+        return_value=mock_runner(mock_result),
     ) as mock:
         result = negative_keyword_shared_sets_add(name="New list", keywords="bad,word")
         assert result["Id"] == 200
@@ -91,7 +85,7 @@ def test_nkss_add():
 
 def test_nkss_update():
     mock_result = {"success": True}
-    runner = _mock_runner(mock_result)
+    runner = mock_runner(mock_result)
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
         return_value=runner,
@@ -115,7 +109,7 @@ def test_nkss_update():
 
 
 def test_nkss_update_requires_changes():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner", return_value=runner
     ):
@@ -128,7 +122,7 @@ def test_nkss_delete():
     mock_result = {"success": True}
     with patch(
         "server.tools.negative_keyword_shared_sets.get_runner",
-        return_value=_mock_runner(mock_result),
+        return_value=mock_runner(mock_result),
     ) as mock:
         result = negative_keyword_shared_sets_delete(id=100)
         assert result["success"] is True

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,10 +1,8 @@
 """Tests for reports MCP tool."""
 
 import json
-import subprocess
 from datetime import date, timedelta
 from unittest.mock import patch, MagicMock
-
 
 from server.tools.reports import (
     CUSTOM_REPORT_TIMEOUT_SECONDS,
@@ -16,6 +14,7 @@ from server.tools.reports import (
     reports_list_types,
 )
 
+from tests.helpers import completed, mock_runner
 
 SAMPLE_REPORTS = [
     {
@@ -28,31 +27,9 @@ SAMPLE_REPORTS = [
 ]
 
 
-def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
-    return subprocess.CompletedProcess(
-        args=["direct"], returncode=returncode, stdout=stdout, stderr=stderr
-    )
-
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result.
-
-    The mock also exposes ``runner.run_checked`` returning an empty stdout
-    CompletedProcess by default — required for paths that go through
-    ``runner.run_checked`` instead of ``runner.run_json`` (file output,
-    non-JSON in-memory). ``run_checked`` already raises on non-zero CLI
-    exit codes; tests that need to assert that behaviour can set
-    ``runner.run_checked.side_effect = CliError(...)``.
-    """
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    runner.run_checked.return_value = _completed()
-    return runner
-
-
 def test_reports_get():
     """Test 16: Statistics for date range."""
-    runner = _mock_runner(SAMPLE_REPORTS)
+    runner = mock_runner(SAMPLE_REPORTS)
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_get(date_from="2026-03-30", date_to="2026-04-06")
         assert len(result) == 1
@@ -79,7 +56,7 @@ def test_reports_get():
 
 def test_reports_no_dates():
     """Reports without date range."""
-    runner = _mock_runner(SAMPLE_REPORTS)
+    runner = mock_runner(SAMPLE_REPORTS)
     today = date.today()
     expected_from = (today - timedelta(days=8)).isoformat()
     expected_to = today.isoformat()
@@ -108,7 +85,7 @@ def test_reports_no_dates():
 
 def test_reports_only_date_to():
     """Missing start date uses the same default 8-day window."""
-    runner = _mock_runner(SAMPLE_REPORTS)
+    runner = mock_runner(SAMPLE_REPORTS)
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_get(date_to="2026-04-08")
         runner.run_json.assert_called_once_with(
@@ -133,7 +110,7 @@ def test_reports_only_date_to():
 
 def test_reports_only_date_from():
     """Missing end date uses the same default 8-day window."""
-    runner = _mock_runner(SAMPLE_REPORTS)
+    runner = mock_runner(SAMPLE_REPORTS)
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_get(date_from="2026-03-30")
         runner.run_json.assert_called_once_with(
@@ -166,7 +143,7 @@ def test_reports_list_types():
         "REACH_AND_FREQUENCY_CAMPAIGN_REPORT",
         "SEARCH_QUERY_PERFORMANCE_REPORT",
     ]
-    runner = _mock_runner(expected_types)
+    runner = mock_runner(expected_types)
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_list_types()
         assert len(result) == 7
@@ -176,7 +153,7 @@ def test_reports_list_types():
 
 def test_reports_get_empty():
     """Test report with empty result."""
-    with patch("server.tools.reports.get_runner", return_value=_mock_runner([])):
+    with patch("server.tools.reports.get_runner", return_value=mock_runner([])):
         result = reports_get(date_from="2026-03-30", date_to="2026-04-06")
         assert result == []
 
@@ -215,7 +192,7 @@ def test_reports_custom_month_with_goals():
     NOT as a `Filter[Goals:IN:...]` entry — Reports API rejects the latter
     with `error_code=8000`.
     """
-    runner = _mock_runner([{"Month": "2024-05", "Goals": "12345", "Conversions": 4}])
+    runner = mock_runner([{"Month": "2024-05", "Goals": "12345", "Conversions": 4}])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Month,CampaignName,Impressions,Clicks,Cost,Goals,Conversions",
@@ -254,7 +231,7 @@ def test_reports_custom_month_with_goals():
 
 def test_reports_custom_goal_ids_only_no_filter_arg():
     """`goal_ids` without other filters must not introduce any --filter."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Goals,Conversions",
@@ -270,7 +247,7 @@ def test_reports_custom_goal_ids_only_no_filter_arg():
 
 def test_reports_custom_goal_ids_with_other_filters_pass_through():
     """`goal_ids` and unrelated filters must coexist: --goals AND --filter both emit."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Device,Goals,Conversions",
@@ -286,7 +263,7 @@ def test_reports_custom_goal_ids_with_other_filters_pass_through():
 
 def test_reports_custom_rejects_goals_filter_with_goal_ids():
     """Raw Goals filters must not combine with native goal_ids routing."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Goals,Conversions",
@@ -303,7 +280,7 @@ def test_reports_custom_rejects_goals_filter_with_goal_ids():
 
 def test_reports_custom_rejects_goals_filter_without_goal_ids():
     """Goal-based slicing must use goal_ids, not Reports API filters."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Goals,Conversions",
@@ -327,7 +304,7 @@ def test_reports_custom_output_path(tmp_path):
         output_arg = args[args.index("--output") + 1]
         assert output_arg == str(out.resolve())
         out.write_text(json.dumps([{"x": 1}, {"x": 2}, {"x": 3}]))
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -354,7 +331,7 @@ def test_reports_custom_output_path(tmp_path):
 
 def test_reports_custom_output_path_rejects_unsafe_location():
     """output_path must stay under plugin data or temp roots."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -377,7 +354,7 @@ def test_reports_custom_output_path_uncountable_file(tmp_path):
         output_arg = args[args.index("--output") + 1]
         assert output_arg == str(out.resolve())
         out.write_text("not json")
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -407,7 +384,7 @@ def test_reports_custom_output_path_counts_large_json_stream(tmp_path):
                     f.write(",")
                 f.write(json.dumps({"i": i, "nested": {"comma": "a,b"}}))
             f.write("]")
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -430,7 +407,7 @@ def test_reports_custom_dry_run():
             "FieldNames": ["Date", "Cost"],
         }
     }
-    runner = _mock_runner({"headers": {}, "body": fake_body})
+    runner = mock_runner({"headers": {}, "body": fake_body})
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -450,7 +427,7 @@ def test_reports_custom_dry_run():
 def test_reports_custom_dry_run_passthrough_when_no_body_key():
     """If runner returns a dict without 'body', it's passed through as request_body."""
     raw = {"unexpected": "shape"}
-    runner = _mock_runner(raw)
+    runner = mock_runner(raw)
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -465,7 +442,7 @@ def test_reports_custom_dry_run_ignores_output_path(tmp_path):
     """dry_run=True must not pass --output to direct, otherwise the CLI writes
     the body to the file and stdout is empty, leaving request_body=[]."""
     fake_body = {"params": {"FieldNames": ["Date"]}}
-    runner = _mock_runner({"headers": {}, "body": fake_body})
+    runner = mock_runner({"headers": {}, "body": fake_body})
     out = tmp_path / "ignored.json"
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
@@ -507,7 +484,7 @@ def test_reports_custom_invalid_request_hint():
 
 def test_reports_custom_date_range_type():
     """date_range_type without explicit dates uses --date-range-type."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -562,7 +539,7 @@ def test_reports_custom_rejects_invalid_date_format():
 
 def test_reports_custom_override_report_type():
     """report_type override propagates to --type."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="CampaignName,Criterion,Cost",
@@ -597,7 +574,7 @@ def test_reports_custom_unknown_report_type():
 
 def test_reports_custom_include_vat_false():
     """include_vat=False produces --no-include-vat."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -615,7 +592,7 @@ def test_reports_custom_include_vat_false():
 
 def test_reports_custom_multiple_order_by():
     """Each order_by element becomes a separate --order-by flag."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Month,CampaignName,Cost",
@@ -649,7 +626,7 @@ def test_reports_custom_in_contract():
 
 def test_reports_custom_default_response_format_threads_json():
     """Default response_format=json must reach the CLI as --format json."""
-    runner = _mock_runner([{"x": 1}])
+    runner = mock_runner([{"x": 1}])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -663,9 +640,7 @@ def test_reports_custom_default_response_format_threads_json():
 def test_reports_custom_response_format_tsv_in_memory():
     """response_format=tsv without output_path returns raw stdout payload."""
     runner = MagicMock()
-    runner.run_checked.return_value = _completed(
-        stdout="Date\tCost\n2026-01-01\t12.5\n"
-    )
+    runner.run_checked.return_value = completed(stdout="Date\tCost\n2026-01-01\t12.5\n")
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -685,7 +660,7 @@ def test_reports_custom_response_format_tsv_in_memory():
 
 def test_reports_custom_response_format_csv_in_memory():
     runner = MagicMock()
-    runner.run_checked.return_value = _completed(stdout="Date,Cost\n2026-01-01,12.5\n")
+    runner.run_checked.return_value = completed(stdout="Date,Cost\n2026-01-01,12.5\n")
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -700,7 +675,7 @@ def test_reports_custom_response_format_csv_in_memory():
 
 
 def test_reports_custom_processing_mode_threads_through():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -714,7 +689,7 @@ def test_reports_custom_processing_mode_threads_through():
 
 
 def test_reports_custom_rejects_invalid_processing_mode():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -728,7 +703,7 @@ def test_reports_custom_rejects_invalid_processing_mode():
 
 
 def test_reports_custom_language_threads_through():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -742,7 +717,7 @@ def test_reports_custom_language_threads_through():
 
 
 def test_reports_custom_rejects_invalid_language():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -754,7 +729,7 @@ def test_reports_custom_rejects_invalid_language():
 
 
 def test_reports_custom_attribution_models_threads_through():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -770,7 +745,7 @@ def test_reports_custom_attribution_models_threads_through():
 def test_reports_custom_attribution_models_normalizes_whitespace():
     """Whitespace around tokens is stripped before forwarding to the CLI so
     `\"LSC, FC\"` becomes `\"LSC,FC\"` — matches what validation accepted."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -784,7 +759,7 @@ def test_reports_custom_attribution_models_normalizes_whitespace():
 
 
 def test_reports_custom_rejects_unknown_attribution_model():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         result = reports_custom(
             field_names="Date,Cost",
@@ -796,7 +771,7 @@ def test_reports_custom_rejects_unknown_attribution_model():
 
 
 def test_reports_custom_skip_flags_threaded():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -816,7 +791,7 @@ def test_reports_custom_skip_flags_threaded():
 
 def test_reports_custom_skip_flags_default_omits_them():
     """When skip_* are not set, the CLI defaults apply (no plugin override)."""
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.reports.get_runner", return_value=runner):
         reports_custom(
             field_names="Date,Cost",
@@ -838,7 +813,7 @@ def test_reports_custom_output_path_with_tsv_format(tmp_path):
 
     def fake_run(args, **kwargs):
         out.write_text("Date\tCost\n2026-01-01\t12.5\n")
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -914,7 +889,7 @@ def test_reports_custom_rows_written_default_skip_state(tmp_path):
     def fake_run(args, **kwargs):
         # 1 header line + 3 data lines = 4 total
         out.write_text("Date\tCost\n2026-01-01\t1\n2026-01-02\t2\n2026-01-03\t3\n")
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -936,7 +911,7 @@ def test_reports_custom_rows_written_with_skip_column_header(tmp_path):
     def fake_run(args, **kwargs):
         # 3 data lines, no header
         out.write_text("2026-01-01\t1\n2026-01-02\t2\n2026-01-03\t3\n")
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -961,7 +936,7 @@ def test_reports_custom_rows_written_with_summary_kept(tmp_path):
         out.write_text(
             "Date\tCost\n2026-01-01\t1\n2026-01-02\t2\n2026-01-03\t3\nTotal rows: 3\n"
         )
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):
@@ -987,7 +962,7 @@ def test_reports_custom_rows_written_with_report_header_kept(tmp_path):
             '"X (2026-01-01 - 2026-01-03)"\n'
             "Date\tCost\n2026-01-01\t1\n2026-01-02\t2\n2026-01-03\t3\n"
         )
-        return _completed()
+        return completed()
 
     runner.run_checked.side_effect = fake_run
     with patch("server.tools.reports.get_runner", return_value=runner):

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,15 +1,10 @@
 """Tests for keyword research MCP tools (CLI 0.3.8 — --region-ids required)."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.research import keywords_has_volume, keywords_deduplicate
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestKeywordsHasVolume:
@@ -18,14 +13,13 @@ class TestKeywordsHasVolume:
     def test_keywords_has_volume_basic(self):
         mock_result = {"keyword1": True, "keyword2": False}
         with patch(
-            "server.tools.research.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.research.get_runner", return_value=mock_runner(mock_result)
         ):
             result = keywords_has_volume(keywords="keyword1,keyword2", region_ids="0")
             assert result["keyword1"] is True
 
     def test_keywords_has_volume_argv(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"k1": True}
+        runner = mock_runner({"k1": True})
         with patch("server.tools.research.get_runner", return_value=runner):
             keywords_has_volume(keywords="k1,k2", region_ids="213")
         runner.run_json.assert_called_once_with(
@@ -59,14 +53,13 @@ class TestKeywordsDeduplicate:
             "deduplicated": ["keyword1", "keyword2"],
         }
         with patch(
-            "server.tools.research.get_runner", return_value=_mock_runner(mock_result)
+            "server.tools.research.get_runner", return_value=mock_runner(mock_result)
         ):
             result = keywords_deduplicate(keywords="keyword1,keyword2,keyword1")
             assert result["deduplicated"] == ["keyword1", "keyword2"]
 
     def test_keywords_deduplicate_argv(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"original": [], "deduplicated": []}
+        runner = mock_runner({"original": [], "deduplicated": []})
         with patch("server.tools.research.get_runner", return_value=runner):
             keywords_deduplicate(keywords="k1,k2")
         runner.run_json.assert_called_once_with(

--- a/tests/test_retargeting.py
+++ b/tests/test_retargeting.py
@@ -12,6 +12,8 @@ from server.tools.retargeting import (
 )
 from server.cli.runner import CliAuthError
 
+from tests.helpers import mock_runner
+
 
 @pytest.fixture
 def mock_retargeting_lists():
@@ -32,13 +34,6 @@ def mock_retargeting_lists():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestRetargetingList:
     """Tests for retargeting_list."""
 
@@ -46,7 +41,7 @@ class TestRetargetingList:
         """Test listing retargeting lists successfully."""
         with patch(
             "server.tools.retargeting.get_runner",
-            return_value=_mock_runner(mock_retargeting_lists),
+            return_value=mock_runner(mock_retargeting_lists),
         ):
             result = retargeting_list(ids="201,202")
             assert len(result) == 2
@@ -55,15 +50,14 @@ class TestRetargetingList:
         """Test listing all retargeting lists."""
         with patch(
             "server.tools.retargeting.get_runner",
-            return_value=_mock_runner(mock_retargeting_lists),
+            return_value=mock_runner(mock_retargeting_lists),
         ):
             result = retargeting_list()
             assert len(result) == 2
 
     def test_list_retargeting_with_types(self):
         """Test listing retargeting lists filtered by types."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch(
             "server.tools.retargeting.get_runner",
             return_value=runner,
@@ -74,8 +68,7 @@ class TestRetargetingList:
 
     def test_list_retargeting_trims_filters(self):
         """Test retargeting filters are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = []
+        runner = mock_runner([])
         with patch("server.tools.retargeting.get_runner", return_value=runner):
             retargeting_list(ids=" 201,202 ", types=" REMARKETING ")
 
@@ -112,8 +105,7 @@ class TestRetargetingAdd:
             "Type": "AUDIENCE",
             "State": "ON",
         }
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
         with patch(
             "server.tools.retargeting.get_runner",
             return_value=runner,
@@ -129,8 +121,7 @@ class TestRetargetingAdd:
 
     def test_add_retargeting_with_rule(self):
         """Test adding with targeting rule in CLI DSL form."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 204}
+        runner = mock_runner({"Id": 204})
         with patch(
             "server.tools.retargeting.get_runner",
             return_value=runner,
@@ -145,8 +136,7 @@ class TestRetargetingAdd:
             assert "ALL:123:30|456:14" in call_args
 
     def test_add_retargeting_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.retargeting.get_runner", return_value=runner):
             retargeting_add(name="x", list_type="RETARGETING", dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -168,7 +158,7 @@ class TestRetargetingDelete:
         mock_result = {"success": True}
         with patch(
             "server.tools.retargeting.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = retargeting_delete(ids="201")
             assert result["success"] is True
@@ -185,8 +175,7 @@ class TestRetargetingUpdate:
     """Tests for retargeting_update."""
 
     def test_update_retargeting_success(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.retargeting.get_runner", return_value=runner):
             result = retargeting_update(
                 id=201,
@@ -214,8 +203,7 @@ class TestRetargetingUpdate:
 
     def test_update_retargeting_rule(self):
         """retargeting_update passes --rule as a CLI-DSL string."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"success": True}
+        runner = mock_runner({"success": True})
         with patch("server.tools.retargeting.get_runner", return_value=runner):
             retargeting_update(id=201, rule="ANY:123:30")
             call_args = runner.run_json.call_args[0][0]
@@ -223,8 +211,7 @@ class TestRetargetingUpdate:
             assert "ANY:123:30" in call_args
 
     def test_update_retargeting_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.retargeting.get_runner", return_value=runner):
             retargeting_update(id=201, name="x", dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]

--- a/tests/test_sitelinks.py
+++ b/tests/test_sitelinks.py
@@ -1,11 +1,13 @@
 """Tests for sitelinks MCP tools."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from server.tools.sitelinks import sitelinks_list, sitelinks_add, sitelinks_delete
+
+from tests.helpers import mock_runner
 
 
 @pytest.fixture
@@ -22,13 +24,6 @@ def mock_sitelinks():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestSitelinksList:
     """Tests for sitelinks_list tool."""
 
@@ -36,7 +31,7 @@ class TestSitelinksList:
         """Test listing sitelinks successfully."""
         with patch(
             "server.tools.sitelinks.get_runner",
-            return_value=_mock_runner(mock_sitelinks),
+            return_value=mock_runner(mock_sitelinks),
         ):
             result = sitelinks_list(ids="1")
             assert len(result) == 1
@@ -46,7 +41,7 @@ class TestSitelinksList:
         """Test listing sitelinks with no IDs returns all."""
         with patch(
             "server.tools.sitelinks.get_runner",
-            return_value=_mock_runner(mock_sitelinks),
+            return_value=mock_runner(mock_sitelinks),
         ):
             result = sitelinks_list()
             assert len(result) == 1
@@ -60,8 +55,7 @@ class TestSitelinksList:
 
     def test_list_sitelinks_trims_ids_before_cli(self, mock_sitelinks):
         """Test sitelink IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_sitelinks
+        runner = mock_runner(mock_sitelinks)
         with patch("server.tools.sitelinks.get_runner", return_value=runner):
             sitelinks_list(ids=" 1 ")
 
@@ -76,8 +70,7 @@ class TestSitelinksAdd:
     def test_add_sitelinks_success(self):
         """Each sitelink spec becomes a separate --sitelink argument."""
         mock_result = {"Id": 123}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.sitelinks.get_runner", return_value=runner):
             result = sitelinks_add(
@@ -99,8 +92,7 @@ class TestSitelinksAdd:
             )
 
     def test_add_sitelinks_items_serialized_to_camelcase_json(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 456}
+        runner = mock_runner({"Id": 456})
         with patch("server.tools.sitelinks.get_runner", return_value=runner):
             sitelinks_add(
                 items=[
@@ -133,8 +125,7 @@ class TestSitelinksAdd:
         assert "url" in result["message"]
 
     def test_add_sitelinks_from_file(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 789}
+        runner = mock_runner({"Id": 789})
         with patch("server.tools.sitelinks.get_runner", return_value=runner):
             sitelinks_add(from_file="/tmp/sitelinks.jsonl")
 
@@ -159,8 +150,7 @@ class TestSitelinksAdd:
         assert result["error"] == "conflicting_modes"
 
     def test_add_sitelinks_dry_run(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"_dry_run": True}
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.sitelinks.get_runner", return_value=runner):
             sitelinks_add(sitelinks=["A|https://a"], dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -205,7 +195,7 @@ class TestSitelinksDelete:
 
         with patch(
             "server.tools.sitelinks.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = sitelinks_delete(ids="1")
             assert result["success"] is True

--- a/tests/test_smart_ad_targets.py
+++ b/tests/test_smart_ad_targets.py
@@ -1,7 +1,6 @@
 """Tests for smart_ad_targets MCP tools."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import patch
 
 from server.tools.smart_ad_targets import (
     smart_ad_targets_list,
@@ -13,6 +12,7 @@ from server.tools.smart_ad_targets import (
     smart_ad_targets_suspend,
 )
 
+from tests.helpers import mock_runner
 
 SAMPLE_TARGETS = [
     {
@@ -25,23 +25,17 @@ SAMPLE_TARGETS = [
 ]
 
 
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 def test_smart_ad_targets_list():
     with patch(
         "server.tools.smart_ad_targets.get_runner",
-        return_value=_mock_runner(SAMPLE_TARGETS),
+        return_value=mock_runner(SAMPLE_TARGETS),
     ):
         result = smart_ad_targets_list(ad_group_ids="200")
         assert len(result) == 1
 
 
 def test_smart_ad_targets_list_trims_ids():
-    runner = _mock_runner(SAMPLE_TARGETS)
+    runner = mock_runner(SAMPLE_TARGETS)
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         smart_ad_targets_list(ad_group_ids=" 200 ")
 
@@ -52,7 +46,7 @@ def test_smart_ad_targets_list_trims_ids():
 
 def test_smart_ad_targets_list_no_filters():
     """Blank ad_group_ids behaves like no filter."""
-    runner = _mock_runner(SAMPLE_TARGETS)
+    runner = mock_runner(SAMPLE_TARGETS)
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         smart_ad_targets_list(ad_group_ids="   ")
     argv = runner.run_json.call_args[0][0]
@@ -61,7 +55,7 @@ def test_smart_ad_targets_list_no_filters():
 
 def test_smart_ad_targets_list_empty():
     with patch(
-        "server.tools.smart_ad_targets.get_runner", return_value=_mock_runner([])
+        "server.tools.smart_ad_targets.get_runner", return_value=mock_runner([])
     ):
         result = smart_ad_targets_list(ad_group_ids="200")
         assert result == []
@@ -69,7 +63,7 @@ def test_smart_ad_targets_list_empty():
 
 def test_smart_ad_targets_add():
     mock_result = {"Id": 400}
-    runner = _mock_runner(mock_result)
+    runner = mock_runner(mock_result)
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_add(
             ad_group_id=200,
@@ -105,7 +99,7 @@ def test_smart_ad_targets_add():
 
 def test_smart_ad_targets_update():
     mock_result = {"success": True}
-    runner = _mock_runner(mock_result)
+    runner = mock_runner(mock_result)
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_update(
             id=100,
@@ -128,7 +122,7 @@ def test_smart_ad_targets_update():
 
 
 def test_smart_ad_targets_update_requires_changes():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_update(id=100)
         assert result["error"] == "missing_update_fields"
@@ -139,7 +133,7 @@ def test_smart_ad_targets_delete():
     mock_result = {"success": True}
     with patch(
         "server.tools.smart_ad_targets.get_runner",
-        return_value=_mock_runner(mock_result),
+        return_value=mock_runner(mock_result),
     ) as mock:
         result = smart_ad_targets_delete(id=100)
         assert result["success"] is True
@@ -149,7 +143,7 @@ def test_smart_ad_targets_delete():
 
 
 def test_smart_ad_targets_suspend_batches_ids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_suspend(ids="100,101")
 
@@ -158,7 +152,7 @@ def test_smart_ad_targets_suspend_batches_ids():
 
 
 def test_smart_ad_targets_resume_batches_ids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_resume(ids="100,101")
 
@@ -167,7 +161,7 @@ def test_smart_ad_targets_resume_batches_ids():
 
 
 def test_smart_ad_targets_set_bids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.smart_ad_targets.get_runner", return_value=runner):
         result = smart_ad_targets_set_bids(
             id=100,

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,7 +1,6 @@
 """Tests for strategy MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.strategies import (
     strategies_add,
@@ -11,12 +10,7 @@ from server.tools.strategies import (
     strategies_update,
 )
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestStrategiesList:
@@ -30,7 +24,7 @@ class TestStrategiesList:
         ]
         with patch(
             "server.tools.strategies.get_runner",
-            return_value=_mock_runner(strategies),
+            return_value=mock_runner(strategies),
         ):
             result = strategies_list()
             assert len(result) == 2
@@ -38,7 +32,7 @@ class TestStrategiesList:
 
     def test_strategies_list_with_types(self):
         """Filter by types passes --types to CLI."""
-        runner = _mock_runner([{"Id": 1, "Type": "AverageCpc"}])
+        runner = mock_runner([{"Id": 1, "Type": "AverageCpc"}])
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_list(types="AverageCpc")
         runner.run_json.assert_called_once_with(
@@ -47,7 +41,7 @@ class TestStrategiesList:
 
     def test_strategies_list_with_is_archived(self):
         """Filter by is_archived passes --is-archived to CLI."""
-        runner = _mock_runner([{"Id": 1}])
+        runner = mock_runner([{"Id": 1}])
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_list(is_archived="NO")
         runner.run_json.assert_called_once_with(
@@ -71,7 +65,7 @@ class TestStrategiesAdd:
 
     def test_strategies_add(self):
         """Basic add with required fields."""
-        runner = _mock_runner({"Id": 100, "Name": "MyStrategy"})
+        runner = mock_runner({"Id": 100, "Name": "MyStrategy"})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             result = strategies_add(name="MyStrategy", type="AverageCpc")
         assert result["Id"] == 100
@@ -81,7 +75,7 @@ class TestStrategiesAdd:
 
     def test_strategies_add_typed_money_fields(self):
         """Money fields pass through as separate typed flags."""
-        runner = _mock_runner({"Id": 101})
+        runner = mock_runner({"Id": 101})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_add(
                 name="CpcStrategy",
@@ -101,7 +95,7 @@ class TestStrategiesAdd:
 
     def test_strategies_add_priority_goals_repeats(self):
         """Each priority_goals item becomes a separate --priority-goal flag."""
-        runner = _mock_runner({"Id": 102})
+        runner = mock_runner({"Id": 102})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_add(
                 name="PayForConv",
@@ -112,7 +106,7 @@ class TestStrategiesAdd:
         assert argv.count("--priority-goal") == 2
 
     def test_strategies_add_dry_run(self):
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_add(name="x", type="AverageCpc", dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -123,7 +117,7 @@ class TestStrategiesUpdate:
 
     def test_strategies_update(self):
         """Update passes id and changed fields to CLI."""
-        runner = _mock_runner({"Id": 100, "Name": "Renamed"})
+        runner = mock_runner({"Id": 100, "Name": "Renamed"})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             result = strategies_update(id=100, name="Renamed")
         assert result["Id"] == 100
@@ -133,7 +127,7 @@ class TestStrategiesUpdate:
 
     def test_strategies_update_requires_changes(self):
         """Update with no change fields returns missing_update_fields error."""
-        runner = _mock_runner({"Id": 100})
+        runner = mock_runner({"Id": 100})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             result = strategies_update(id=100)
         assert result["error"] == "missing_update_fields"
@@ -145,7 +139,7 @@ class TestStrategiesArchive:
 
     def test_strategies_archive(self):
         """Archive passes id to CLI."""
-        runner = _mock_runner({"Id": 100})
+        runner = mock_runner({"Id": 100})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             result = strategies_archive(id=100)
         assert result["Id"] == 100
@@ -154,7 +148,7 @@ class TestStrategiesArchive:
         )
 
     def test_strategies_archive_dry_run(self):
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_archive(id=100, dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]
@@ -165,7 +159,7 @@ class TestStrategiesUnarchive:
 
     def test_strategies_unarchive(self):
         """Unarchive passes id to CLI."""
-        runner = _mock_runner({"Id": 100})
+        runner = mock_runner({"Id": 100})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             result = strategies_unarchive(id=100)
         assert result["Id"] == 100
@@ -174,7 +168,7 @@ class TestStrategiesUnarchive:
         )
 
     def test_strategies_unarchive_dry_run(self):
-        runner = _mock_runner({"_dry_run": True})
+        runner = mock_runner({"_dry_run": True})
         with patch("server.tools.strategies.get_runner", return_value=runner):
             strategies_unarchive(id=100, dry_run=True)
             assert "--dry-run" in runner.run_json.call_args[0][0]

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -10,15 +10,14 @@ from server.cli.runner import (
     CliTimeoutError,
     DirectCliRunner,
 )
-from server.tools.ads import _check_batch_limit as ads_check_batch_limit
-from server.tools.ads import _parse_ids
 from server.tools.auth_tools import _human_readable_time
 from server.tools.helpers import (
+    check_batch_limit,
+    parse_ids,
     provided_update_value,
     run_single_id_batch,
     tool_error_dict,
 )
-from server.tools.keywords import _check_batch_limit as keywords_check_batch_limit
 
 
 def test_human_readable_time_formats_expected_ranges() -> None:
@@ -189,19 +188,12 @@ def test_get_runner_returns_profile_based_runner() -> None:
 
 
 def test_parse_ids_strips_whitespace_and_empty_values() -> None:
-    assert _parse_ids(" 1, 2 ,,3 , ") == ["1", "2", "3"]
+    assert parse_ids(" 1, 2 ,,3 , ") == ["1", "2", "3"]
 
 
-def test_ads_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
-    assert ads_check_batch_limit(",".join(str(i) for i in range(10))) is None
-    result = ads_check_batch_limit(",".join(str(i) for i in range(11)))
-    assert result is not None
-    assert result.error == "batch_limit"
-
-
-def test_keywords_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
-    assert keywords_check_batch_limit(",".join(str(i) for i in range(10))) is None
-    result = keywords_check_batch_limit(",".join(str(i) for i in range(11)))
+def test_batch_limit_allows_ten_ids_and_rejects_eleven() -> None:
+    assert check_batch_limit(",".join(str(i) for i in range(10))) is None
+    result = check_batch_limit(",".join(str(i) for i in range(11)))
     assert result is not None
     assert result.error == "batch_limit"
 

--- a/tests/test_turbo_pages.py
+++ b/tests/test_turbo_pages.py
@@ -1,16 +1,10 @@
 """Tests for turbo pages MCP tools."""
 
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import patch
 
 from server.tools.turbo_pages import turbo_pages_list
 
-
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 class TestTurboPagesList:
@@ -21,7 +15,7 @@ class TestTurboPagesList:
         mock_result = {"turboPages": [{"id": 1, "name": "Page 1"}]}
         with patch(
             "server.tools.turbo_pages.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = turbo_pages_list(ids="1")
             assert "turboPages" in result
@@ -31,15 +25,14 @@ class TestTurboPagesList:
         mock_result = {"turboPages": []}
         with patch(
             "server.tools.turbo_pages.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = turbo_pages_list()
             assert "turboPages" in result
 
     def test_turbo_pages_list_trims_ids(self):
         """Test turbo page IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"turboPages": []}
+        runner = mock_runner({"turboPages": []})
         with patch("server.tools.turbo_pages.get_runner", return_value=runner):
             turbo_pages_list(ids=" 1 ")
 
@@ -49,8 +42,7 @@ class TestTurboPagesList:
 
     def test_turbo_pages_list_full_argv(self):
         """Test all optional flags pass through to CLI."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"turboPages": []}
+        runner = mock_runner({"turboPages": []})
         with patch("server.tools.turbo_pages.get_runner", return_value=runner):
             turbo_pages_list(
                 ids="1",
@@ -71,15 +63,14 @@ class TestTurboPagesList:
         """Test empty response returns empty dict."""
         with patch(
             "server.tools.turbo_pages.get_runner",
-            return_value=_mock_runner({"turboPages": []}),
+            return_value=mock_runner({"turboPages": []}),
         ):
             result = turbo_pages_list()
             assert result == {"turboPages": []}
 
     def test_turbo_pages_list_ignores_blank_ids(self):
         """Test blank ids behave like no filter."""
-        runner = MagicMock()
-        runner.run_json.return_value = {"turboPages": []}
+        runner = mock_runner({"turboPages": []})
         with patch("server.tools.turbo_pages.get_runner", return_value=runner):
             turbo_pages_list(ids="   ")
             call_args = runner.run_json.call_args[0][0]

--- a/tests/test_v4_tools.py
+++ b/tests/test_v4_tools.py
@@ -1,6 +1,6 @@
 """Tests for v4 Live MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from server.cli.runner import DirectCliRunner
 from server.contract import (
@@ -24,23 +24,11 @@ from server.tools.v4tags import (
     v4tags_update_campaigns,
 )
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
-def _completed(stdout: str) -> MagicMock:
-    result = MagicMock()
-    result.stdout = stdout
-    result.stderr = ""
-    result.returncode = 0
-    return result
+from tests.helpers import completed, mock_runner
 
 
 def test_balance_get_without_logins():
-    runner = _mock_runner({"Accounts": []})
+    runner = mock_runner({"Accounts": []})
     with patch("server.tools.balance.get_runner", return_value=runner):
         result = balance_get()
 
@@ -49,7 +37,7 @@ def test_balance_get_without_logins():
 
 
 def test_balance_get_with_logins():
-    runner = _mock_runner({"Accounts": []})
+    runner = mock_runner({"Accounts": []})
     with patch("server.tools.balance.get_runner", return_value=runner):
         result = balance_get(logins=" client-a,client-b ")
 
@@ -61,7 +49,7 @@ def test_balance_get_with_logins():
 
 def test_balance_get_passes_email_shaped_logins_to_direct_unchanged():
     """Issue #145: Client-Login normalization belongs to direct-cli auth."""
-    runner = _mock_runner({"Accounts": []})
+    runner = mock_runner({"Accounts": []})
     with patch("server.tools.balance.get_runner", return_value=runner):
         result = balance_get(logins=" client@yandex.ru ")
 
@@ -72,7 +60,7 @@ def test_balance_get_passes_email_shaped_logins_to_direct_unchanged():
 
 
 def test_v4goals_get_stat_goals():
-    runner = _mock_runner({"Goals": []})
+    runner = mock_runner({"Goals": []})
     with patch("server.tools.v4goals.get_runner", return_value=runner):
         result = v4goals_get_stat_goals(campaign_ids=" 123,456 ")
 
@@ -90,7 +78,7 @@ def test_v4goals_get_stat_goals():
 
 
 def test_v4goals_get_retargeting_goals():
-    runner = _mock_runner({"RetargetingGoals": []})
+    runner = mock_runner({"RetargetingGoals": []})
     with patch("server.tools.v4goals.get_runner", return_value=runner):
         result = v4goals_get_retargeting_goals(campaign_ids="123,456")
 
@@ -118,7 +106,7 @@ def test_v4goals_retargeting_requires_campaign_ids():
 
 
 def test_v4tags_get_campaigns():
-    runner = _mock_runner({"Campaigns": []})
+    runner = mock_runner({"Campaigns": []})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_get_campaigns(campaign_ids=" 123,456 ")
 
@@ -141,7 +129,7 @@ def test_v4tags_get_campaigns_requires_campaign_ids():
 
 
 def test_v4tags_get_banners_by_campaign_ids():
-    runner = _mock_runner({"Banners": []})
+    runner = mock_runner({"Banners": []})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_get_banners(campaign_ids=" 123,456 ")
 
@@ -159,7 +147,7 @@ def test_v4tags_get_banners_by_campaign_ids():
 
 
 def test_v4tags_get_banners_by_banner_ids():
-    runner = _mock_runner({"Banners": []})
+    runner = mock_runner({"Banners": []})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_get_banners(banner_ids=" 111,222 ")
 
@@ -201,7 +189,7 @@ def test_v4tags_get_banners_rejects_too_many_banner_ids():
 
 
 def test_v4tags_update_campaigns_with_tags():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_update_campaigns(
             campaign_id=123,
@@ -226,7 +214,7 @@ def test_v4tags_update_campaigns_with_tags():
 
 
 def test_v4tags_update_campaigns_clear_tags_dry_run():
-    runner = _mock_runner({"dry_run": True})
+    runner = mock_runner({"dry_run": True})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_update_campaigns(
             campaign_id=123,
@@ -264,7 +252,7 @@ def test_v4tags_update_campaigns_rejects_tags_and_clear():
 
 
 def test_v4tags_update_banners_with_tag_ids():
-    runner = _mock_runner({"success": True})
+    runner = mock_runner({"success": True})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_update_banners(
             banner_ids=" 111,222 ",
@@ -287,7 +275,7 @@ def test_v4tags_update_banners_with_tag_ids():
 
 
 def test_v4tags_update_banners_clear_tags_dry_run():
-    runner = _mock_runner({"dry_run": True})
+    runner = mock_runner({"dry_run": True})
     with patch("server.tools.v4tags.get_runner", return_value=runner):
         result = v4tags_update_banners(
             banner_ids="111,222",
@@ -318,7 +306,7 @@ def test_v4tags_update_banners_returns_wrapped_scalar():
             "server.cli.runner._resolve_direct_cached",
             return_value="/usr/bin/direct",
         ),
-        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+        patch("server.cli.runner.subprocess.run", return_value=completed("1")),
     ):
         result = v4tags_update_banners(
             banner_ids="111,222",
@@ -433,7 +421,7 @@ def test_v4_contract_exposes_only_cli_backed_tools():
 
 
 def test_v4keywords_get_suggestion() -> None:
-    runner = _mock_runner(["мебельные ручки", "ручка мебельная"])
+    runner = mock_runner(["мебельные ручки", "ручка мебельная"])
     with patch("server.tools.v4keywords.get_runner", return_value=runner):
         result = v4keywords_get_suggestion(keywords=[" ручки для шкафа ", "стол"])
 
@@ -458,7 +446,7 @@ def test_v4keywords_get_suggestion_requires_keywords() -> None:
 
 
 def test_v4adimage_get_without_filters() -> None:
-    runner = _mock_runner({"AdImageAssociations": [], "TotalObjectsCount": "0"})
+    runner = mock_runner({"AdImageAssociations": [], "TotalObjectsCount": "0"})
     with patch("server.tools.v4adimage.get_runner", return_value=runner):
         result = v4adimage_get()
 
@@ -467,7 +455,7 @@ def test_v4adimage_get_without_filters() -> None:
 
 
 def test_v4adimage_get_with_filters() -> None:
-    runner = _mock_runner({"AdImageAssociations": []})
+    runner = mock_runner({"AdImageAssociations": []})
     with patch("server.tools.v4adimage.get_runner", return_value=runner):
         result = v4adimage_get(
             campaign_ids=" 123,456 ",
@@ -500,7 +488,7 @@ def test_v4adimage_get_with_filters() -> None:
 
 
 def test_v4adimage_set() -> None:
-    runner = _mock_runner({"AdImageAssociations": []})
+    runner = mock_runner({"AdImageAssociations": []})
     with patch("server.tools.v4adimage.get_runner", return_value=runner):
         result = v4adimage_set(
             associations=[" 15552664629=aX63TKm1t_G4hJ93AKlAxg ", "16344915985"],

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -1,6 +1,6 @@
 """Tests for v4account MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from server.tools.v4account import (
     v4account_deposit,
@@ -11,13 +11,9 @@ from server.tools.v4account import (
     v4account_update_account,
 )
 
+from tests.helpers import mock_runner
+
 _FINANCE_TOKEN_FLAGS = ("--finance-token", "--master-token", "--finance-login")
-
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
 
 
 def _assert_no_finance_token_flags(argv: list[str]) -> None:
@@ -32,7 +28,7 @@ def _assert_no_finance_token_flags(argv: list[str]) -> None:
 
 
 def test_v4account_enable_shared_account_dry_run_argv():
-    runner = _mock_runner({"method": "EnableSharedAccount"})
+    runner = mock_runner({"method": "EnableSharedAccount"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_enable_shared_account(
             client_login=" client-login ",
@@ -52,7 +48,7 @@ def test_v4account_enable_shared_account_dry_run_argv():
 
 
 def test_v4account_enable_shared_account_sandbox_argv():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_enable_shared_account(
             client_login="client-login",
@@ -87,7 +83,7 @@ def test_v4account_enable_shared_account_requires_login():
 
 
 def test_v4account_get_accounts_by_logins_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(logins=" client-a,client-b ", dry_run=True)
     runner.run_json.assert_called_once_with(
@@ -107,7 +103,7 @@ def test_v4account_get_accounts_by_logins_argv():
 
 def test_v4account_get_accounts_passes_email_shaped_logins_to_direct_unchanged():
     """Issue #145: do not guess Client-Login from Passport email in MCP."""
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(logins=" client@yandex.ru ", dry_run=True)
     runner.run_json.assert_called_once_with(
@@ -126,7 +122,7 @@ def test_v4account_get_accounts_passes_email_shaped_logins_to_direct_unchanged()
 
 
 def test_v4account_get_accounts_by_account_ids_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(account_ids="111,222", sandbox=True)
     runner.run_json.assert_called_once_with(
@@ -152,7 +148,7 @@ def test_v4account_get_accounts_without_selectors_lists_all():
     as ``{"Action": "Get"}``. The MCP wrapper must not impose a stricter
     barrier than the CLI itself.
     """
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(dry_run=True)
     runner.run_json.assert_called_once_with(
@@ -173,7 +169,7 @@ def test_v4account_get_accounts_accepts_both_selectors():
     ``--logins`` and ``--account-ids`` into one ``SelectionCriteria``,
     so the MCP wrapper must not reject the combination.
     """
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(logins="a,b", account_ids="1,2", dry_run=True)
     runner.run_json.assert_called_once_with(
@@ -212,7 +208,7 @@ def test_v4account_get_accounts_rejects_explicitly_empty_account_ids():
 
 
 def test_v4account_get_accounts_does_not_require_dry_run_or_sandbox():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_get_accounts(logins="client-a")
     runner.run_json.assert_called_once()
@@ -227,7 +223,7 @@ def test_v4account_get_accounts_does_not_require_dry_run_or_sandbox():
 
 
 def test_v4account_update_account_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_update_account(
             account_id=1327944,
@@ -279,7 +275,7 @@ def test_v4account_update_account_argv():
 
 
 def test_v4account_update_account_sandbox_argv():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_update_account(
             account_id=1327944,
@@ -302,7 +298,7 @@ def test_v4account_update_account_requires_dry_run_or_sandbox():
 
 
 def test_v4account_deposit_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_deposit(
             payment=["111=50000", "222=30000"],
@@ -338,7 +334,7 @@ def test_v4account_deposit_argv():
 
 
 def test_v4account_deposit_sandbox_argv():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_deposit(
             payment=["1=100"],
@@ -420,7 +416,7 @@ def test_v4account_transfer_money_rejects_empty_amount():
 
 def test_v4account_deposit_does_not_pass_finance_token():
     """Even with full optional surface, no finance/master/login flag leaks."""
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_deposit(
             payment=["1=100"],
@@ -439,7 +435,7 @@ def test_v4account_deposit_does_not_pass_finance_token():
 
 
 def test_v4account_invoice_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_invoice(
             payment=["555=10000"],
@@ -467,7 +463,7 @@ def test_v4account_invoice_argv():
 
 
 def test_v4account_invoice_sandbox_argv():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_invoice(payment=["1=100"], currency="usd", sandbox=True)
     argv = runner.run_json.call_args.args[0]
@@ -486,7 +482,7 @@ def test_v4account_invoice_requires_payment():
 
 
 def test_v4account_invoice_does_not_pass_finance_token():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_invoice(payment=["1=100"], currency="rub", dry_run=True)
     _assert_no_finance_token_flags(runner.run_json.call_args.args[0])
@@ -498,7 +494,7 @@ def test_v4account_invoice_does_not_pass_finance_token():
 
 
 def test_v4account_transfer_money_argv():
-    runner = _mock_runner({"method": "AccountManagement"})
+    runner = mock_runner({"method": "AccountManagement"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_transfer_money(
             from_account_id=10,
@@ -532,7 +528,7 @@ def test_v4account_transfer_money_argv():
 
 
 def test_v4account_transfer_money_sandbox_argv():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_transfer_money(
             from_account_id=1,
@@ -557,7 +553,7 @@ def test_v4account_transfer_money_requires_dry_run_or_sandbox():
 
 
 def test_v4account_transfer_money_does_not_pass_finance_token():
-    runner = _mock_runner({"result": "ok"})
+    runner = mock_runner({"result": "ok"})
     with patch("server.tools.v4account.get_runner", return_value=runner):
         v4account_transfer_money(
             from_account_id=1,

--- a/tests/test_v4events.py
+++ b/tests/test_v4events.py
@@ -1,18 +1,14 @@
 """Tests for v4events MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from server.tools.v4events import v4events_get_events_log
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
+from tests.helpers import mock_runner
 
 
 def test_v4events_get_events_log_argv():
-    runner = _mock_runner({"Events": []})
+    runner = mock_runner({"Events": []})
     with patch("server.tools.v4events.get_runner", return_value=runner):
         v4events_get_events_log(
             timestamp_from=" 2026-05-01T00:00:00 ",
@@ -55,7 +51,7 @@ def test_v4events_get_events_log_requires_timestamps():
 
 
 def test_v4events_get_events_log_dry_run():
-    runner = _mock_runner({"method": "GetEventsLog"})
+    runner = mock_runner({"method": "GetEventsLog"})
     with patch("server.tools.v4events.get_runner", return_value=runner):
         v4events_get_events_log(
             timestamp_from="2026-05-01T00:00:00",

--- a/tests/test_v4forecast.py
+++ b/tests/test_v4forecast.py
@@ -1,6 +1,6 @@
 """Tests for v4forecast MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from server.cli.runner import DirectCliRunner
 from server.tools.v4forecast import (
@@ -10,23 +10,11 @@ from server.tools.v4forecast import (
     v4forecast_list,
 )
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
-def _completed(stdout: str) -> MagicMock:
-    result = MagicMock()
-    result.stdout = stdout
-    result.stderr = ""
-    result.returncode = 0
-    return result
+from tests.helpers import completed, mock_runner
 
 
 def test_v4forecast_create_argv():
-    runner = _mock_runner({"forecast_id": 1})
+    runner = mock_runner({"forecast_id": 1})
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_create(
             phrases="phrase1, phrase2",
@@ -61,7 +49,7 @@ def test_v4forecast_create_phrase_limit():
 
 
 def test_v4forecast_create_dry_run():
-    runner = _mock_runner({"_dry_run": True})
+    runner = mock_runner({"_dry_run": True})
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_create(phrases="x", dry_run=True)
         argv = runner.run_json.call_args[0][0]
@@ -78,7 +66,7 @@ def test_v4forecast_create_returns_wrapped_scalar():
         ),
         patch(
             "server.cli.runner.subprocess.run",
-            return_value=_completed("987654321"),
+            return_value=completed("987654321"),
         ),
     ):
         result = v4forecast_create(phrases="phrase")
@@ -86,14 +74,14 @@ def test_v4forecast_create_returns_wrapped_scalar():
 
 
 def test_v4forecast_list_argv():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_list()
     runner.run_json.assert_called_once_with(["v4forecast", "list", "--format", "json"])
 
 
 def test_v4forecast_get_argv():
-    runner = _mock_runner({"forecast_id": 42})
+    runner = mock_runner({"forecast_id": 42})
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_get(forecast_id=42)
     runner.run_json.assert_called_once_with(
@@ -109,7 +97,7 @@ def test_v4forecast_get_argv():
 
 
 def test_v4forecast_delete_argv():
-    runner = _mock_runner({"ok": True})
+    runner = mock_runner({"ok": True})
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_delete(forecast_id=42)
     runner.run_json.assert_called_once_with(
@@ -125,7 +113,7 @@ def test_v4forecast_delete_argv():
 
 
 def test_v4forecast_delete_dry_run():
-    runner = _mock_runner({"_dry_run": True})
+    runner = mock_runner({"_dry_run": True})
     with patch("server.tools.v4forecast.get_runner", return_value=runner):
         v4forecast_delete(forecast_id=42, dry_run=True)
         argv = runner.run_json.call_args[0][0]
@@ -140,7 +128,7 @@ def test_v4forecast_delete_returns_wrapped_scalar():
             "server.cli.runner._resolve_direct_cached",
             return_value="/usr/bin/direct",
         ),
-        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+        patch("server.cli.runner.subprocess.run", return_value=completed("1")),
     ):
         result = v4forecast_delete(forecast_id=42)
     assert result == {"result": 1}

--- a/tests/test_v4wordstat.py
+++ b/tests/test_v4wordstat.py
@@ -1,6 +1,6 @@
 """Tests for v4wordstat MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from server.cli.runner import DirectCliRunner
 from server.tools.v4wordstat import (
@@ -10,23 +10,11 @@ from server.tools.v4wordstat import (
     v4wordstat_list_reports,
 )
 
-
-def _mock_runner(return_value):
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
-def _completed(stdout: str) -> MagicMock:
-    result = MagicMock()
-    result.stdout = stdout
-    result.stderr = ""
-    result.returncode = 0
-    return result
+from tests.helpers import completed, mock_runner
 
 
 def test_v4wordstat_create_report_argv():
-    runner = _mock_runner({"ReportID": 1})
+    runner = mock_runner({"ReportID": 1})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_create_report(
             phrases=" phrase one, phrase two ",
@@ -63,7 +51,7 @@ def test_v4wordstat_create_report_phrase_limit():
 
 
 def test_v4wordstat_create_report_dry_run():
-    runner = _mock_runner({"method": "CreateNewWordstatReport"})
+    runner = mock_runner({"method": "CreateNewWordstatReport"})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_create_report(phrases="phrase", dry_run=True)
     argv = runner.run_json.call_args.args[0]
@@ -80,7 +68,7 @@ def test_v4wordstat_create_report_returns_wrapped_scalar():
         ),
         patch(
             "server.cli.runner.subprocess.run",
-            return_value=_completed("1233756017"),
+            return_value=completed("1233756017"),
         ),
     ):
         result = v4wordstat_create_report(phrases="phrase")
@@ -88,7 +76,7 @@ def test_v4wordstat_create_report_returns_wrapped_scalar():
 
 
 def test_v4wordstat_list_reports_argv():
-    runner = _mock_runner([])
+    runner = mock_runner([])
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_list_reports()
     runner.run_json.assert_called_once_with(
@@ -97,14 +85,14 @@ def test_v4wordstat_list_reports_argv():
 
 
 def test_v4wordstat_list_reports_dry_run():
-    runner = _mock_runner({"method": "GetWordstatReportList"})
+    runner = mock_runner({"method": "GetWordstatReportList"})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_list_reports(dry_run=True)
     assert "--dry-run" in runner.run_json.call_args.args[0]
 
 
 def test_v4wordstat_get_report_argv():
-    runner = _mock_runner({"ReportID": 42})
+    runner = mock_runner({"ReportID": 42})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_get_report(report_id=42)
     runner.run_json.assert_called_once_with(
@@ -120,14 +108,14 @@ def test_v4wordstat_get_report_argv():
 
 
 def test_v4wordstat_get_report_dry_run():
-    runner = _mock_runner({"method": "GetWordstatReport"})
+    runner = mock_runner({"method": "GetWordstatReport"})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_get_report(report_id=42, dry_run=True)
     assert "--dry-run" in runner.run_json.call_args.args[0]
 
 
 def test_v4wordstat_delete_report_argv():
-    runner = _mock_runner({"ok": True})
+    runner = mock_runner({"ok": True})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_delete_report(report_id=42)
     runner.run_json.assert_called_once_with(
@@ -143,7 +131,7 @@ def test_v4wordstat_delete_report_argv():
 
 
 def test_v4wordstat_delete_report_dry_run():
-    runner = _mock_runner({"method": "DeleteWordstatReport"})
+    runner = mock_runner({"method": "DeleteWordstatReport"})
     with patch("server.tools.v4wordstat.get_runner", return_value=runner):
         v4wordstat_delete_report(report_id=42, dry_run=True)
     assert "--dry-run" in runner.run_json.call_args.args[0]
@@ -157,7 +145,7 @@ def test_v4wordstat_delete_report_returns_wrapped_scalar():
             "server.cli.runner._resolve_direct_cached",
             return_value="/usr/bin/direct",
         ),
-        patch("server.cli.runner.subprocess.run", return_value=_completed("1")),
+        patch("server.cli.runner.subprocess.run", return_value=completed("1")),
     ):
         result = v4wordstat_delete_report(report_id=42)
     assert result == {"result": 1}

--- a/tests/test_vcards.py
+++ b/tests/test_vcards.py
@@ -1,10 +1,12 @@
 """Tests for vCards MCP tools."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from server.tools.vcards import vcards_list, vcards_add, vcards_delete
+
+from tests.helpers import mock_runner
 
 
 @pytest.fixture
@@ -26,13 +28,6 @@ def mock_vcards():
     ]
 
 
-def _mock_runner(return_value):
-    """Create a mock get_runner that returns a runner with the given run_json result."""
-    runner = MagicMock()
-    runner.run_json.return_value = return_value
-    return runner
-
-
 class TestVcardsList:
     """Tests for vcards_list tool."""
 
@@ -40,7 +35,7 @@ class TestVcardsList:
         """Test listing vCards successfully."""
         with patch(
             "server.tools.vcards.get_runner",
-            return_value=_mock_runner(mock_vcards),
+            return_value=mock_runner(mock_vcards),
         ):
             result = vcards_list(ids="1,2")
             assert len(result) == 2
@@ -50,7 +45,7 @@ class TestVcardsList:
         """Test listing all vCards with no IDs."""
         with patch(
             "server.tools.vcards.get_runner",
-            return_value=_mock_runner(mock_vcards),
+            return_value=mock_runner(mock_vcards),
         ):
             result = vcards_list()
             assert len(result) == 2
@@ -64,8 +59,7 @@ class TestVcardsList:
 
     def test_list_vcards_trims_ids_before_cli(self, mock_vcards):
         """Test vCard IDs are normalized before argv construction."""
-        runner = MagicMock()
-        runner.run_json.return_value = mock_vcards
+        runner = mock_runner(mock_vcards)
         with patch("server.tools.vcards.get_runner", return_value=runner):
             vcards_list(ids=" 1,2 ")
 
@@ -80,8 +74,7 @@ class TestVcardsAdd:
     def test_add_vcard_required_fields(self):
         """Test adding vCard with all required typed flags."""
         mock_result = {"Id": 123}
-        runner = MagicMock()
-        runner.run_json.return_value = mock_result
+        runner = mock_runner(mock_result)
 
         with patch("server.tools.vcards.get_runner", return_value=runner):
             result = vcards_add(
@@ -101,8 +94,7 @@ class TestVcardsAdd:
             assert "--phone-number" in argv
 
     def test_add_vcard_optional_fields(self):
-        runner = MagicMock()
-        runner.run_json.return_value = {"Id": 124}
+        runner = mock_runner({"Id": 124})
         with patch("server.tools.vcards.get_runner", return_value=runner):
             vcards_add(
                 campaign_id=42,
@@ -134,7 +126,7 @@ class TestVcardsDelete:
 
         with patch(
             "server.tools.vcards.get_runner",
-            return_value=_mock_runner(mock_result),
+            return_value=mock_runner(mock_result),
         ):
             result = vcards_delete(ids="1")
             assert result["success"] is True


### PR DESCRIPTION
## Summary

Refactor-only change (no behavior change) that consolidates repeated patterns into shared helpers across MCP tool modules and the test suite. Audited file-by-file: CLI args emitted to `direct`, MCP error payloads, validation bounds, and guard ordering are all preserved.

### Tool helpers (`server/tools/helpers.py`)
- New `run_set_bids` — shared scope/update guards + flag emit for `*targets` `set-bids`. Wired into `audiencetargets`, `smartadtargets`, `dynamicads`, `dynamicfeedadtargets`. Guard order (scope → update) and per-module messages preserved verbatim.
- New `normalize_optional_str`, `normalize_str_list`, `finalize_json_args`; adopted in the v4 modules; removed local `_check_batch_limit` / `_parse_ids` / `_normalize_*` duplicates.
- `run_set_bids` error serialization aligned on `tool_error_dict()` (= `dataclasses.asdict`) to match its sibling `run_single_id_batch`. For `ToolError` this yields a byte-identical payload to the prior `.__dict__`, so the MCP client response is unchanged.

### Also refactored: `server/tools/v4tags.py`
- Local `_normalize_optional` / `_normalize_tags` replaced with `normalize_optional_str` / `normalize_str_list`; inline dry-run/format emit replaced with `finalize_json_args`. Tag guards, batch limits (10/2000/30), and flag emission are untouched. (This is a production change too — calling it out explicitly; the earlier description listed v4tags only under tests.)

### Test helpers (`tests/helpers.py`)
- New `completed()` (real `subprocess.CompletedProcess`) / `mock_runner()` (sets `run_json.return_value` plus an inert `run_checked.return_value`).
- Migrated inline `runner = MagicMock(); runner.run_json.return_value = X` blocks to `runner = mock_runner(X)` across the test suite; dropped now-unused `MagicMock` imports where the symbol became unused (it is intentionally kept where `side_effect` mocks still need it).
- `side_effect`-based mocks deliberately left untouched (different semantics).
- `tests/test_tool_helpers.py`: the two near-identical batch-limit tests (`test_ads_*` / `test_keywords_*`) were merged into one `test_batch_limit_*`, since the per-module `_check_batch_limit` functions were physically removed in favour of the shared `helpers.check_batch_limit`. Net −1 test; the same ≤10-ok / 11-rejected assertions remain, and per-module wiring stays covered by call-site tests.

### Net
`+732 / -1149` (GitHub diffstat) — duplication removed, no API surface change. `contract.py`, `main.py`, `runner.py`, and the plugin manifest/config are untouched; the 145-tool surface is unchanged.

## Verification
- `ruff check` ✅ · `ruff format --check` ✅ · `mypy server/tools/helpers.py` ✅
- `pytest` ✅ **694 passed, 7 skipped** · CI green on 3.11 / 3.12 / 3.13
- No CLI bypass introduced (no `urllib`/`requests`/`http`/`tapi` added); transport boundary (`direct` CLI) intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
