### PR TITLE
feat: surface allowed FieldNames from error 8000 in the hint (#148)

### DIFF
--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -13,6 +13,26 @@ from server.cli.runner import (
 
 _FILTER_TOKEN_RE = re.compile(r"\bfilter\b", re.IGNORECASE)
 
+# Yandex error_detail for an invalid enum spells out the allowed values, e.g.
+# "One of the following values is expected: Id, Name, State". Capture that list
+# so the agent gets the right field names from the first response instead of
+# guessing and re-calling. Stop at the first sentence break / end of string.
+_EXPECTED_VALUES_RE = re.compile(
+    r"following values?\s+(?:is|are)\s+expected:\s*(?P<values>[^.\n]+)",
+    re.IGNORECASE,
+)
+
+
+def _extract_expected_values(stderr: str | None) -> str | None:
+    """Pull the 'One of the following values is expected: ...' list from stderr."""
+    if not stderr:
+        return None
+    match = _EXPECTED_VALUES_RE.search(stderr)
+    if not match:
+        return None
+    values = match.group("values").strip().rstrip(",").strip()
+    return values or None
+
 
 @dataclass
 class ToolError:
@@ -98,12 +118,20 @@ def _build_invalid_request_hint(stderr: str | None) -> str:
         return _INVALID_REQUEST_HINT_GENERIC
     detail = stderr.lower()
     if "fieldnames" in detail:
-        return _INVALID_REQUEST_HINT_FIELDNAMES
-    if "sortorder" in detail:
-        return _INVALID_REQUEST_HINT_SORTORDER
-    if _FILTER_TOKEN_RE.search(stderr):
-        return _INVALID_REQUEST_HINT_FILTER
-    return _INVALID_REQUEST_HINT_GENERIC
+        base = _INVALID_REQUEST_HINT_FIELDNAMES
+    elif "sortorder" in detail:
+        base = _INVALID_REQUEST_HINT_SORTORDER
+    elif _FILTER_TOKEN_RE.search(stderr):
+        base = _INVALID_REQUEST_HINT_FILTER
+    else:
+        base = _INVALID_REQUEST_HINT_GENERIC
+
+    # When Yandex enumerates the allowed values, surface them verbatim so the
+    # agent picks correct fields on the first try instead of re-calling.
+    expected = _extract_expected_values(stderr)
+    if expected:
+        return f"{base} Allowed values for this endpoint: {expected}."
+    return base
 
 
 def _hint_for_cli_error(error: CliError) -> str | None:

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -141,6 +141,52 @@ def test_handle_cli_errors_targeted_hint_8000_generic_when_no_detail_match() -> 
     assert "dry_run=True" in result["hint"]
 
 
+def test_handle_cli_errors_8000_hint_surfaces_allowed_values_for_fieldnames() -> None:
+    """The allowed-values enumeration from the API is appended to the hint, so
+    the agent gets the right FieldNames without a second guessing call."""
+    result = _wrap_cli_error(
+        "boom",
+        error_code=8000,
+        stderr=(
+            "error_code=8000, error_detail=An item in the FieldNames array "
+            "contains an invalid enumeration value. One of the following "
+            "values is expected: Id, Name, State, Status"
+        ),
+    )()
+    assert result["error"] == "invalid_request"
+    assert "FieldNames are case-sensitive" in result["hint"]
+    assert "Allowed values for this endpoint: Id, Name, State, Status" in result["hint"]
+
+
+def test_handle_cli_errors_8000_hint_surfaces_allowed_values_in_generic_case() -> None:
+    """Allowed values are surfaced even when no FieldNames/SortOrder/Filter
+    keyword matched (generic 8000)."""
+    result = _wrap_cli_error(
+        "boom",
+        error_code=8000,
+        stderr=(
+            "error_code=8000, error_detail=Invalid value. One of the following "
+            "values is expected: WEEK, MONTH, CUSTOM_PERIOD."
+        ),
+    )()
+    assert result["error"] == "invalid_request"
+    assert (
+        "Allowed values for this endpoint: WEEK, MONTH, CUSTOM_PERIOD" in result["hint"]
+    )
+
+
+def test_handle_cli_errors_8000_hint_without_enumeration_keeps_base_hint() -> None:
+    """No 'expected:' list in stderr → hint stays the base text, no trailing junk."""
+    result = _wrap_cli_error(
+        "boom",
+        error_code=8000,
+        stderr="error_code=8000, error_detail=FieldNames must not be empty",
+    )()
+    assert result["error"] == "invalid_request"
+    assert "FieldNames are case-sensitive" in result["hint"]
+    assert "Allowed values for this endpoint" not in result["hint"]
+
+
 def test_handle_cli_errors_maps_error_code_53_to_auth_error_with_hint() -> None:
     result = _wrap_cli_error("boom", error_code=53, stderr="error_code=53")()
     assert result["error"] == "auth_error"


### PR DESCRIPTION
## Проблема (#148)

У каждого endpoint Direct API свой набор допустимых `FieldNames`, и агент вынужден их **угадывать**. При неверном поле API возвращает ошибку 8000 с текстом *"One of the following values is expected: ..."*, агент читает список из сырой ошибки и повторяет запрос — **2-3 лишних API-вызова на каждый endpoint**, расход API Points и токенов.

## Решение — вариант C (обогащение hint)

`_build_invalid_request_hint` (`server/tools/__init__.py`) теперь извлекает перечисление допустимых значений из `stderr` ошибки 8000 регуляркой и дословно вкладывает его в hint:

```
... FieldNames are case-sensitive ... Allowed values for this endpoint: Id, Name, State, Status.
```

Агент получает правильные поля из первого же ответа.

### Почему не вариант A

Вариант A из issue (захардкодить списки полей в `description` каждого `*_get` тула) **раздувает стартовый tool-spec бюджет** и прямо конфликтует с эпиком #149 (снижение токенов). Текущее решение добавляет **ноль** стартовых токенов — список приходит только в момент реальной ошибки.

## Тесты

`tests/test_tool_helpers.py`: список в hint при FieldNames-ошибке, в generic-случае (enum без ключевого слова), и graceful-fallback когда перечисления нет.

`pytest` (697 passed), `ruff`, `ruff format --check`, `mypy` — зелёные.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)