### PR TITLE
fix: human-readable hints for delete errors 8300/8301 (#157)

### DIFF
--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -77,6 +77,18 @@ _HINTS_BY_ERROR_CODE: dict[int, str] = {
         "Per-account object limit reached (campaigns / ads / keywords). "
         "Archive or delete unused objects first."
     ),
+    8300: (
+        "Ad cannot be removed: it was shown / passed moderation while the "
+        "account had funds. Yandex forbids ads.delete for such ads — use "
+        "ads_archive instead. A draft can only be fully removed by hand in "
+        "the Direct web interface."
+    ),
+    8301: (
+        "Ad group cannot be removed because it still contains ads, so "
+        "adgroups_delete does not apply. Direct API v5 has no archive/suspend "
+        "method for ad groups — a draft group can only be removed by hand in "
+        "the Direct web interface."
+    ),
     8800: (
         "Object not found. Either the ID is wrong or it belongs to a "
         "different client. Verify with a *_get call."
@@ -158,6 +170,8 @@ def handle_cli_errors(func):
                 error_kind = "transient"
             elif e.error_code == 8800:
                 error_kind = "not_found"
+            elif e.error_code == 8300 or e.error_code == 8301:
+                error_kind = "invalid_status"
             elif e.error_code == 9300 or e.error_code == 7001:
                 error_kind = "limit_exceeded"
             else:

--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -84,10 +84,11 @@ _HINTS_BY_ERROR_CODE: dict[int, str] = {
         "the Direct web interface."
     ),
     8301: (
-        "Ad group cannot be removed because it still contains ads, so "
-        "adgroups_delete does not apply. Direct API v5 has no archive/suspend "
-        "method for ad groups — a draft group can only be removed by hand in "
-        "the Direct web interface."
+        "Ad group cannot be removed because it still contains ads (error "
+        "8301). Archive the ads first: call ads_get with ad_group_ids to list "
+        "them, then ads_archive for those ads, then retry adgroups_delete. If "
+        "ads_archive also fails with error 8300, the group can only be removed "
+        "from the Direct web interface."
     ),
     8800: (
         "Object not found. Either the ID is wrong or it belongs to a "

--- a/server/tools/helpers.py
+++ b/server/tools/helpers.py
@@ -5,11 +5,12 @@ from dataclasses import asdict, dataclass
 
 from server.cli.runner import (
     CliAuthError,
+    CliError,
     CliNotFoundError,
     CliRegistrationError,
     CliTimeoutError,
 )
-from server.tools import ToolError
+from server.tools import ToolError, _hint_for_cli_error
 
 MAX_BATCH_SIZE = 10
 
@@ -171,7 +172,12 @@ def run_single_id_batch(
         except (CliAuthError, CliNotFoundError, CliRegistrationError, CliTimeoutError):
             raise
         except Exception as e:
-            results.append({"success": False, "id": item_id, "error": str(e)})
+            item_error: dict = {"success": False, "id": item_id, "error": str(e)}
+            if isinstance(e, CliError):
+                hint = _hint_for_cli_error(e)
+                if hint is not None:
+                    item_error["hint"] = hint
+            results.append(item_error)
             failed.append(item_id)
     if len(results) == 1:
         return results[0]

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -178,7 +178,9 @@ def test_handle_cli_errors_maps_error_code_8300_to_invalid_status_with_hint() ->
 def test_handle_cli_errors_maps_error_code_8301_to_invalid_status_with_hint() -> None:
     result = _wrap_cli_error("boom", error_code=8301)()
     assert result["error"] == "invalid_status"
-    assert "archive/suspend method for ad groups" in result["hint"]
+    assert "ads_get with ad_group_ids" in result["hint"]
+    assert "ads_archive" in result["hint"]
+    assert "adgroups_delete" in result["hint"]
 
 
 def test_handle_cli_errors_unknown_code_keeps_unknown_and_no_hint() -> None:

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -169,6 +169,18 @@ def test_handle_cli_errors_maps_error_code_9300_to_limit_exceeded() -> None:
     assert "10 IDs" in result["hint"]
 
 
+def test_handle_cli_errors_maps_error_code_8300_to_invalid_status_with_hint() -> None:
+    result = _wrap_cli_error("boom", error_code=8300)()
+    assert result["error"] == "invalid_status"
+    assert "ads_archive" in result["hint"]
+
+
+def test_handle_cli_errors_maps_error_code_8301_to_invalid_status_with_hint() -> None:
+    result = _wrap_cli_error("boom", error_code=8301)()
+    assert result["error"] == "invalid_status"
+    assert "archive/suspend method for ad groups" in result["hint"]
+
+
 def test_handle_cli_errors_unknown_code_keeps_unknown_and_no_hint() -> None:
     result = _wrap_cli_error("boom", error_code=99999)()
     assert result["error"] == "unknown"
@@ -228,3 +240,35 @@ def test_run_single_id_batch_reports_partial_failure() -> None:
     assert result["succeeded"] == ["1"]
     assert result["failed"] == ["2"]
     assert result["results"][1] == {"success": False, "id": "2", "error": "boom"}
+
+
+def test_run_single_id_batch_attaches_hint_for_business_cli_error() -> None:
+    """A batch (>1 ID) CliError must carry the same hint as the single-ID path."""
+    from server.cli.runner import CliError
+
+    runner = MagicMock()
+    runner.run_json.side_effect = [
+        {"success": True},
+        CliError("direct failed (exit 1): Error 8300", error_code=8300),
+    ]
+
+    result = run_single_id_batch(runner, "ads", "delete", "1,2")
+
+    assert result["success"] is False
+    assert result["results"][1]["id"] == "2"
+    assert "ads_archive" in result["results"][1]["hint"]
+
+
+def test_run_single_id_batch_omits_hint_when_none_applies() -> None:
+    """A CliError with an unknown code keeps the raw error and no hint key."""
+    from server.cli.runner import CliError
+
+    runner = MagicMock()
+    runner.run_json.side_effect = [
+        CliError("direct failed (exit 1): Error 99999", error_code=99999),
+        {"success": True},
+    ]
+
+    result = run_single_id_batch(runner, "ads", "delete", "1,2")
+
+    assert "hint" not in result["results"][0]


### PR DESCRIPTION
## Проблема (#157)

В аккаунтах накапливаются DRAFT-группы с ранее модерированными объявлениями, которые **нельзя ни удалить, ни заархивировать** через MCP:
- `ads_delete` → `Error 8300` (объявление было в показе / прошло модерацию при наличии средств; Яндекс рекомендует `archive`)
- `adgroups_delete` → `Error 8301` (группа содержит объявления)
- `archive`/`suspend` для **групп** в API v5 нет вообще

Это ограничение API Яндекса, не плагина (`server/contract.py` зеркалит API точно). Но плагин отдавал сырую строку `direct failed (exit 1): ... Error 8300` без подсказки, и агент крутил лишний цикл `unarchive → модерация → delete → снова 8300` — с риском вывести объявление в реальный показ на мёртвый лендинг.

Подтверждено по [docs ads.delete](https://yandex.ru/dev/direct/doc/ref-v5/ads/delete.html): для таких объявлений доступна только архивация.

## Изменения

1. `server/tools/__init__.py` — `8300`/`8301` добавлены в `_HINTS_BY_ERROR_CODE` (хинт указывает на `ads_archive` / ручное удаление в веб-интерфейсе) и классифицированы как `invalid_status`.
2. `server/tools/helpers.py` — `run_single_id_batch` теперь прикрепляет тот же `_hint_for_cli_error()` хинт к per-item `CliError` в батче из >1 ID. Раньше одиночный путь получал хинт через `handle_cli_errors`, а батч-путь его терял (именно по нему идут `ads_delete`/`adgroups_delete`).

Контракт payload расширяется аддитивно (новый ключ `hint` в элементе `results` только при наличии подходящего хинта).

## Тесты

`tests/test_tool_helpers.py`: хинты для 8300/8301, прокидывание хинта в батч-путь, отсутствие ключа `hint` для неизвестного кода.

`pytest` (698 passed), `ruff`, `ruff format --check`, `mypy` — зелёные.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)