### PR TITLE
perf: progressive disclosure of tool descriptions (−25% tool-spec tokens)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "yandex-direct",
-      "version": "0.2.4.3",
+      "version": "0.3.0",
       "source": {
         "source": "local",
         "path": "./plugins/yandex-direct"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.4.3",
+  "version": "0.3.0",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ yandex-direct-mcp-plugin/
 └── .github/workflows/           # CI/CD pipelines
 ```
 
-## MCP Tools (145 total) + 1 Prompt
+## MCP Tools (146 total) + 1 Prompt
 
 The canonical source of truth for tool names is `server/contract.py`.
 Naming follows `service_method` from `tapi-yandex-direct`/`direct-cli`;
@@ -344,7 +344,7 @@ These are public but explicitly not 1:1 Direct API methods.
 | `dictionaries_list_names` | List available dictionary names |
 | `reports_list_types` | List available report types |
 
-### Plugin tools (3)
+### Plugin tools (4)
 
 Auth/utility tools unrelated to Direct API parity.
 
@@ -353,6 +353,7 @@ Auth/utility tools unrelated to Direct API parity.
 | `auth_status` | Check direct auth profile status |
 | `auth_setup` | Submit authorization code or direct token |
 | `auth_login` | Interactive OAuth flow with elicitation |
+| `tool_help` | Return the full docstring (parameters, examples, constraints) for any tool on demand. Every tool exposes only a one-line description to keep startup context small; call `tool_help('<name>')` before using an unfamiliar tool. Omit the name to list all tools. |
 
 | Prompt | Purpose |
 |---|---|
@@ -388,6 +389,31 @@ New tools added in v2 (`advideos_*`, `bids_set_auto`, `keywordbids_set_auto`, `r
 - CLI binary: `direct` (installed via `pip install direct-cli`). Minimum required: `direct-cli>=0.4.1`.
 - `reports_custom(goal_ids=...)` adds per-goal output columns: `Conversions_<goal_id>_<attribution>` and same for `CostPerConversion`. Default attribution code is `LSC`.
 - Language: project docs in Russian, code identifiers in English
+
+## Breaking Changes (0.3.0 — progressive disclosure of tool descriptions)
+
+- **Tools now expose a one-line `description`; full docs moved to `tool_help`.**
+  Previously every tool's entire docstring (parameter reference, examples,
+  constraints) was sent to the model as the tool `description` on every request
+  — ~16.6k tokens of the plugin's tool-spec budget. Now each `@mcp.tool(...)`
+  carries a short English `description=` (what it does + when to pick it over a
+  sibling), and the full docstring is served on demand by a new meta-tool
+  `tool_help('<name>')`. The function docstrings themselves are unchanged — they
+  are simply no longer broadcast at startup.
+
+- **Measured effect** (`python -m tests.measure_tool_tokens`, tiktoken
+  cl100k_base): tool-spec budget **54,457 → 40,792 tokens (−25%)**; the
+  descriptions portion **16,582 → 4,522 (−73%)**. JSON-Schema of parameters is
+  untouched (that is a separate, riskier task — see issue #154 / Epic #149).
+
+- **No API break.** Tool names, parameters and behavior are identical. The only
+  surface change is what the model sees: short summaries instead of full docs.
+  A client that relied on reading the long `description` text must now call
+  `tool_help`.
+
+- **Tool count 145 → 146.** One new plugin tool `tool_help`. Registered in
+  `server/contract.py` (`PLUGIN_TOOL_NAMES`), `server/main.py`, the bundled
+  `plugins/yandex-direct/server/main.py`, `CLAUDE.md`, and `README.md`.
 
 ## Breaking Changes (CLI 0.4.1 alignment)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ direct auth login --client-id "ваш-client-id" --client-secret "ваш-client-
 Это удобство уровня CLI: плагин использует значение по умолчанию и не
 пробрасывает флаг, поэтому на работу MCP-инструментов он не влияет.
 
-## MCP contract (145 tools)
+## MCP contract (146 tools)
 
 The public contract is now defined as:
 
@@ -171,7 +171,7 @@ The machine-readable parity source lives in
 |---|---|---|
 | Direct API tools | `campaigns_get`, `advideos_add`, `dictionaries_get_geo_regions`, `dynamicads_set_bids`, `balance_get`, `v4goals_get_stat_goals`, `v4tags_get_campaigns` | Canonical CLI-mediated Direct contract |
 | CLI helper tools | `agencyclients_delete`, `dictionaries_list_names`, `reports_list_types` | Public, but explicitly not 1:1 Direct API methods |
-| Plugin tools | `auth_status`, `auth_setup`, `auth_login` | Plugin-only auth flows, not Direct operations |
+| Plugin tools | `auth_status`, `auth_setup`, `auth_login`, `tool_help` | Plugin-only utilities, not Direct operations. `tool_help('<name>')` returns a tool's full docs on demand — tools expose only a one-line description to keep startup context small |
 
 ### Breaking-change migration highlights
 

--- a/plugins/yandex-direct/.codex-plugin/plugin.json
+++ b/plugins/yandex-direct/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-direct",
-  "version": "0.2.4.3",
+  "version": "0.3.0",
   "description": "Управление Яндекс.Директ: кампании, объявления, ставки, OAuth",
   "author": {
     "name": "axisrow",

--- a/plugins/yandex-direct/server/main.py
+++ b/plugins/yandex-direct/server/main.py
@@ -43,6 +43,7 @@ import server.tools.retargeting  # noqa: E402, F401
 import server.tools.sitelinks  # noqa: E402, F401
 import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.strategies  # noqa: E402, F401
+import server.tools.tool_help  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
 import server.tools.v4account  # noqa: E402, F401
 import server.tools.v4adimage  # noqa: E402, F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "yandex-direct-mcp-plugin"
 version = "0.3.0"
 requires-python = ">=3.11"
-dependencies = ["mcp", "direct-cli>=0.4.1"]
+# mcp lower bound matches the version whose internal API (_tool_manager,
+# _tools, Tool.fn) tool_help relies on; capped below the next major so a
+# breaking rename can't slip in via an unattended upgrade.
+dependencies = ["mcp>=1.23.3,<2", "direct-cli>=0.4.1"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff", "mypy", "pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yandex-direct-mcp-plugin"
-version = "0.2.4.3"
+version = "0.3.0"
 requires-python = ">=3.11"
 dependencies = ["mcp", "direct-cli>=0.4.1"]
 

--- a/server/contract.py
+++ b/server/contract.py
@@ -530,7 +530,10 @@ V4_LIVE_BLOCKED_METHODS: tuple[BlockedV4Method, ...] = (
     ),
 )
 
-PLUGIN_TOOL_NAMES = ("auth_status", "auth_setup", "auth_login")
+# ``tool_help`` is a meta-tool: it serves the full docstring of any tool on
+# demand so the other tools can expose only a short one-line description and
+# keep the startup context small (progressive disclosure).
+PLUGIN_TOOL_NAMES = ("auth_status", "auth_setup", "auth_login", "tool_help")
 
 # Operations that exist in the WSDL/tapi surface but cannot be exposed
 # in MCP because `direct` has no matching transport subcommand.

--- a/server/contract.py
+++ b/server/contract.py
@@ -3,8 +3,8 @@
 Tool count (derived from the structures below):
 - Direct API tools: 139
 - CLI helper tools:   3
-- Plugin tools:       3
-Total:              145
+- Plugin tools:       4
+Total:              146
 """
 
 from __future__ import annotations

--- a/server/main.py
+++ b/server/main.py
@@ -43,6 +43,7 @@ import server.tools.retargeting  # noqa: E402, F401
 import server.tools.sitelinks  # noqa: E402, F401
 import server.tools.smart_ad_targets  # noqa: E402, F401
 import server.tools.strategies  # noqa: E402, F401
+import server.tools.tool_help  # noqa: E402, F401
 import server.tools.turbo_pages  # noqa: E402, F401
 import server.tools.v4account  # noqa: E402, F401
 import server.tools.v4adimage  # noqa: E402, F401

--- a/server/tools/adextensions.py
+++ b/server/tools/adextensions.py
@@ -5,7 +5,10 @@ from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_single_id_batch
 
 
-@mcp.tool(name="adextensions_get")
+@mcp.tool(
+    name="adextensions_get",
+    description="List ad extensions (callouts/clarifications shown with ads), optionally filtered by IDs/types/states. Use adextensions_add to create, adextensions_delete to remove. Call tool_help('adextensions_get') for parameters.",
+)
 @handle_cli_errors
 def adextensions_list(
     ids: str | None = None,
@@ -58,7 +61,9 @@ def adextensions_list(
     return get_runner().run_json(cmd)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add an ad extension (callout type only; for sitelinks use sitelinks_add). Use adextensions_get to list existing extensions. Call tool_help('adextensions_add') for parameters.",
+)
 @handle_cli_errors
 def adextensions_add(callout_text: str, dry_run: bool = False) -> dict:
     """Add an ad extension (callout).
@@ -76,7 +81,9 @@ def adextensions_add(callout_text: str, dry_run: bool = False) -> dict:
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete ad extensions by ID (max 10 per call). Use adextensions_get to find IDs. Call tool_help('adextensions_delete') for parameters.",
+)
 @handle_cli_errors
 def adextensions_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete ad extensions.

--- a/server/tools/adgroups.py
+++ b/server/tools/adgroups.py
@@ -45,7 +45,10 @@ ADGROUP_EXTRA_OPTIONS = (
 )
 
 
-@mcp.tool(name="adgroups_get")
+@mcp.tool(
+    name="adgroups_get",
+    description="List ad groups filtered by campaign or ad group IDs, plus optional status/type filters. Read-only; use adgroups_add to create or adgroups_update to modify. Call tool_help('adgroups_get') for parameters.",
+)
 @handle_cli_errors
 def adgroups_list(
     campaign_ids: str | None = None,
@@ -121,7 +124,9 @@ def adgroups_list(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Create a new ad group within a campaign (sets type, regions, targeting). Use adgroups_update to change an existing group instead. Call tool_help('adgroups_add') for parameters.",
+)
 @handle_cli_errors
 def adgroups_add(
     campaign_id: int,
@@ -206,7 +211,9 @@ def adgroups_add(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update fields of an existing ad group identified by id (name, status, regions, targeting). Use adgroups_add to create a new group instead. Call tool_help('adgroups_update') for parameters.",
+)
 @handle_cli_errors
 def adgroups_update(
     id: int,
@@ -284,7 +291,9 @@ def adgroups_update(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Permanently delete ad groups by ID (max 10). Call tool_help('adgroups_delete') for parameters.",
+)
 @handle_cli_errors
 def adgroups_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete ad groups.

--- a/server/tools/ads.py
+++ b/server/tools/ads.py
@@ -62,7 +62,10 @@ ADS_UPDATE_EXTRA_OPTIONS = (
 )
 
 
-@mcp.tool(name="ads_get")
+@mcp.tool(
+    name="ads_get",
+    description="List ads filtered by campaign, ad group, or ad IDs, plus optional status/type filters. Read-only; use ads_add to create or ads_update to modify. Call tool_help('ads_get') for parameters.",
+)
 @handle_cli_errors
 def ads_list(
     campaign_ids: str | None = None,
@@ -171,7 +174,9 @@ def ads_list(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Create a new ad in an ad group (TEXT_AD, TEXT_IMAGE_AD, MOBILE_APP_AD, etc.). Use ads_update to change an existing ad instead. Call tool_help('ads_add') for parameters.",
+)
 @handle_cli_errors
 def ads_add(
     ad_group_id: int,
@@ -288,7 +293,9 @@ def ads_add(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update fields of an existing ad identified by id (title, text, href, extensions, status, etc.). Use ads_add to create a new ad instead. Call tool_help('ads_update') for parameters.",
+)
 @handle_cli_errors
 def ads_update(
     id: int,
@@ -483,7 +490,9 @@ def ads_update(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Permanently delete ads by ID (max 10). Call tool_help('ads_delete') for parameters.",
+)
 @handle_cli_errors
 def ads_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete ads.
@@ -496,7 +505,9 @@ def ads_delete(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "ads", "delete", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Submit ads for moderation by ID (max 10). Call tool_help('ads_moderate') for parameters.",
+)
 @handle_cli_errors
 def ads_moderate(ids: str, dry_run: bool = False) -> dict:
     """Submit ads for moderation.
@@ -509,7 +520,9 @@ def ads_moderate(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "ads", "moderate", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Suspend (pause) serving ads by ID (max 10); reverse with ads_resume. Call tool_help('ads_suspend') for parameters.",
+)
 @handle_cli_errors
 def ads_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend ads.
@@ -522,7 +535,9 @@ def ads_suspend(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "ads", "suspend", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Resume previously suspended ads by ID (max 10). Call tool_help('ads_resume') for parameters.",
+)
 @handle_cli_errors
 def ads_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume suspended ads.
@@ -535,7 +550,9 @@ def ads_resume(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "ads", "resume", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Archive ads by ID (max 10); reverse with ads_unarchive. Call tool_help('ads_archive') for parameters.",
+)
 @handle_cli_errors
 def ads_archive(ids: str, dry_run: bool = False) -> dict:
     """Archive ads.
@@ -548,7 +565,9 @@ def ads_archive(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "ads", "archive", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Unarchive previously archived ads by ID (max 10). Call tool_help('ads_unarchive') for parameters.",
+)
 @handle_cli_errors
 def ads_unarchive(ids: str, dry_run: bool = False) -> dict:
     """Unarchive ads.

--- a/server/tools/advideos.py
+++ b/server/tools/advideos.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="advideos_get")
+@mcp.tool(
+    name="advideos_get",
+    description="Get ad videos (video assets used in video/multimedia ads) by required IDs. Use advideos_add to upload a new video. Call tool_help('advideos_get') for parameters.",
+)
 @handle_cli_errors
 def advideos_get(
     ids: str,
@@ -39,7 +42,10 @@ def advideos_get(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="advideos_add")
+@mcp.tool(
+    name="advideos_add",
+    description="Add an ad video from a URL, base64 data, or local file (exactly one source). Use advideos_get to list existing videos. Call tool_help('advideos_add') for parameters.",
+)
 @handle_cli_errors
 def advideos_add(
     url: str | None = None,

--- a/server/tools/agency.py
+++ b/server/tools/agency.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="agencyclients_get")
+@mcp.tool(
+    name="agencyclients_get",
+    description="List agency clients, optionally filtered by logins or archived state. Call tool_help('agencyclients_get') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_list(
     logins: str | None = None,
@@ -48,7 +51,10 @@ def agency_clients_list(
     return runner.run_json(cmd)
 
 
-@mcp.tool(name="agencyclients_add")
+@mcp.tool(
+    name="agencyclients_add",
+    description="Add a new client to the agency (mirrors WSDL ClientAddItem); use agencyclients_add_passport_organization for a Passport-backed client. Call tool_help('agencyclients_add') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_add(
     login: str,
@@ -103,7 +109,10 @@ def agency_clients_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="agencyclients_delete")
+@mcp.tool(
+    name="agencyclients_delete",
+    description="Remove a client from the agency (no real Direct API backing; kept for completeness). Call tool_help('agencyclients_delete') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_delete(id: int) -> dict:
     """Remove a client from an agency.
@@ -119,7 +128,10 @@ def agency_clients_delete(id: int) -> dict:
     return result
 
 
-@mcp.tool(name="agencyclients_update")
+@mcp.tool(
+    name="agencyclients_update",
+    description="Update an agency client's settings, contacts and grants (mirrors WSDL ClientUpdateItem). Call tool_help('agencyclients_update') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_update(
     client_id: int,
@@ -213,7 +225,10 @@ def agency_clients_update(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="agencyclients_add_passport_organization")
+@mcp.tool(
+    name="agencyclients_add_passport_organization",
+    description="Add a new agency client backed by a Passport organization; use agencyclients_add for a regular client. Call tool_help('agencyclients_add_passport_organization') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_add_passport_organization(
     name: str,
@@ -260,7 +275,10 @@ def agency_clients_add_passport_organization(
     return runner.run_json(args)
 
 
-@mcp.tool(name="agencyclients_add_passport_organization_member")
+@mcp.tool(
+    name="agencyclients_add_passport_organization_member",
+    description="Invite a user to a Passport organization client account. Call tool_help('agencyclients_add_passport_organization_member') for parameters.",
+)
 @handle_cli_errors
 def agency_clients_add_passport_organization_member(
     passport_organization_login: str,

--- a/server/tools/audience.py
+++ b/server/tools/audience.py
@@ -5,7 +5,10 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_set_bids, run_single_id_batch
 
 
-@mcp.tool(name="audiencetargets_get")
+@mcp.tool(
+    name="audiencetargets_get",
+    description="List audience targets (retargeting lists / interests linked to ad groups). Call tool_help('audiencetargets_get') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_list(
     campaign_ids: str | None = None,
@@ -67,7 +70,10 @@ def audience_targets_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="audiencetargets_add")
+@mcp.tool(
+    name="audiencetargets_add",
+    description="Attach an audience target (retargeting list or interest) to an ad group. Call tool_help('audiencetargets_add') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_add(
     ad_group_id: int,
@@ -121,7 +127,10 @@ def audience_targets_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="audiencetargets_delete")
+@mcp.tool(
+    name="audiencetargets_delete",
+    description="Delete audience targets by ID. Call tool_help('audiencetargets_delete') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete audience targets.
@@ -134,7 +143,10 @@ def audience_targets_delete(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="audiencetargets_suspend")
+@mcp.tool(
+    name="audiencetargets_suspend",
+    description="Pause audience targets by ID. Call tool_help('audiencetargets_suspend') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend audience targets.
@@ -147,7 +159,10 @@ def audience_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="audiencetargets_resume")
+@mcp.tool(
+    name="audiencetargets_resume",
+    description="Resume previously suspended audience targets by ID. Call tool_help('audiencetargets_resume') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume suspended audience targets.
@@ -160,7 +175,10 @@ def audience_targets_resume(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="audiencetargets_set_bids")
+@mcp.tool(
+    name="audiencetargets_set_bids",
+    description="Set context bids / priority for audience targets. Call tool_help('audiencetargets_set_bids') for parameters.",
+)
 @handle_cli_errors
 def audience_targets_set_bids(
     id: int | None = None,

--- a/server/tools/auth_tools.py
+++ b/server/tools/auth_tools.py
@@ -240,13 +240,17 @@ def _complete_login_with_code(profile: str, code: str) -> dict:
 # --- MCP Tools ---
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Check the current direct auth profile status (token presence, login, expiry). Call tool_help('auth_status') for parameters.",
+)
 def auth_status(profile: str | None = None) -> dict:
     """Check the current direct auth profile status."""
     return _status_from_cli(profile)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Save a ready-made direct OAuth token (y0_...) into a direct auth profile; use auth_login for the interactive browser flow. Call tool_help('auth_setup') for parameters.",
+)
 def auth_setup(code: str, login: str | None = None, profile: str = "default") -> dict:
     """Save a direct OAuth token into a direct auth profile.
 
@@ -295,7 +299,9 @@ class AuthCredential(BaseModel):
     value: str = Field(description="Код авторизации с сайта Яндекса")
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Start interactive OAuth login through direct (elicits the authorization code); use auth_setup if you already have a y0_ token. Call tool_help('auth_login') for parameters.",
+)
 async def auth_login(
     ctx: Context,
     login: str | None = None,

--- a/server/tools/balance.py
+++ b/server/tools/balance.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
 
-@mcp.tool(name="balance_get")
+@mcp.tool(
+    name="balance_get",
+    description="Read account money balance via the v4 Live AccountManagement method (read-only finance query). Call tool_help('balance_get') for parameters.",
+)
 @handle_cli_errors
 def balance_get(logins: str | None = None) -> dict | list[dict]:
     """Get account money balance via the v4 Live AccountManagement method.

--- a/server/tools/bidmodifiers.py
+++ b/server/tools/bidmodifiers.py
@@ -23,7 +23,10 @@ _BIDMOD_TYPES = (
 )
 
 
-@mcp.tool(name="bidmodifiers_get")
+@mcp.tool(
+    name="bidmodifiers_get",
+    description="List bid modifiers (percentage adjustments by device, demographics, region, etc.). Call tool_help('bidmodifiers_get') for parameters.",
+)
 @handle_cli_errors
 def bidmodifiers_list(
     ids: str | None = None,
@@ -85,7 +88,10 @@ def bidmodifiers_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="bidmodifiers_set")
+@mcp.tool(
+    name="bidmodifiers_set",
+    description="Update the percentage of an existing bid modifier by ID; use bidmodifiers_add to create one, and bids_set/keywordbids_set for actual bid amounts. Call tool_help('bidmodifiers_set') for parameters.",
+)
 @handle_cli_errors
 def bidmodifiers_set(
     id: int,
@@ -116,7 +122,10 @@ def bidmodifiers_set(
     return runner.run_json(args)
 
 
-@mcp.tool(name="bidmodifiers_delete")
+@mcp.tool(
+    name="bidmodifiers_delete",
+    description="Delete bid modifiers by ID. Call tool_help('bidmodifiers_delete') for parameters.",
+)
 @handle_cli_errors
 def bidmodifiers_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete bid modifiers.
@@ -131,7 +140,10 @@ def bidmodifiers_delete(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="bidmodifiers_add")
+@mcp.tool(
+    name="bidmodifiers_add",
+    description="Create a new bid modifier (percentage adjustment) on a campaign or ad group; use bidmodifiers_set to change an existing one. Call tool_help('bidmodifiers_add') for parameters.",
+)
 @handle_cli_errors
 def bidmodifiers_add(
     modifier_type: str,

--- a/server/tools/bids.py
+++ b/server/tools/bids.py
@@ -5,7 +5,10 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit
 
 
-@mcp.tool(name="bids_get")
+@mcp.tool(
+    name="bids_get",
+    description="List bids at the campaign/ad-group/keyword level. Call tool_help('bids_get') for parameters.",
+)
 @handle_cli_errors
 def bids_list(
     campaign_ids: str | None = None,
@@ -59,7 +62,10 @@ def bids_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="bids_set")
+@mcp.tool(
+    name="bids_set",
+    description="Set fixed bids scoped to a campaign, ad group, or keyword; for keyword-only bids prefer keywordbids_set, and for adjustments use bidmodifiers_set. Call tool_help('bids_set') for parameters.",
+)
 @handle_cli_errors
 def bids_set(
     keyword_id: int | None = None,
@@ -132,7 +138,10 @@ def bids_set(
     return runner.run_json(args)
 
 
-@mcp.tool(name="bids_set_auto")
+@mcp.tool(
+    name="bids_set_auto",
+    description="Switch campaign/ad-group/keyword bids to an automatic bidding strategy. Call tool_help('bids_set_auto') for parameters.",
+)
 @handle_cli_errors
 def bids_set_auto(
     campaign_id: int | None = None,

--- a/server/tools/businesses.py
+++ b/server/tools/businesses.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
 
-@mcp.tool(name="businesses_get")
+@mcp.tool(
+    name="businesses_get",
+    description="List Yandex.Business profiles (organizations) for the account. Call tool_help('businesses_get') for parameters.",
+)
 @handle_cli_errors
 def businesses_list(
     ids: str | None = None,

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -405,7 +405,10 @@ CAMPAIGN_UPDATE_ONLY_OPTIONS = (
 )
 
 
-@mcp.tool(name="campaigns_get")
+@mcp.tool(
+    name="campaigns_get",
+    description="List advertising campaigns, with optional state/status/type/ID filters. Read-only; use campaigns_add to create or campaigns_update to modify. Call tool_help('campaigns_get') for parameters.",
+)
 @handle_cli_errors
 def campaigns_list(
     state: str | None = None,
@@ -497,7 +500,9 @@ def campaigns_list(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update fields of an existing campaign identified by id (name, budget, status, bidding strategy, etc.). Use campaigns_add to create a new campaign instead. Call tool_help('campaigns_update') for parameters.",
+)
 @handle_cli_errors
 def campaigns_update(
     id: int,
@@ -837,7 +842,9 @@ def campaigns_update(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Create a new advertising campaign of any type (Text/Dynamic/Smart/Unified/MobileApp/Cpm). Use campaigns_update to change an existing campaign instead. Call tool_help('campaigns_add') for parameters.",
+)
 @handle_cli_errors
 def campaigns_add(
     name: str,
@@ -1198,7 +1205,9 @@ def campaigns_add(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Permanently delete campaigns by ID (max 10). Call tool_help('campaigns_delete') for parameters.",
+)
 @handle_cli_errors
 def campaigns_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete campaigns.
@@ -1213,7 +1222,9 @@ def campaigns_delete(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Archive campaigns by ID (max 10); reverse with campaigns_unarchive. Call tool_help('campaigns_archive') for parameters.",
+)
 @handle_cli_errors
 def campaigns_archive(ids: str, dry_run: bool = False) -> dict:
     """Archive campaigns.
@@ -1228,7 +1239,9 @@ def campaigns_archive(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Unarchive previously archived campaigns by ID (max 10). Call tool_help('campaigns_unarchive') for parameters.",
+)
 @handle_cli_errors
 def campaigns_unarchive(ids: str, dry_run: bool = False) -> dict:
     """Unarchive campaigns.
@@ -1243,7 +1256,9 @@ def campaigns_unarchive(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Suspend (pause) running campaigns by ID (max 10); reverse with campaigns_resume. Call tool_help('campaigns_suspend') for parameters.",
+)
 @handle_cli_errors
 def campaigns_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend campaigns.
@@ -1258,7 +1273,9 @@ def campaigns_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Resume previously suspended campaigns by ID (max 10). Call tool_help('campaigns_resume') for parameters.",
+)
 @handle_cli_errors
 def campaigns_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume suspended campaigns.

--- a/server/tools/changes.py
+++ b/server/tools/changes.py
@@ -48,7 +48,9 @@ def _validate_field_names(field_names: str) -> ToolError | None:
     return None
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Check what changed since a timestamp within specific objects, filtered by exactly one of campaign_ids / ad_group_ids / ad_ids. Use this for targeted checks; use changes_check_campaigns for an account-wide campaign-level scan. Call tool_help('changes_check') for parameters.",
+)
 @handle_cli_errors
 def changes_check(
     timestamp: str,
@@ -138,7 +140,10 @@ def changes_check(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="changes_check_campaigns")
+@mcp.tool(
+    name="changes_check_campaigns",
+    description="Check account-wide campaign-level changes since a timestamp (which campaigns changed). Use this for a broad scan; use changes_check to drill into specific campaign/ad-group/ad IDs. Call tool_help('changes_check_campaigns') for parameters.",
+)
 @handle_cli_errors
 def changes_checkcamp(timestamp: str) -> dict:
     """Check account-wide campaign changes since ``timestamp``.
@@ -162,7 +167,10 @@ def changes_checkcamp(timestamp: str) -> dict:
     )
 
 
-@mcp.tool(name="changes_check_dictionaries")
+@mcp.tool(
+    name="changes_check_dictionaries",
+    description="Check whether Yandex.Direct reference dictionaries (e.g. regions) have changed; takes no parameters. Call tool_help('changes_check_dictionaries') for parameters.",
+)
 @handle_cli_errors
 def changes_checkdict() -> dict:
     """Check dictionary changes.

--- a/server/tools/clients.py
+++ b/server/tools/clients.py
@@ -33,7 +33,9 @@ ERIR_OPTIONS = (
 )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Get information about clients by IDs (the authenticated account or its sub-clients). Call tool_help('clients_get') for parameters.",
+)
 @handle_cli_errors
 def clients_get(
     ids: str | None = None,
@@ -62,7 +64,9 @@ def clients_get(
     return get_runner().run_json(cmd)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update the authenticated client's settings and ERIR organization/contract/contragent fields. Call tool_help('clients_update') for parameters.",
+)
 @handle_cli_errors
 def clients_update(
     client_info: str | None = None,

--- a/server/tools/creatives.py
+++ b/server/tools/creatives.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
 
-@mcp.tool(name="creatives_get")
+@mcp.tool(
+    name="creatives_get",
+    description="List creatives (rich media/video creatives built in Constructor), optionally filtered by IDs/types. Use creatives_add to create one. Call tool_help('creatives_get') for parameters.",
+)
 @handle_cli_errors
 def creatives_list(
     ids: str | None = None,
@@ -41,7 +44,10 @@ def creatives_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="creatives_add")
+@mcp.tool(
+    name="creatives_add",
+    description="Add a video-extension creative from a video ID. Use creatives_get to list existing creatives. Call tool_help('creatives_add') for parameters.",
+)
 @handle_cli_errors
 def creatives_add(video_id: str, dry_run: bool = False) -> dict:
     """Add a creative.

--- a/server/tools/dictionaries.py
+++ b/server/tools/dictionaries.py
@@ -17,7 +17,9 @@ ALLOWED_DICTIONARY_NAMES = (
 )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Get reference dictionary data by names (Currencies, GeoRegions, TimeZones, etc.); use dictionaries_list_names to see options. Call tool_help('dictionaries_get') for parameters.",
+)
 @handle_cli_errors
 def dictionaries_get(names: str) -> dict:
     """Get dictionary data.
@@ -35,14 +37,19 @@ def dictionaries_get(names: str) -> dict:
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    description="List the dictionary names accepted by dictionaries_get. Call tool_help('dictionaries_list_names') for parameters.",
+)
 @handle_cli_errors
 def dictionaries_list_names() -> list[str]:
     """List available dictionary names."""
     return list(ALLOWED_DICTIONARY_NAMES)
 
 
-@mcp.tool(name="dictionaries_get_geo_regions")
+@mcp.tool(
+    name="dictionaries_get_geo_regions",
+    description="Get GeoRegions dictionary entries, optionally filtered by name or region IDs. Call tool_help('dictionaries_get_geo_regions') for parameters.",
+)
 @handle_cli_errors
 def dictionaries_get_geo_regions(
     fields: str,

--- a/server/tools/dynamic_ads.py
+++ b/server/tools/dynamic_ads.py
@@ -5,7 +5,10 @@ from server.tools import get_runner, handle_cli_errors
 from server.tools.helpers import run_set_bids, run_single_id_batch
 
 
-@mcp.tool(name="dynamicads_get")
+@mcp.tool(
+    name="dynamicads_get",
+    description="List dynamic ad targets (website-based webpage filters for dynamic text ads). Call tool_help('dynamicads_get') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_list(
     ids: str | None = None,
@@ -51,7 +54,10 @@ def dynamic_ads_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="dynamicads_add")
+@mcp.tool(
+    name="dynamicads_add",
+    description="Create a dynamic ad target (webpage filter) for dynamic text ads. Call tool_help('dynamicads_add') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_add(
     ad_group_id: int,
@@ -98,7 +104,10 @@ def dynamic_ads_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="dynamicads_delete")
+@mcp.tool(
+    name="dynamicads_delete",
+    description="Delete a dynamic ad target (webpage filter) by ID. Call tool_help('dynamicads_delete') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_delete(id: int, dry_run: bool = False) -> dict:
     """Delete a dynamic ad target (webpage).
@@ -113,7 +122,10 @@ def dynamic_ads_delete(id: int, dry_run: bool = False) -> dict:
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="dynamicads_suspend")
+@mcp.tool(
+    name="dynamicads_suspend",
+    description="Pause dynamic ad targets by ID. Call tool_help('dynamicads_suspend') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend dynamic ad targets."""
@@ -122,7 +134,10 @@ def dynamic_ads_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="dynamicads_resume")
+@mcp.tool(
+    name="dynamicads_resume",
+    description="Resume suspended dynamic ad targets by ID. Call tool_help('dynamicads_resume') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume dynamic ad targets."""
@@ -131,7 +146,10 @@ def dynamic_ads_resume(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="dynamicads_set_bids")
+@mcp.tool(
+    name="dynamicads_set_bids",
+    description="Set search/context bids or priority for dynamic ad targets. Call tool_help('dynamicads_set_bids') for parameters.",
+)
 @handle_cli_errors
 def dynamic_ads_set_bids(
     id: int | None = None,

--- a/server/tools/dynamic_feed_ad_targets.py
+++ b/server/tools/dynamic_feed_ad_targets.py
@@ -5,7 +5,10 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import check_batch_limit, run_set_bids, run_single_id_batch
 
 
-@mcp.tool(name="dynamicfeedadtargets_get")
+@mcp.tool(
+    name="dynamicfeedadtargets_get",
+    description="List dynamic feed ad targets (filters over product-feed items for dynamic ads). Call tool_help('dynamicfeedadtargets_get') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_list(
     ids: str | None = None,
@@ -58,7 +61,10 @@ def dynamic_feed_ad_targets_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="dynamicfeedadtargets_add")
+@mcp.tool(
+    name="dynamicfeedadtargets_add",
+    description="Create a dynamic feed ad target (filter over product-feed items). Call tool_help('dynamicfeedadtargets_add') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_add(
     ad_group_id: int,
@@ -118,7 +124,10 @@ def dynamic_feed_ad_targets_add(
     return runner.run_json(args)
 
 
-@mcp.tool(name="dynamicfeedadtargets_delete")
+@mcp.tool(
+    name="dynamicfeedadtargets_delete",
+    description="Delete a dynamic feed ad target by ID. Call tool_help('dynamicfeedadtargets_delete') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_delete(id: int, dry_run: bool = False) -> dict:
     """Delete a dynamic feed ad target.
@@ -133,7 +142,10 @@ def dynamic_feed_ad_targets_delete(id: int, dry_run: bool = False) -> dict:
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="dynamicfeedadtargets_suspend")
+@mcp.tool(
+    name="dynamicfeedadtargets_suspend",
+    description="Pause dynamic feed ad targets by ID. Call tool_help('dynamicfeedadtargets_suspend') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend dynamic feed ad targets.
@@ -146,7 +158,10 @@ def dynamic_feed_ad_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="dynamicfeedadtargets_resume")
+@mcp.tool(
+    name="dynamicfeedadtargets_resume",
+    description="Resume suspended dynamic feed ad targets by ID. Call tool_help('dynamicfeedadtargets_resume') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume dynamic feed ad targets.
@@ -159,7 +174,10 @@ def dynamic_feed_ad_targets_resume(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="dynamicfeedadtargets_set_bids")
+@mcp.tool(
+    name="dynamicfeedadtargets_set_bids",
+    description="Set search/context bids for dynamic feed ad targets. Call tool_help('dynamicfeedadtargets_set_bids') for parameters.",
+)
 @handle_cli_errors
 def dynamic_feed_ad_targets_set_bids(
     id: int | None = None,

--- a/server/tools/feeds.py
+++ b/server/tools/feeds.py
@@ -15,7 +15,10 @@ FEED_SOURCE_OPTIONS = (
 )
 
 
-@mcp.tool(name="feeds_get")
+@mcp.tool(
+    name="feeds_get",
+    description="List feeds (product data feeds powering smart/dynamic ads), optionally filtered by IDs. Use feeds_add to create, feeds_update to edit, feeds_delete to remove. Call tool_help('feeds_get') for parameters.",
+)
 @handle_cli_errors
 def feeds_list(
     ids: str | None = None,
@@ -44,7 +47,9 @@ def feeds_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add a product feed from a URL (UrlFeed) or a local file upload (FileFeed). Use feeds_update to change an existing feed. Call tool_help('feeds_add') for parameters.",
+)
 @handle_cli_errors
 def feeds_add(
     name: str,
@@ -100,7 +105,9 @@ def feeds_add(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update an existing feed's fields by ID (name, URL, source settings). Use feeds_add to create a new feed. Call tool_help('feeds_update') for parameters.",
+)
 @handle_cli_errors
 def feeds_update(
     id: int,
@@ -152,7 +159,9 @@ def feeds_update(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete feeds by ID (max 10 per call). Use feeds_get to find IDs. Call tool_help('feeds_delete') for parameters.",
+)
 @handle_cli_errors
 def feeds_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete feeds.

--- a/server/tools/images.py
+++ b/server/tools/images.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="adimages_get")
+@mcp.tool(
+    name="adimages_get",
+    description="List ad images (image assets used in ads), optionally filtered by IDs/hashes/association. Use adimages_add to upload, adimages_delete to remove. Call tool_help('adimages_get') for parameters.",
+)
 @handle_cli_errors
 def adimages_list(
     ids: str | None = None,
@@ -47,7 +50,9 @@ def adimages_list(
     return get_runner().run_json(cmd)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add an ad image from base64 data or a local file path. Use adimages_get to list existing images. Call tool_help('adimages_add') for parameters.",
+)
 @handle_cli_errors
 def adimages_add(
     name: str,
@@ -91,7 +96,9 @@ def adimages_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete an ad image by its hash. Use adimages_get to find the hash. Call tool_help('adimages_delete') for parameters.",
+)
 @handle_cli_errors
 def adimages_delete(hash_value: str, dry_run: bool = False) -> dict:
     """Delete an ad image by its hash.

--- a/server/tools/keyword_bids.py
+++ b/server/tools/keyword_bids.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="keywordbids_get")
+@mcp.tool(
+    name="keywordbids_get",
+    description="List bids for individual keywords. Call tool_help('keywordbids_get') for parameters.",
+)
 @handle_cli_errors
 def keyword_bids_list(
     campaign_ids: str | None = None,
@@ -44,7 +47,10 @@ def keyword_bids_list(
     return runner.run_json(args)
 
 
-@mcp.tool(name="keywordbids_set")
+@mcp.tool(
+    name="keywordbids_set",
+    description="Set fixed bids for keywords; use bids_set for campaign/group-level bids and bidmodifiers_set for adjustments. Call tool_help('keywordbids_set') for parameters.",
+)
 @handle_cli_errors
 def keyword_bids_set(
     keyword_id: int | None = None,
@@ -114,7 +120,10 @@ def keyword_bids_set(
     return runner.run_json(args)
 
 
-@mcp.tool(name="keywordbids_set_auto")
+@mcp.tool(
+    name="keywordbids_set_auto",
+    description="Switch keyword bids to an automatic bidding strategy. Call tool_help('keywordbids_set_auto') for parameters.",
+)
 @handle_cli_errors
 def keyword_bids_set_auto(
     campaign_id: int | None = None,

--- a/server/tools/keywords.py
+++ b/server/tools/keywords.py
@@ -39,7 +39,10 @@ KEYWORD_AUTOTARGETING_OPTIONS = (
 )
 
 
-@mcp.tool(name="keywords_get")
+@mcp.tool(
+    name="keywords_get",
+    description="List keywords filtered by campaign, ad group, or keyword IDs. Call tool_help('keywords_get') for parameters.",
+)
 @handle_cli_errors
 def keywords_list(
     campaign_ids: str | None = None,
@@ -116,7 +119,9 @@ def keywords_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Update keyword text or user params; use keywordbids_set for bids. Call tool_help('keywords_update') for parameters.",
+)
 @handle_cli_errors
 def keywords_update(
     id: int,
@@ -204,7 +209,9 @@ def keywords_update(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add one or many keywords to an ad group (single, JSONL file, or inline JSON). Call tool_help('keywords_add') for parameters.",
+)
 @handle_cli_errors
 def keywords_add(
     ad_group_id: int | None = None,
@@ -317,7 +324,9 @@ def keywords_add(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete keywords by ID. Call tool_help('keywords_delete') for parameters.",
+)
 @handle_cli_errors
 def keywords_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete keywords.
@@ -330,7 +339,9 @@ def keywords_delete(ids: str, dry_run: bool = False) -> dict:
     return run_single_id_batch(get_runner(), "keywords", "delete", ids, dry_run=dry_run)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Suspend keywords by ID. Call tool_help('keywords_suspend') for parameters.",
+)
 @handle_cli_errors
 def keywords_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend keywords.
@@ -345,7 +356,9 @@ def keywords_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Resume suspended keywords by ID. Call tool_help('keywords_resume') for parameters.",
+)
 @handle_cli_errors
 def keywords_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume suspended keywords.

--- a/server/tools/leads.py
+++ b/server/tools/leads.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="leads_get")
+@mcp.tool(
+    name="leads_get",
+    description="List leads (form submissions) for the given Turbo pages; leads are scoped to Turbo pages, not campaigns. Call tool_help('leads_get') for parameters.",
+)
 @handle_cli_errors
 def leads_list(
     turbo_page_ids: str,

--- a/server/tools/negative_keyword_shared_sets.py
+++ b/server/tools/negative_keyword_shared_sets.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="negativekeywordsharedsets_get")
+@mcp.tool(
+    name="negativekeywordsharedsets_get",
+    description="List shared sets of negative keywords reusable across campaigns. Call tool_help('negativekeywordsharedsets_get') for parameters.",
+)
 @handle_cli_errors
 def negative_keyword_shared_sets_list(
     ids: str | None = None,
@@ -33,7 +36,10 @@ def negative_keyword_shared_sets_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="negativekeywordsharedsets_add")
+@mcp.tool(
+    name="negativekeywordsharedsets_add",
+    description="Create a shared negative keyword set. Call tool_help('negativekeywordsharedsets_add') for parameters.",
+)
 @handle_cli_errors
 def negative_keyword_shared_sets_add(
     name: str, keywords: str, dry_run: bool = False
@@ -58,7 +64,10 @@ def negative_keyword_shared_sets_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="negativekeywordsharedsets_update")
+@mcp.tool(
+    name="negativekeywordsharedsets_update",
+    description="Update a shared negative keyword set's name or keyword list. Call tool_help('negativekeywordsharedsets_update') for parameters.",
+)
 @handle_cli_errors
 def negative_keyword_shared_sets_update(
     id: int,
@@ -92,7 +101,10 @@ def negative_keyword_shared_sets_update(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="negativekeywordsharedsets_delete")
+@mcp.tool(
+    name="negativekeywordsharedsets_delete",
+    description="Delete a shared negative keyword set by ID. Call tool_help('negativekeywordsharedsets_delete') for parameters.",
+)
 @handle_cli_errors
 def negative_keyword_shared_sets_delete(id: int, dry_run: bool = False) -> dict:
     """Delete a negative keyword shared set.

--- a/server/tools/reports.py
+++ b/server/tools/reports.py
@@ -119,7 +119,10 @@ def _resolve_report_dates(
     return (today - timedelta(days=DEFAULT_WINDOW_DAYS)).isoformat(), today.isoformat()
 
 
-@mcp.tool(name="reports_get")
+@mcp.tool(
+    name="reports_get",
+    description="Quick per-campaign performance snapshot over a short recent window (~last 8 days, default fields). Use reports_get for a fast overview; use reports_custom for arbitrary fields, filters, or date/goal breakdowns. Call tool_help('reports_get') for parameters.",
+)
 @handle_cli_errors
 def reports_get(
     date_from: str | None = None, date_to: str | None = None
@@ -168,7 +171,9 @@ def reports_get(
     return runner.run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="List supported Yandex.Direct report types with guidance on when to pick each (use before reports_custom if unsure which report_type fits). Call tool_help('reports_list_types') for parameters.",
+)
 @handle_cli_errors
 def reports_list_types() -> list[str] | dict:
     """List supported Yandex.Direct report types with guidance per type.
@@ -340,7 +345,10 @@ def _count_rows_written(
         return None
 
 
-@mcp.tool(name="reports_custom")
+@mcp.tool(
+    name="reports_custom",
+    description="Build an arbitrary Yandex.Direct statistics report: any FieldNames, filters, ordering, date/week/month/goal breakdowns, pagination, and file output. Use reports_custom for arbitrary fields & breakdowns; use reports_get for a quick recent snapshot. Call tool_help('reports_custom') for parameters.",
+)
 @handle_cli_errors
 def reports_custom(
     field_names: str,

--- a/server/tools/research.py
+++ b/server/tools/research.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import ToolError, get_runner, handle_cli_errors
 
 
-@mcp.tool(name="keywordsresearch_has_search_volume")
+@mcp.tool(
+    name="keywordsresearch_has_search_volume",
+    description="Check whether keywords have search volume in given regions. Call tool_help('keywordsresearch_has_search_volume') for parameters.",
+)
 @handle_cli_errors
 def keywords_has_volume(
     keywords: str,
@@ -46,7 +49,10 @@ def keywords_has_volume(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="keywordsresearch_deduplicate")
+@mcp.tool(
+    name="keywordsresearch_deduplicate",
+    description="Deduplicate a list of keywords. Call tool_help('keywordsresearch_deduplicate') for parameters.",
+)
 @handle_cli_errors
 def keywords_deduplicate(keywords: str) -> dict:
     """Deduplicate keywords.

--- a/server/tools/retargeting.py
+++ b/server/tools/retargeting.py
@@ -8,7 +8,10 @@ _LIST_TYPES = ("RETARGETING", "AUDIENCE")
 RETARGETING_RULE_OPTIONS = (CliOption("rules", "--rule", repeat=True),)
 
 
-@mcp.tool(name="retargeting_get")
+@mcp.tool(
+    name="retargeting_get",
+    description="List retargeting lists (audience/goal-based segments) for the account. Call tool_help('retargeting_get') for parameters.",
+)
 @handle_cli_errors
 def retargeting_list(
     ids: str | None = None,
@@ -42,7 +45,10 @@ def retargeting_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="retargeting_add")
+@mcp.tool(
+    name="retargeting_add",
+    description="Create a retargeting list from Metrica goal / Audience segment rules. Call tool_help('retargeting_add') for parameters.",
+)
 @handle_cli_errors
 def retargeting_add(
     name: str,
@@ -92,7 +98,10 @@ def retargeting_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="retargeting_delete")
+@mcp.tool(
+    name="retargeting_delete",
+    description="Delete retargeting lists by ID. Call tool_help('retargeting_delete') for parameters.",
+)
 @handle_cli_errors
 def retargeting_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete retargeting lists.
@@ -105,7 +114,10 @@ def retargeting_delete(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="retargeting_update")
+@mcp.tool(
+    name="retargeting_update",
+    description="Update an existing retargeting list's name, description, type, or rules. Call tool_help('retargeting_update') for parameters.",
+)
 @handle_cli_errors
 def retargeting_update(
     id: int,

--- a/server/tools/sitelinks.py
+++ b/server/tools/sitelinks.py
@@ -14,7 +14,10 @@ _SITELINK_FIELD_MAP = {
 }
 
 
-@mcp.tool(name="sitelinks_get")
+@mcp.tool(
+    name="sitelinks_get",
+    description="List sitelinks sets (quick links shown under an ad), optionally filtered by IDs (max 10). Use sitelinks_add to create, sitelinks_delete to remove. Call tool_help('sitelinks_get') for parameters.",
+)
 @handle_cli_errors
 def sitelinks_list(
     ids: str | None = None,
@@ -66,7 +69,9 @@ def _to_wsdl_sitelink(item: dict) -> dict | ToolError:
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add a sitelinks set via one of three input modes (pipe specs, structured items, or a JSONL file). Use sitelinks_get to list existing sets. Call tool_help('sitelinks_add') for parameters.",
+)
 @handle_cli_errors
 def sitelinks_add(
     sitelinks: list[str] | None = None,
@@ -156,7 +161,9 @@ def sitelinks_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete sitelinks sets by ID (max 10 per call). Use sitelinks_get to find IDs. Call tool_help('sitelinks_delete') for parameters.",
+)
 @handle_cli_errors
 def sitelinks_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete sitelinks sets.

--- a/server/tools/smart_ad_targets.py
+++ b/server/tools/smart_ad_targets.py
@@ -13,7 +13,10 @@ _YES_NO = ("YES", "NO")
 SMART_TARGET_CONDITION_OPTIONS = (CliOption("conditions", "--condition", repeat=True),)
 
 
-@mcp.tool(name="smartadtargets_get")
+@mcp.tool(
+    name="smartadtargets_get",
+    description="List smart ad targets (audience filters for smart banner / dynamic feed campaigns). Call tool_help('smartadtargets_get') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_list(
     ids: str | None = None,
@@ -59,7 +62,10 @@ def smart_ad_targets_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="smartadtargets_add")
+@mcp.tool(
+    name="smartadtargets_add",
+    description="Create a smart ad target (filter/audience condition for smart banners). Call tool_help('smartadtargets_add') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_add(
     ad_group_id: int,
@@ -126,7 +132,10 @@ def smart_ad_targets_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="smartadtargets_update")
+@mcp.tool(
+    name="smartadtargets_update",
+    description="Update an existing smart ad target's name, audience, conditions, or bids. Call tool_help('smartadtargets_update') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_update(
     id: int,
@@ -206,7 +215,10 @@ def smart_ad_targets_update(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="smartadtargets_delete")
+@mcp.tool(
+    name="smartadtargets_delete",
+    description="Delete a smart ad target by ID. Call tool_help('smartadtargets_delete') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_delete(id: int, dry_run: bool = False) -> dict:
     """Delete a smart ad target.
@@ -221,7 +233,10 @@ def smart_ad_targets_delete(id: int, dry_run: bool = False) -> dict:
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="smartadtargets_suspend")
+@mcp.tool(
+    name="smartadtargets_suspend",
+    description="Pause smart ad targets by ID. Call tool_help('smartadtargets_suspend') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     """Suspend smart ad targets."""
@@ -230,7 +245,10 @@ def smart_ad_targets_suspend(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="smartadtargets_resume")
+@mcp.tool(
+    name="smartadtargets_resume",
+    description="Resume suspended smart ad targets by ID. Call tool_help('smartadtargets_resume') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_resume(ids: str, dry_run: bool = False) -> dict:
     """Resume smart ad targets."""
@@ -239,7 +257,10 @@ def smart_ad_targets_resume(ids: str, dry_run: bool = False) -> dict:
     )
 
 
-@mcp.tool(name="smartadtargets_set_bids")
+@mcp.tool(
+    name="smartadtargets_set_bids",
+    description="Set average CPC/CPA or priority for smart ad targets. Call tool_help('smartadtargets_set_bids') for parameters.",
+)
 @handle_cli_errors
 def smart_ad_targets_set_bids(
     id: int | None = None,

--- a/server/tools/strategies.py
+++ b/server/tools/strategies.py
@@ -26,7 +26,10 @@ STRATEGY_TYPES = (
 ATTRIBUTION_MODELS = ("LYDC", "FC", "LC", "LSC", "LYDC_WEIGHT", "CROSSTDEVICE")
 
 
-@mcp.tool(name="strategies_get")
+@mcp.tool(
+    name="strategies_get",
+    description="List bidding strategies, optionally filtered by ID, type, or archived status. Call tool_help('strategies_get') for parameters.",
+)
 @handle_cli_errors
 def strategies_list(
     ids: str | None = None,
@@ -74,7 +77,10 @@ def strategies_list(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="strategies_add")
+@mcp.tool(
+    name="strategies_add",
+    description="Create a new bidding strategy of a given type with its money fields. Call tool_help('strategies_add') for parameters.",
+)
 @handle_cli_errors
 def strategies_add(
     name: str,
@@ -181,7 +187,10 @@ def strategies_add(
     return runner.run_json(args)
 
 
-@mcp.tool(name="strategies_update")
+@mcp.tool(
+    name="strategies_update",
+    description="Update an existing bidding strategy's fields by ID. Call tool_help('strategies_update') for parameters.",
+)
 @handle_cli_errors
 def strategies_update(
     id: int,
@@ -314,7 +323,10 @@ def strategies_update(
     return runner.run_json(args)
 
 
-@mcp.tool(name="strategies_archive")
+@mcp.tool(
+    name="strategies_archive",
+    description="Archive a bidding strategy by ID. Call tool_help('strategies_archive') for parameters.",
+)
 @handle_cli_errors
 def strategies_archive(id: int, dry_run: bool = False) -> dict:
     """Archive a bidding strategy.
@@ -329,7 +341,10 @@ def strategies_archive(id: int, dry_run: bool = False) -> dict:
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="strategies_unarchive")
+@mcp.tool(
+    name="strategies_unarchive",
+    description="Unarchive a bidding strategy by ID. Call tool_help('strategies_unarchive') for parameters.",
+)
 @handle_cli_errors
 def strategies_unarchive(id: int, dry_run: bool = False) -> dict:
     """Unarchive a bidding strategy.

--- a/server/tools/tool_help.py
+++ b/server/tools/tool_help.py
@@ -4,6 +4,15 @@ To keep the startup context small, every tool exposes only a short one-line
 ``description``. The full documentation (parameter reference, examples,
 constraints) lives in each tool function's docstring and is served lazily
 through ``tool_help`` instead of being loaded on every request.
+
+``tool_help`` reaches into a few private FastMCP internals
+(``mcp._tool_manager``, ``manager._tools``, ``tool.fn``) because the public
+API does not expose a tool's underlying function/docstring. Those accesses are
+wrapped defensively: if a future ``mcp`` upgrade renames or removes them,
+``tool_help`` returns a graceful error dict instead of raising — important
+because every other tool's description now points here for its parameters, so
+a hard crash would cascade across the whole plugin. The ``mcp`` dependency is
+also version-pinned in ``pyproject.toml`` to bound that risk.
 """
 
 from server.main import mcp
@@ -15,19 +24,54 @@ _SHORT_DESCRIPTION = (
     "name (e.g. 'campaigns_add'); omit the name to list every available tool."
 )
 
+_INTERNAL_ERROR = {
+    "error": "tool_manager_unavailable",
+    "message": (
+        "Could not read the MCP tool registry — the mcp library's internal "
+        "API may have changed. Upgrade or reinstall the plugin."
+    ),
+}
+
+
+def _list_tool_names() -> list[str] | None:
+    """Return all registered tool names, or None if mcp internals changed."""
+    try:
+        return sorted(mcp._tool_manager._tools.keys())
+    except AttributeError:
+        return None
+
 
 @mcp.tool(name="tool_help", description=_SHORT_DESCRIPTION)
 def tool_help(name: str | None = None) -> dict:
-    # Full docstring intentionally omitted from the schema — the short
-    # description above is what the model sees; this body is the help payload.
-    manager = mcp._tool_manager
-    available = sorted(manager._tools.keys())
+    """Return the full documentation for any registered MCP tool.
+
+    Every tool in this plugin exposes only a one-line summary so the startup
+    context stays small; the full parameter reference, examples and
+    constraints live in each tool's docstring and are served here on demand.
+
+    Args:
+        name: Exact tool name to document (e.g. 'campaigns_add'). Omit it to
+            get the list of all available tool names instead.
+
+    Returns:
+        - With a valid name: {"tool", "documentation"} — the tool's full docs.
+        - Without a name: {"available_tools", "count"} — every tool name.
+        - Unknown name: {"error": "unknown_tool", "message", "available_tools"}.
+    """
+    available = _list_tool_names()
+    if available is None:
+        return dict(_INTERNAL_ERROR)
 
     if not name:
         return {"available_tools": available, "count": len(available)}
 
     requested = name.strip()
-    tool = manager.get_tool(requested)
+    try:
+        tool = mcp._tool_manager.get_tool(requested)
+        doc = (getattr(tool.fn, "__doc__", None) or "").strip() if tool else None
+    except AttributeError:
+        return dict(_INTERNAL_ERROR)
+
     if tool is None:
         return {
             "error": "unknown_tool",
@@ -35,7 +79,6 @@ def tool_help(name: str | None = None) -> dict:
             "available_tools": available,
         }
 
-    doc = (getattr(tool.fn, "__doc__", None) or "").strip()
     return {
         "tool": tool.name,
         "documentation": doc or "(no documentation available)",

--- a/server/tools/tool_help.py
+++ b/server/tools/tool_help.py
@@ -1,0 +1,42 @@
+"""Meta-tool: on-demand detailed help for any MCP tool.
+
+To keep the startup context small, every tool exposes only a short one-line
+``description``. The full documentation (parameter reference, examples,
+constraints) lives in each tool function's docstring and is served lazily
+through ``tool_help`` instead of being loaded on every request.
+"""
+
+from server.main import mcp
+
+_SHORT_DESCRIPTION = (
+    "Get the full documentation for another tool: parameter reference, "
+    "examples and constraints. Call this BEFORE using an unfamiliar tool — "
+    "the tools themselves carry only a one-line summary. Pass the exact tool "
+    "name (e.g. 'campaigns_add'); omit the name to list every available tool."
+)
+
+
+@mcp.tool(name="tool_help", description=_SHORT_DESCRIPTION)
+def tool_help(name: str | None = None) -> dict:
+    # Full docstring intentionally omitted from the schema — the short
+    # description above is what the model sees; this body is the help payload.
+    manager = mcp._tool_manager
+    available = sorted(manager._tools.keys())
+
+    if not name:
+        return {"available_tools": available, "count": len(available)}
+
+    requested = name.strip()
+    tool = manager.get_tool(requested)
+    if tool is None:
+        return {
+            "error": "unknown_tool",
+            "message": f"No tool named {requested!r}.",
+            "available_tools": available,
+        }
+
+    doc = (getattr(tool.fn, "__doc__", None) or "").strip()
+    return {
+        "tool": tool.name,
+        "documentation": doc or "(no documentation available)",
+    }

--- a/server/tools/turbo_pages.py
+++ b/server/tools/turbo_pages.py
@@ -4,7 +4,10 @@ from server.main import mcp
 from server.tools import get_runner, handle_cli_errors
 
 
-@mcp.tool(name="turbopages_get")
+@mcp.tool(
+    name="turbopages_get",
+    description="List turbo pages (fast mobile landing pages built in Yandex.Direct), optionally filtered by IDs or bound hrefs. Read-only. Call tool_help('turbopages_get') for parameters.",
+)
 @handle_cli_errors
 def turbo_pages_list(
     ids: str | None = None,

--- a/server/tools/v4account.py
+++ b/server/tools/v4account.py
@@ -84,7 +84,10 @@ def _require_non_empty(value: str, *, field: str, error: str) -> ToolError | str
     return normalized
 
 
-@mcp.tool(name="v4account_enable_shared_account")
+@mcp.tool(
+    name="v4account_enable_shared_account",
+    description="Enable a shared account for a client (v4 Live EnableSharedAccount); requires dry_run or sandbox. Call tool_help('v4account_enable_shared_account') for parameters.",
+)
 @handle_cli_errors
 def v4account_enable_shared_account(
     client_login: str,
@@ -114,7 +117,10 @@ def v4account_enable_shared_account(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4account_get_accounts")
+@mcp.tool(
+    name="v4account_get_accounts",
+    description="Read shared-account info via v4 Live AccountManagement (Get); pass logins and/or account_ids, or omit both to list all. Read-only. Call tool_help('v4account_get_accounts') for parameters.",
+)
 @handle_cli_errors
 def v4account_get_accounts(
     logins: str | None = None,
@@ -176,7 +182,10 @@ def v4account_get_accounts(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4account_update_account")
+@mcp.tool(
+    name="v4account_update_account",
+    description="Update shared-account settings (budget, SMS/email notifications) via v4 Live AccountManagement (Update); requires dry_run or sandbox. Call tool_help('v4account_update_account') for parameters.",
+)
 @handle_cli_errors
 def v4account_update_account(
     account_id: int,
@@ -239,7 +248,10 @@ def v4account_update_account(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4account_deposit")
+@mcp.tool(
+    name="v4account_deposit",
+    description="Money operation: deposit funds into shared accounts via v4 Live AccountManagement (Deposit); finance tokens are env-only, requires dry_run or sandbox. Call tool_help('v4account_deposit') for parameters.",
+)
 @handle_cli_errors
 def v4account_deposit(
     payment: list[str],
@@ -293,7 +305,10 @@ def v4account_deposit(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4account_invoice")
+@mcp.tool(
+    name="v4account_invoice",
+    description="Money operation: issue invoice payments via v4 Live AccountManagement (Invoice); finance tokens are env-only, requires dry_run or sandbox. Call tool_help('v4account_invoice') for parameters.",
+)
 @handle_cli_errors
 def v4account_invoice(
     payment: list[str],
@@ -337,7 +352,10 @@ def v4account_invoice(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4account_transfer_money")
+@mcp.tool(
+    name="v4account_transfer_money",
+    description="Money operation: transfer funds between shared accounts via v4 Live AccountManagement (TransferMoney); finance tokens are env-only, requires dry_run or sandbox. Call tool_help('v4account_transfer_money') for parameters.",
+)
 @handle_cli_errors
 def v4account_transfer_money(
     from_account_id: int,

--- a/server/tools/v4adimage.py
+++ b/server/tools/v4adimage.py
@@ -9,7 +9,10 @@ from server.tools.helpers import (
 )
 
 
-@mcp.tool(name="v4adimage_get")
+@mcp.tool(
+    name="v4adimage_get",
+    description="Read ad-image associations via v4 Live AdImageAssociation (Get); empty filter returns up to 10000. Call tool_help('v4adimage_get') for parameters.",
+)
 @handle_cli_errors
 def v4adimage_get(
     logins: str | None = None,
@@ -65,7 +68,10 @@ def v4adimage_get(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4adimage_set")
+@mcp.tool(
+    name="v4adimage_set",
+    description="Link or unlink ad images via v4 Live AdImageAssociation (Set); up to 10000 per call. Call tool_help('v4adimage_set') for parameters.",
+)
 @handle_cli_errors
 def v4adimage_set(
     associations: list[str],

--- a/server/tools/v4events.py
+++ b/server/tools/v4events.py
@@ -5,7 +5,10 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import finalize_json_args
 
 
-@mcp.tool(name="v4events_get_events_log")
+@mcp.tool(
+    name="v4events_get_events_log",
+    description="Get v4 Live events log entries via GetEventsLog for a timestamp range. Call tool_help('v4events_get_events_log') for parameters.",
+)
 @handle_cli_errors
 def v4events_get_events_log(
     timestamp_from: str,

--- a/server/tools/v4forecast.py
+++ b/server/tools/v4forecast.py
@@ -7,7 +7,10 @@ from server.tools.helpers import finalize_json_args
 MAX_PHRASES = 100
 
 
-@mcp.tool(name="v4forecast_create")
+@mcp.tool(
+    name="v4forecast_create",
+    description="Create a v4 Live budget forecast via CreateNewForecast (up to 100 phrases). Call tool_help('v4forecast_create') for parameters.",
+)
 @handle_cli_errors
 def v4forecast_create(
     phrases: str,
@@ -47,14 +50,20 @@ def v4forecast_create(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4forecast_list")
+@mcp.tool(
+    name="v4forecast_list",
+    description="List v4 Live budget forecasts via GetForecastList. Call tool_help('v4forecast_list') for parameters.",
+)
 @handle_cli_errors
 def v4forecast_list() -> dict | list[dict]:
     """List v4 Live budget forecasts via GetForecastList."""
     return get_runner().run_json(["v4forecast", "list", "--format", "json"])
 
 
-@mcp.tool(name="v4forecast_get")
+@mcp.tool(
+    name="v4forecast_get",
+    description="Get a ready v4 Live budget forecast by ID via GetForecast. Call tool_help('v4forecast_get') for parameters.",
+)
 @handle_cli_errors
 def v4forecast_get(forecast_id: int) -> dict | list[dict]:
     """Get a ready v4 Live budget forecast via GetForecast.
@@ -74,7 +83,10 @@ def v4forecast_get(forecast_id: int) -> dict | list[dict]:
     )
 
 
-@mcp.tool(name="v4forecast_delete")
+@mcp.tool(
+    name="v4forecast_delete",
+    description="Delete a v4 Live budget forecast by ID via DeleteForecastReport. Call tool_help('v4forecast_delete') for parameters.",
+)
 @handle_cli_errors
 def v4forecast_delete(forecast_id: int, dry_run: bool = False) -> dict | list[dict]:
     """Delete a v4 Live budget forecast via DeleteForecastReport.

--- a/server/tools/v4goals.py
+++ b/server/tools/v4goals.py
@@ -16,7 +16,10 @@ def _run_goals_command(method: str, campaign_ids: str) -> dict | list[dict]:
     )
 
 
-@mcp.tool(name="v4goals_get_stat_goals")
+@mcp.tool(
+    name="v4goals_get_stat_goals",
+    description="Get Yandex Metrica stat goals available for campaigns (v4 Live); use v4goals_get_retargeting_goals for retargeting goals. Call tool_help('v4goals_get_stat_goals') for parameters.",
+)
 @handle_cli_errors
 def v4goals_get_stat_goals(campaign_ids: str) -> dict | list[dict]:
     """Get Yandex Metrica goals available for campaigns.
@@ -27,7 +30,10 @@ def v4goals_get_stat_goals(campaign_ids: str) -> dict | list[dict]:
     return _run_goals_command("get-stat-goals", campaign_ids)
 
 
-@mcp.tool(name="v4goals_get_retargeting_goals")
+@mcp.tool(
+    name="v4goals_get_retargeting_goals",
+    description="Get retargeting goals for campaigns (v4 Live); use v4goals_get_stat_goals for Metrica stat goals. Call tool_help('v4goals_get_retargeting_goals') for parameters.",
+)
 @handle_cli_errors
 def v4goals_get_retargeting_goals(campaign_ids: str) -> dict | list[dict]:
     """Get retargeting goals for campaigns.

--- a/server/tools/v4keywords.py
+++ b/server/tools/v4keywords.py
@@ -5,7 +5,10 @@ from server.tools import ToolError, get_runner, handle_cli_errors
 from server.tools.helpers import normalize_str_list
 
 
-@mcp.tool(name="v4keywords_get_suggestion")
+@mcp.tool(
+    name="v4keywords_get_suggestion",
+    description="Get related keyword suggestions via v4 Live GetKeywordsSuggestion (up to 20 phrases; spends API points). Call tool_help('v4keywords_get_suggestion') for parameters.",
+)
 @handle_cli_errors
 def v4keywords_get_suggestion(keywords: list[str]) -> dict | list[dict]:
     """Get related keyword suggestions via v4 Live GetKeywordsSuggestion.

--- a/server/tools/v4tags.py
+++ b/server/tools/v4tags.py
@@ -10,7 +10,10 @@ from server.tools.helpers import (
 )
 
 
-@mcp.tool(name="v4tags_get_campaigns")
+@mcp.tool(
+    name="v4tags_get_campaigns",
+    description="Get campaign tags via v4 Live GetCampaignsTags; use v4tags_get_banners for banner tags. Call tool_help('v4tags_get_campaigns') for parameters.",
+)
 @handle_cli_errors
 def v4tags_get_campaigns(campaign_ids: str) -> dict | list[dict]:
     """Get campaign tags via v4 Live GetCampaignsTags.
@@ -37,7 +40,10 @@ def v4tags_get_campaigns(campaign_ids: str) -> dict | list[dict]:
     )
 
 
-@mcp.tool(name="v4tags_get_banners")
+@mcp.tool(
+    name="v4tags_get_banners",
+    description="Get banner tag IDs via v4 Live GetBannersTags (filter by campaign_ids or banner_ids); use v4tags_get_campaigns for campaign tags. Call tool_help('v4tags_get_banners') for parameters.",
+)
 @handle_cli_errors
 def v4tags_get_banners(
     campaign_ids: str | None = None, banner_ids: str | None = None
@@ -80,7 +86,10 @@ def v4tags_get_banners(
     return get_runner().run_json(args)
 
 
-@mcp.tool(name="v4tags_update_campaigns")
+@mcp.tool(
+    name="v4tags_update_campaigns",
+    description="Replace campaign tags via v4 Live UpdateCampaignsTags; use v4tags_update_banners for banner tags. Call tool_help('v4tags_update_campaigns') for parameters.",
+)
 @handle_cli_errors
 def v4tags_update_campaigns(
     campaign_id: int,
@@ -117,7 +126,10 @@ def v4tags_update_campaigns(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4tags_update_banners")
+@mcp.tool(
+    name="v4tags_update_banners",
+    description="Replace banner tag assignments via v4 Live UpdateBannersTags; use v4tags_update_campaigns for campaign tags. Call tool_help('v4tags_update_banners') for parameters.",
+)
 @handle_cli_errors
 def v4tags_update_banners(
     banner_ids: str,

--- a/server/tools/v4wordstat.py
+++ b/server/tools/v4wordstat.py
@@ -7,7 +7,10 @@ from server.tools.helpers import finalize_json_args
 MAX_WORDSTAT_PHRASES = 10
 
 
-@mcp.tool(name="v4wordstat_create_report")
+@mcp.tool(
+    name="v4wordstat_create_report",
+    description="Create a v4 Live Wordstat report via CreateNewWordstatReport (up to 10 phrases). Call tool_help('v4wordstat_create_report') for parameters.",
+)
 @handle_cli_errors
 def v4wordstat_create_report(
     phrases: str,
@@ -49,7 +52,10 @@ def v4wordstat_create_report(
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4wordstat_list_reports")
+@mcp.tool(
+    name="v4wordstat_list_reports",
+    description="List v4 Live Wordstat reports via GetWordstatReportList. Call tool_help('v4wordstat_list_reports') for parameters.",
+)
 @handle_cli_errors
 def v4wordstat_list_reports(dry_run: bool = False) -> dict | list[dict]:
     """List v4 Live Wordstat reports via GetWordstatReportList."""
@@ -57,7 +63,10 @@ def v4wordstat_list_reports(dry_run: bool = False) -> dict | list[dict]:
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4wordstat_get_report")
+@mcp.tool(
+    name="v4wordstat_get_report",
+    description="Get a ready v4 Live Wordstat report by ID via GetWordstatReport. Call tool_help('v4wordstat_get_report') for parameters.",
+)
 @handle_cli_errors
 def v4wordstat_get_report(report_id: int, dry_run: bool = False) -> dict | list[dict]:
     """Get a ready v4 Live Wordstat report via GetWordstatReport.
@@ -70,7 +79,10 @@ def v4wordstat_get_report(report_id: int, dry_run: bool = False) -> dict | list[
     return get_runner().run_json(finalize_json_args(args, dry_run))
 
 
-@mcp.tool(name="v4wordstat_delete_report")
+@mcp.tool(
+    name="v4wordstat_delete_report",
+    description="Delete a v4 Live Wordstat report by ID via DeleteWordstatReport. Call tool_help('v4wordstat_delete_report') for parameters.",
+)
 @handle_cli_errors
 def v4wordstat_delete_report(
     report_id: int, dry_run: bool = False

--- a/server/tools/vcards.py
+++ b/server/tools/vcards.py
@@ -21,7 +21,10 @@ VCARD_0312_OPTIONS = (
 )
 
 
-@mcp.tool(name="vcards_get")
+@mcp.tool(
+    name="vcards_get",
+    description="List vCards (business contact cards with address/phone shown with ads), optionally filtered by IDs (max 10). Use vcards_add to create, vcards_delete to remove. Call tool_help('vcards_get') for parameters.",
+)
 @handle_cli_errors
 def vcards_list(
     ids: str | None = None,
@@ -53,7 +56,9 @@ def vcards_list(
     return get_runner().run_json(cmd)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Add a vCard (business contact card with company name, address, and phone) to a campaign. Use vcards_get to list existing vCards. Call tool_help('vcards_add') for parameters.",
+)
 @handle_cli_errors
 def vcards_add(
     campaign_id: int,
@@ -160,7 +165,9 @@ def vcards_add(
     return get_runner().run_json(args)
 
 
-@mcp.tool()
+@mcp.tool(
+    description="Delete vCards by ID (max 10 per call). Use vcards_get to find IDs. Call tool_help('vcards_delete') for parameters.",
+)
 @handle_cli_errors
 def vcards_delete(ids: str, dry_run: bool = False) -> dict:
     """Delete vCards.

--- a/tests/measure_tool_tokens.py
+++ b/tests/measure_tool_tokens.py
@@ -1,0 +1,105 @@
+"""Воспроизводимый измеритель «веса» MCP-инструментов в токенах.
+
+Считает то, что реально уходит в контекст модели при инициализации MCP:
+для каждого инструмента — name + description + inputSchema (JSON Schema
+параметров). Это постоянная стоимость, которая платится на каждом запросе,
+пока плагин подключён.
+
+Запуск:
+    python -m tests.measure_tool_tokens            # сводка + топ-20
+    python -m tests.measure_tool_tokens --json     # полный JSON по всем тулам
+
+Оценка токенов:
+    - если установлен tiktoken — кодировка cl100k_base (близко к токенайзеру Claude, ±~10%);
+    - иначе — приближение len(text) / 4 (грубее, но без зависимостей).
+Способ оценки печатается в выводе, чтобы цифры были сопоставимы между запусками.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+
+def _make_counter():
+    """Вернуть (функция_подсчёта, метка_способа)."""
+    try:
+        import tiktoken
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        return (lambda s: len(enc.encode(s or "")), "tiktoken/cl100k_base")
+    except Exception:
+        # Приближение: ~4 символа на токен. Достаточно для сравнения «до/после».
+        return (lambda s: (len(s or "") + 3) // 4, "approx(len/4)")
+
+
+async def collect_rows():
+    from server.main import mcp
+
+    count, method = _make_counter()
+    tools = await mcp.list_tools()
+    rows = []
+    for t in tools:
+        name = t.name
+        desc = t.description or ""
+        schema = t.inputSchema or {}
+        schema_json = json.dumps(schema, ensure_ascii=False, separators=(",", ":"))
+        payload = json.dumps(
+            {"name": name, "description": desc, "input_schema": schema},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        props = schema.get("properties") or {}
+        rows.append(
+            {
+                "name": name,
+                "n_params": len(props),
+                "desc_tok": count(desc),
+                "schema_tok": count(schema_json),
+                "total_tok": count(payload),
+            }
+        )
+    rows.sort(key=lambda r: r["total_tok"], reverse=True)
+    return rows, method
+
+
+def summarize(rows, method):
+    total = sum(r["total_tok"] for r in rows)
+    total_desc = sum(r["desc_tok"] for r in rows)
+    total_schema = sum(r["schema_tok"] for r in rows)
+    return {
+        "method": method,
+        "n_tools": len(rows),
+        "total_tok": total,
+        "total_desc_tok": total_desc,
+        "total_schema_tok": total_schema,
+    }
+
+
+def main():
+    rows, method = asyncio.run(collect_rows())
+    s = summarize(rows, method)
+
+    if "--json" in sys.argv:
+        print(json.dumps({**s, "rows": rows}, ensure_ascii=False, indent=2))
+        return
+
+    print(f"Способ оценки: {s['method']}")
+    print(f"Инструментов: {s['n_tools']}")
+    print(f"Суммарно токенов (спецификация): {s['total_tok']:,}")
+    print(f"  descriptions: {s['total_desc_tok']:,}")
+    print(f"  JSON Schema:  {s['total_schema_tok']:,}")
+    print(f"Среднее на инструмент: {s['total_tok'] // max(s['n_tools'], 1):,}")
+    print()
+    print("ТОП-20 по весу:")
+    print(f"{'#':>3} {'tool':<42} {'params':>6} {'desc':>6} {'schema':>7} {'TOTAL':>7}")
+    for i, r in enumerate(rows[:20], 1):
+        print(
+            f"{i:>3} {r['name']:<42} {r['n_params']:>6} "
+            f"{r['desc_tok']:>6} {r['schema_tok']:>7} {r['total_tok']:>7}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/measure_tool_tokens.py
+++ b/tests/measure_tool_tokens.py
@@ -25,7 +25,9 @@ import sys
 def _make_counter():
     """Вернуть (функция_подсчёта, метка_способа)."""
     try:
-        import tiktoken
+        # tiktoken is optional and intentionally not a project dependency;
+        # the except-branch below falls back to a dependency-free estimate.
+        import tiktoken  # type: ignore[import-not-found]
 
         enc = tiktoken.get_encoding("cl100k_base")
         return (lambda s: len(enc.encode(s or "")), "tiktoken/cl100k_base")


### PR DESCRIPTION
## Что и зачем

Раньше каждый MCP-инструмент отправлял модели **весь свой docstring** (описание полей, примеры, ограничения) в качестве `description` — на каждом запросе, постоянно. Это ~16.6k токенов из бюджета спецификации инструментов, которые висят в контексте всё время, даже когда ни один инструмент не используется.

Теперь применён **progressive disclosure**: у каждого инструмента короткая однострочная подпись (что делает + когда выбирать вместо похожего), а полная документация выдаётся **по требованию** новым мета-инструментом `tool_help('<name>')`. Docstring самих функций не тронут — они просто перестали транслироваться при старте.

## Замер (воспроизводимо: `python -m tests.measure_tool_tokens`, tiktoken cl100k_base)

| | До | После | Δ |
|---|---:|---:|---:|
| Бюджет спецификации инструментов | 54 457 | 40 792 | **−25%** |
| из них descriptions | 16 582 | 4 522 | **−73%** |
| JSON Schema параметров | 34 513 | не тронуто | — |

Сжатие схем параметров (главный оставшийся вес — `campaigns_add/update`) — отдельная, более рискованная задача, см. #154 / #149.

## Изменения

- Новый `server/tools/tool_help.py` — мета-инструмент `tool_help(name)`: возвращает полный docstring любого инструмента (`mcp._tool_manager.get_tool(name).fn.__doc__`); без имени — список всех инструментов.
- Короткий `description=` в `@mcp.tool(...)` у всех инструментов (40 файлов в `server/tools/`). Похожие инструменты различены (`reports_custom` vs `reports_get`, `bids_*`/`keywordbids_*`/`bidmodifiers_*` и т.п.).
- Регистрация `tool_help` в `server/main.py`, бандле `plugins/yandex-direct/server/main.py` и `server/contract.py` (`PLUGIN_TOOL_NAMES`).
- Новый воспроизводимый измеритель `tests/measure_tool_tokens.py` (опирается на tiktoken, есть fallback без зависимостей).
- Версия плагина 0.2.4.3 → **0.3.0**; заметка в секции Breaking Changes (CLAUDE.md), счётчик 145 → 146 в CLAUDE.md/README.md.

## Совместимость

API инструментов не сломан: имена, параметры и поведение идентичны. Меняется только то, что видит модель — короткие подписи вместо полных docs. Клиент, который полагался на чтение длинного `description`, теперь вызывает `tool_help`.

## Проверка

- `python -m tests.measure_tool_tokens` — цифры выше
- `ruff check .` — чисто
- `mypy server/tools/tool_help.py` — чисто
- `pytest` — **694 passed, 7 skipped** (обновлён контракт под +1 инструмент)
- `tool_help('campaigns_add')` возвращает полный docstring (4942 симв.), при этом его `description` в спецификации — 42 токена

Refs #154, #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)