### PR TITLE
perf: group campaigns bidding-strategy params into dicts (−20% tool-spec) (#154)

### DIFF
--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -405,6 +405,86 @@ CAMPAIGN_UPDATE_ONLY_OPTIONS = (
 )
 
 
+# --- Grouped bidding-strategy parameters ---------------------------------
+# The per-campaign-type strategy flags (~147 of them) are exposed to the model
+# as 10 nested dict params instead of 147 flat `int|None`/`str|None` params.
+# This collapses the JSON-Schema that FastMCP broadcasts at startup (each flat
+# Optional emits a verbose `anyOf:[...,{"type":"null"}]`) without touching the
+# generated CLI argv: incoming dicts are expanded back into the flat option
+# names below before append_cli_options runs, so the `direct` call is identical.
+#
+# Each registry entry is derived from CAMPAIGN_MUTATION_OPTIONS by name prefix,
+# so the grouping stays in sync automatically if options are added/removed.
+_STRATEGY_PREFIXES: tuple[str, ...] = (
+    "text_search",
+    "text_network",
+    "dyn_search",
+    "dyn_network",
+    "smart_search",
+    "smart_network",
+    "unified_search",
+    "unified_network",
+    "mobile_search",
+    "mobile_network",
+)
+
+# (dict_param_name, CliOptions absorbed). Order matches the signatures below.
+_STRATEGY_DICT_REGISTRY: tuple[tuple[str, tuple[CliOption, ...]], ...] = tuple(
+    (
+        f"{prefix}_options",
+        tuple(o for o in CAMPAIGN_MUTATION_OPTIONS if o.name.startswith(f"{prefix}_")),
+    )
+    for prefix in _STRATEGY_PREFIXES
+)
+
+# Update-only budget-type opts keyed by their strategy prefix.
+_BUDGET_TYPE_BY_PREFIX: dict[str, CliOption] = {
+    o.name.replace("_budget_type", ""): o for o in CAMPAIGN_UPDATE_ONLY_OPTIONS
+}
+
+
+def _expand_strategy_dicts(
+    values: dict,
+    strategy_dicts: dict[str, dict | None],
+    *,
+    include_budget_types: bool,
+) -> ToolError | None:
+    """Expand grouped strategy dict params into flat keys in *values*.
+
+    Mutates *values* in place so that ``append_cli_options`` sees the individual
+    option names it expects, keeping the generated CLI argv byte-for-byte
+    identical to the old flat signature. Returns a ToolError on a type mismatch
+    (non-dict value), or None on success.
+
+    Unknown keys inside a strategy dict are silently ignored — they never reach
+    the CLI. This is intentional forward-compatibility: a new CLI flag does not
+    require a plugin release to be passable.
+    """
+    for dict_name, incoming in strategy_dicts.items():
+        if incoming is None:
+            continue
+        if not isinstance(incoming, dict):
+            return ToolError(
+                error="invalid_param",
+                message=(
+                    f"'{dict_name}' must be a dict or null, "
+                    f"got {type(incoming).__name__}"
+                ),
+            )
+        for reg_name, opts in _STRATEGY_DICT_REGISTRY:
+            if reg_name == dict_name:
+                for opt in opts:
+                    if opt.name in incoming:
+                        values[opt.name] = incoming[opt.name]
+                break
+        if include_budget_types:
+            prefix = dict_name.removesuffix("_options")
+            bt_opt = _BUDGET_TYPE_BY_PREFIX.get(prefix)
+            if bt_opt is not None and bt_opt.name in incoming:
+                values[bt_opt.name] = incoming[bt_opt.name]
+    return None
+
+
 @mcp.tool(
     name="campaigns_get",
     description="List advertising campaigns, with optional state/status/type/ID filters. Read-only; use campaigns_add to create or campaigns_update to modify. Call tool_help('campaigns_get') for parameters.",
@@ -575,165 +655,19 @@ def campaigns_update(
     strategy_end_date: str | None = None,
     strategy_spend_limit: int | None = None,
     strategy_start_date: str | None = None,
-    # --- TextCampaign.BiddingStrategy.Search (13 flags) ---
-    text_search_average_cpc: int | None = None,
-    text_search_clicks_per_week: int | None = None,
-    text_search_custom_period_auto_continue: str | None = None,
-    text_search_custom_period_end_date: str | None = None,
-    text_search_custom_period_spend_limit: int | None = None,
-    text_search_custom_period_start_date: str | None = None,
-    text_search_exploration_is_custom: str | None = None,
-    text_search_exploration_min_budget: int | None = None,
-    text_search_pay_cpa: int | None = None,
-    text_search_profitability: int | None = None,
-    text_search_reserve_return: int | None = None,
-    text_search_roi_coef: int | None = None,
-    text_search_weekly_spend_limit: int | None = None,
-    # --- TextCampaign.BiddingStrategy.Network (14 flags) ---
-    text_network_average_cpc: int | None = None,
-    text_network_clicks_per_week: int | None = None,
-    text_network_custom_period_auto_continue: str | None = None,
-    text_network_custom_period_end_date: str | None = None,
-    text_network_custom_period_spend_limit: int | None = None,
-    text_network_custom_period_start_date: str | None = None,
-    text_network_exploration_is_custom: str | None = None,
-    text_network_exploration_min_budget: int | None = None,
-    text_network_limit_percent: int | None = None,
-    text_network_pay_cpa: int | None = None,
-    text_network_profitability: int | None = None,
-    text_network_reserve_return: int | None = None,
-    text_network_roi_coef: int | None = None,
-    text_network_weekly_spend_limit: int | None = None,
-    # --- DynamicTextCampaign.BiddingStrategy.Search (17 flags) ---
-    dyn_search_average_cpa: int | None = None,
-    dyn_search_average_cpc: int | None = None,
-    dyn_search_bid_ceiling: int | None = None,
-    dyn_search_clicks_per_week: int | None = None,
-    dyn_search_cpa: int | None = None,
-    dyn_search_crr: int | None = None,
-    dyn_search_custom_period_auto_continue: str | None = None,
-    dyn_search_custom_period_end_date: str | None = None,
-    dyn_search_custom_period_spend_limit: int | None = None,
-    dyn_search_custom_period_start_date: str | None = None,
-    dyn_search_exploration_budget: int | None = None,
-    dyn_search_exploration_budget_custom: str | None = None,
-    dyn_search_goal_id: int | None = None,
-    dyn_search_profitability: int | None = None,
-    dyn_search_reserve_return: int | None = None,
-    dyn_search_roi_coef: int | None = None,
-    dyn_search_weekly_spend_limit: int | None = None,
-    # --- DynamicTextCampaign.BiddingStrategy.Network (18 flags) ---
-    dyn_network_average_cpa: int | None = None,
-    dyn_network_average_cpc: int | None = None,
-    dyn_network_bid_ceiling: int | None = None,
-    dyn_network_clicks_per_week: int | None = None,
-    dyn_network_cpa: int | None = None,
-    dyn_network_crr: int | None = None,
-    dyn_network_custom_period_auto_continue: str | None = None,
-    dyn_network_custom_period_end_date: str | None = None,
-    dyn_network_custom_period_spend_limit: int | None = None,
-    dyn_network_custom_period_start_date: str | None = None,
-    dyn_network_exploration_budget: int | None = None,
-    dyn_network_exploration_budget_custom: str | None = None,
-    dyn_network_goal_id: int | None = None,
-    dyn_network_limit_percent: int | None = None,
-    dyn_network_profitability: int | None = None,
-    dyn_network_reserve_return: int | None = None,
-    dyn_network_roi_coef: int | None = None,
-    dyn_network_weekly_spend_limit: int | None = None,
-    # --- SmartCampaign.BiddingStrategy.Search (18 flags) ---
-    smart_search_average_cpa: int | None = None,
-    smart_search_average_cpc: int | None = None,
-    smart_search_bid_ceiling: int | None = None,
-    smart_search_cp_auto_continue: str | None = None,
-    smart_search_cp_end_date: str | None = None,
-    smart_search_cp_spend_limit: int | None = None,
-    smart_search_cp_start_date: str | None = None,
-    smart_search_cpa: int | None = None,
-    smart_search_crr: int | None = None,
-    smart_search_exploration_min: int | None = None,
-    smart_search_exploration_min_custom: str | None = None,
-    smart_search_filter_average_cpa: int | None = None,
-    smart_search_filter_average_cpc: int | None = None,
-    smart_search_goal_id: int | None = None,
-    smart_search_profitability: int | None = None,
-    smart_search_reserve_return: int | None = None,
-    smart_search_roi_coef: int | None = None,
-    smart_search_weekly_spend_limit: int | None = None,
-    # --- SmartCampaign.BiddingStrategy.Network (19 flags) ---
-    smart_network_average_cpa: int | None = None,
-    smart_network_average_cpc: int | None = None,
-    smart_network_bid_ceiling: int | None = None,
-    smart_network_cp_auto_continue: str | None = None,
-    smart_network_cp_end_date: str | None = None,
-    smart_network_cp_spend_limit: int | None = None,
-    smart_network_cp_start_date: str | None = None,
-    smart_network_cpa: int | None = None,
-    smart_network_crr: int | None = None,
-    smart_network_exploration_min: int | None = None,
-    smart_network_exploration_min_custom: str | None = None,
-    smart_network_filter_average_cpa: int | None = None,
-    smart_network_filter_average_cpc: int | None = None,
-    smart_network_goal_id: int | None = None,
-    smart_network_limit_percent: int | None = None,
-    smart_network_profitability: int | None = None,
-    smart_network_reserve_return: int | None = None,
-    smart_network_roi_coef: int | None = None,
-    smart_network_weekly_spend_limit: int | None = None,
-    # --- UnifiedCampaign.BiddingStrategy.Search (11 flags) ---
-    unified_search_average_cpc: int | None = None,
-    unified_search_custom_period_auto_continue: str | None = None,
-    unified_search_custom_period_end_date: str | None = None,
-    unified_search_custom_period_spend_limit: int | None = None,
-    unified_search_custom_period_start_date: str | None = None,
-    unified_search_exploration_is_custom: str | None = None,
-    unified_search_exploration_min_budget: int | None = None,
-    unified_search_pay_cpa: int | None = None,
-    unified_search_placement_maps: str | None = None,
-    unified_search_placement_search_organization_list: str | None = None,
-    unified_search_weekly_spend_limit: int | None = None,
-    # --- UnifiedCampaign.BiddingStrategy.Network (9 flags) ---
-    unified_network_average_cpc: int | None = None,
-    unified_network_cpa: int | None = None,
-    unified_network_custom_period_auto_continue: str | None = None,
-    unified_network_custom_period_end_date: str | None = None,
-    unified_network_custom_period_spend_limit: int | None = None,
-    unified_network_custom_period_start_date: str | None = None,
-    unified_network_exploration_is_custom: str | None = None,
-    unified_network_exploration_min_budget: int | None = None,
-    unified_network_weekly_spend_limit: int | None = None,
-    # --- MobileAppCampaign.BiddingStrategy.Search (9 flags) ---
-    mobile_search_average_cpc: int | None = None,
-    mobile_search_average_cpi: int | None = None,
-    mobile_search_bid_ceiling: int | None = None,
-    mobile_search_clicks_per_week: int | None = None,
-    mobile_search_custom_period_auto_continue: str | None = None,
-    mobile_search_custom_period_end_date: str | None = None,
-    mobile_search_custom_period_spend_limit: int | None = None,
-    mobile_search_custom_period_start_date: str | None = None,
-    mobile_search_weekly_spend_limit: int | None = None,
-    # --- MobileAppCampaign.BiddingStrategy.Network (10 flags) ---
-    mobile_network_average_cpc: int | None = None,
-    mobile_network_average_cpi: int | None = None,
-    mobile_network_bid_ceiling: int | None = None,
-    mobile_network_clicks_per_week: int | None = None,
-    mobile_network_custom_period_auto_continue: str | None = None,
-    mobile_network_custom_period_end_date: str | None = None,
-    mobile_network_custom_period_spend_limit: int | None = None,
-    mobile_network_custom_period_start_date: str | None = None,
-    mobile_network_limit_percent: int | None = None,
-    mobile_network_weekly_spend_limit: int | None = None,
-    # --- update-only: switch between WEEKLY_BUDGET / CUSTOM_PERIOD_BUDGET (10 flags) ---
-    text_search_budget_type: str | None = None,
-    text_network_budget_type: str | None = None,
-    dyn_search_budget_type: str | None = None,
-    dyn_network_budget_type: str | None = None,
-    smart_search_budget_type: str | None = None,
-    smart_network_budget_type: str | None = None,
-    unified_search_budget_type: str | None = None,
-    unified_network_budget_type: str | None = None,
-    mobile_search_budget_type: str | None = None,
-    mobile_network_budget_type: str | None = None,
+    # --- Grouped bidding-strategy dicts (replace ~147 flat params) ---
+    # Keys = the original flat option names (e.g. text_search_average_cpc).
+    # update-only *_budget_type keys also go inside the matching dict.
+    text_search_options: dict | None = None,
+    text_network_options: dict | None = None,
+    dyn_search_options: dict | None = None,
+    dyn_network_options: dict | None = None,
+    smart_search_options: dict | None = None,
+    smart_network_options: dict | None = None,
+    unified_search_options: dict | None = None,
+    unified_network_options: dict | None = None,
+    mobile_search_options: dict | None = None,
+    mobile_network_options: dict | None = None,
     notification_json: str | None = None,
     time_targeting_json: str | None = None,
     dry_run: bool = False,
@@ -771,10 +705,19 @@ def campaigns_update(
         budget: Optional new daily budget in micro-units (RUB × 1_000_000).
         start_date: Optional new start date (YYYY-MM-DD).
         end_date: Optional new end date (YYYY-MM-DD).
-        text_search_budget_type / text_network_budget_type / dyn_*_budget_type /
-            smart_*_budget_type / unified_*_budget_type / mobile_*_budget_type:
-            Switch the existing strategy between WEEKLY_BUDGET and
-            CUSTOM_PERIOD_BUDGET. Update-only; not accepted by campaigns_add.
+        text_search_options / text_network_options / dyn_search_options /
+            dyn_network_options / smart_search_options / smart_network_options /
+            unified_search_options / unified_network_options /
+            mobile_search_options / mobile_network_options: Optional dicts
+            grouping the per-campaign-type bidding-strategy detail flags. Each
+            dict key is the original flat option name, e.g.
+            text_search_options={"text_search_average_cpc": 15_000_000,
+            "text_search_weekly_spend_limit": 500_000_000}. The micro-unit and
+            plain-integer rules above apply to the dict values. Unknown keys are
+            ignored. The update-only "*_budget_type" key (switch a strategy
+            between WEEKLY_BUDGET and CUSTOM_PERIOD_BUDGET) goes inside the
+            matching dict, e.g. text_search_options={"text_search_budget_type":
+            "WEEKLY_BUDGET"}; it is accepted here but ignored by campaigns_add.
         dry_run: Show the direct request without sending it.
     """
     values = locals()
@@ -792,6 +735,18 @@ def campaigns_update(
             error="missing_update_fields",
             message="Provide at least one typed campaign field to update.",
         ).__dict__
+
+    # Expand grouped strategy dicts into the flat option names append_cli_options
+    # expects. Runs after the guard (a non-empty dict already satisfies it) and
+    # before argv assembly, so the generated CLI call is byte-identical to the
+    # old flat signature.
+    expansion_error = _expand_strategy_dicts(
+        values,
+        {name: values[name] for name, _ in _STRATEGY_DICT_REGISTRY},
+        include_budget_types=True,
+    )
+    if expansion_error is not None:
+        return expansion_error.__dict__
 
     args = ["campaigns", "update", "--id", str(id)]
     if name:
@@ -916,154 +871,18 @@ def campaigns_add(
     strategy_end_date: str | None = None,
     strategy_spend_limit: int | None = None,
     strategy_start_date: str | None = None,
-    # --- TextCampaign.BiddingStrategy.Search (13 flags) ---
-    text_search_average_cpc: int | None = None,
-    text_search_clicks_per_week: int | None = None,
-    text_search_custom_period_auto_continue: str | None = None,
-    text_search_custom_period_end_date: str | None = None,
-    text_search_custom_period_spend_limit: int | None = None,
-    text_search_custom_period_start_date: str | None = None,
-    text_search_exploration_is_custom: str | None = None,
-    text_search_exploration_min_budget: int | None = None,
-    text_search_pay_cpa: int | None = None,
-    text_search_profitability: int | None = None,
-    text_search_reserve_return: int | None = None,
-    text_search_roi_coef: int | None = None,
-    text_search_weekly_spend_limit: int | None = None,
-    # --- TextCampaign.BiddingStrategy.Network (14 flags) ---
-    text_network_average_cpc: int | None = None,
-    text_network_clicks_per_week: int | None = None,
-    text_network_custom_period_auto_continue: str | None = None,
-    text_network_custom_period_end_date: str | None = None,
-    text_network_custom_period_spend_limit: int | None = None,
-    text_network_custom_period_start_date: str | None = None,
-    text_network_exploration_is_custom: str | None = None,
-    text_network_exploration_min_budget: int | None = None,
-    text_network_limit_percent: int | None = None,
-    text_network_pay_cpa: int | None = None,
-    text_network_profitability: int | None = None,
-    text_network_reserve_return: int | None = None,
-    text_network_roi_coef: int | None = None,
-    text_network_weekly_spend_limit: int | None = None,
-    # --- DynamicTextCampaign.BiddingStrategy.Search (17 flags) ---
-    dyn_search_average_cpa: int | None = None,
-    dyn_search_average_cpc: int | None = None,
-    dyn_search_bid_ceiling: int | None = None,
-    dyn_search_clicks_per_week: int | None = None,
-    dyn_search_cpa: int | None = None,
-    dyn_search_crr: int | None = None,
-    dyn_search_custom_period_auto_continue: str | None = None,
-    dyn_search_custom_period_end_date: str | None = None,
-    dyn_search_custom_period_spend_limit: int | None = None,
-    dyn_search_custom_period_start_date: str | None = None,
-    dyn_search_exploration_budget: int | None = None,
-    dyn_search_exploration_budget_custom: str | None = None,
-    dyn_search_goal_id: int | None = None,
-    dyn_search_profitability: int | None = None,
-    dyn_search_reserve_return: int | None = None,
-    dyn_search_roi_coef: int | None = None,
-    dyn_search_weekly_spend_limit: int | None = None,
-    # --- DynamicTextCampaign.BiddingStrategy.Network (18 flags) ---
-    dyn_network_average_cpa: int | None = None,
-    dyn_network_average_cpc: int | None = None,
-    dyn_network_bid_ceiling: int | None = None,
-    dyn_network_clicks_per_week: int | None = None,
-    dyn_network_cpa: int | None = None,
-    dyn_network_crr: int | None = None,
-    dyn_network_custom_period_auto_continue: str | None = None,
-    dyn_network_custom_period_end_date: str | None = None,
-    dyn_network_custom_period_spend_limit: int | None = None,
-    dyn_network_custom_period_start_date: str | None = None,
-    dyn_network_exploration_budget: int | None = None,
-    dyn_network_exploration_budget_custom: str | None = None,
-    dyn_network_goal_id: int | None = None,
-    dyn_network_limit_percent: int | None = None,
-    dyn_network_profitability: int | None = None,
-    dyn_network_reserve_return: int | None = None,
-    dyn_network_roi_coef: int | None = None,
-    dyn_network_weekly_spend_limit: int | None = None,
-    # --- SmartCampaign.BiddingStrategy.Search (18 flags) ---
-    smart_search_average_cpa: int | None = None,
-    smart_search_average_cpc: int | None = None,
-    smart_search_bid_ceiling: int | None = None,
-    smart_search_cp_auto_continue: str | None = None,
-    smart_search_cp_end_date: str | None = None,
-    smart_search_cp_spend_limit: int | None = None,
-    smart_search_cp_start_date: str | None = None,
-    smart_search_cpa: int | None = None,
-    smart_search_crr: int | None = None,
-    smart_search_exploration_min: int | None = None,
-    smart_search_exploration_min_custom: str | None = None,
-    smart_search_filter_average_cpa: int | None = None,
-    smart_search_filter_average_cpc: int | None = None,
-    smart_search_goal_id: int | None = None,
-    smart_search_profitability: int | None = None,
-    smart_search_reserve_return: int | None = None,
-    smart_search_roi_coef: int | None = None,
-    smart_search_weekly_spend_limit: int | None = None,
-    # --- SmartCampaign.BiddingStrategy.Network (19 flags) ---
-    smart_network_average_cpa: int | None = None,
-    smart_network_average_cpc: int | None = None,
-    smart_network_bid_ceiling: int | None = None,
-    smart_network_cp_auto_continue: str | None = None,
-    smart_network_cp_end_date: str | None = None,
-    smart_network_cp_spend_limit: int | None = None,
-    smart_network_cp_start_date: str | None = None,
-    smart_network_cpa: int | None = None,
-    smart_network_crr: int | None = None,
-    smart_network_exploration_min: int | None = None,
-    smart_network_exploration_min_custom: str | None = None,
-    smart_network_filter_average_cpa: int | None = None,
-    smart_network_filter_average_cpc: int | None = None,
-    smart_network_goal_id: int | None = None,
-    smart_network_limit_percent: int | None = None,
-    smart_network_profitability: int | None = None,
-    smart_network_reserve_return: int | None = None,
-    smart_network_roi_coef: int | None = None,
-    smart_network_weekly_spend_limit: int | None = None,
-    # --- UnifiedCampaign.BiddingStrategy.Search (11 flags) ---
-    unified_search_average_cpc: int | None = None,
-    unified_search_custom_period_auto_continue: str | None = None,
-    unified_search_custom_period_end_date: str | None = None,
-    unified_search_custom_period_spend_limit: int | None = None,
-    unified_search_custom_period_start_date: str | None = None,
-    unified_search_exploration_is_custom: str | None = None,
-    unified_search_exploration_min_budget: int | None = None,
-    unified_search_pay_cpa: int | None = None,
-    unified_search_placement_maps: str | None = None,
-    unified_search_placement_search_organization_list: str | None = None,
-    unified_search_weekly_spend_limit: int | None = None,
-    # --- UnifiedCampaign.BiddingStrategy.Network (9 flags) ---
-    unified_network_average_cpc: int | None = None,
-    unified_network_cpa: int | None = None,
-    unified_network_custom_period_auto_continue: str | None = None,
-    unified_network_custom_period_end_date: str | None = None,
-    unified_network_custom_period_spend_limit: int | None = None,
-    unified_network_custom_period_start_date: str | None = None,
-    unified_network_exploration_is_custom: str | None = None,
-    unified_network_exploration_min_budget: int | None = None,
-    unified_network_weekly_spend_limit: int | None = None,
-    # --- MobileAppCampaign.BiddingStrategy.Search (9 flags) ---
-    mobile_search_average_cpc: int | None = None,
-    mobile_search_average_cpi: int | None = None,
-    mobile_search_bid_ceiling: int | None = None,
-    mobile_search_clicks_per_week: int | None = None,
-    mobile_search_custom_period_auto_continue: str | None = None,
-    mobile_search_custom_period_end_date: str | None = None,
-    mobile_search_custom_period_spend_limit: int | None = None,
-    mobile_search_custom_period_start_date: str | None = None,
-    mobile_search_weekly_spend_limit: int | None = None,
-    # --- MobileAppCampaign.BiddingStrategy.Network (10 flags) ---
-    mobile_network_average_cpc: int | None = None,
-    mobile_network_average_cpi: int | None = None,
-    mobile_network_bid_ceiling: int | None = None,
-    mobile_network_clicks_per_week: int | None = None,
-    mobile_network_custom_period_auto_continue: str | None = None,
-    mobile_network_custom_period_end_date: str | None = None,
-    mobile_network_custom_period_spend_limit: int | None = None,
-    mobile_network_custom_period_start_date: str | None = None,
-    mobile_network_limit_percent: int | None = None,
-    mobile_network_weekly_spend_limit: int | None = None,
+    # --- Grouped bidding-strategy dicts (replace ~138 flat params) ---
+    # Keys = the original flat option names (e.g. text_search_average_cpc).
+    text_search_options: dict | None = None,
+    text_network_options: dict | None = None,
+    dyn_search_options: dict | None = None,
+    dyn_network_options: dict | None = None,
+    smart_search_options: dict | None = None,
+    smart_network_options: dict | None = None,
+    unified_search_options: dict | None = None,
+    unified_network_options: dict | None = None,
+    mobile_search_options: dict | None = None,
+    mobile_network_options: dict | None = None,
     notification_json: str | None = None,
     time_targeting_json: str | None = None,
     dry_run: bool = False,
@@ -1132,14 +951,17 @@ def campaigns_add(
         average_cpm / average_cpv / strategy_spend_limit / strategy_start_date /
             strategy_end_date / strategy_auto_continue: CpmBannerCampaign bidding
             strategy flags (money in micro-units).
-        text_search_* / text_network_*: TextCampaign Search/Network bidding
-            strategy detail flags (WSDL parity).
-        dyn_search_* / dyn_network_*: DynamicTextCampaign Search/Network.
-        smart_search_* / smart_network_*: SmartCampaign Search/Network
-            (per-campaign / per-filter variants — `*_filter_average_*` are
-            per-filter, others per-campaign).
-        unified_search_* / unified_network_*: UnifiedCampaign Search/Network.
-        mobile_search_* / mobile_network_*: MobileAppCampaign Search/Network.
+        text_search_options / text_network_options / dyn_search_options /
+            dyn_network_options / smart_search_options / smart_network_options /
+            unified_search_options / unified_network_options /
+            mobile_search_options / mobile_network_options: Optional dicts
+            grouping the per-campaign-type bidding-strategy detail flags (WSDL
+            parity). Each dict key is the original flat option name, e.g.
+            text_search_options={"text_search_average_cpc": 15_000_000}. The
+            micro-unit / plain-integer rules above apply to the dict values.
+            Smart `*_filter_average_*` keys are per-filter, others per-campaign.
+            Unknown keys are ignored. The update-only "*_budget_type" key is
+            not used by campaigns_add (use campaigns_update).
         search_placement_search_results / search_placement_product_gallery /
             search_placement_dynamic_places: TextCampaign / Unified /
             DynamicText Search PlacementTypes (YES/NO).
@@ -1184,6 +1006,15 @@ def campaigns_add(
         values["notification"] = notification_json
     if time_targeting is None and time_targeting_json is not None:
         values["time_targeting"] = time_targeting_json
+    # Expand grouped strategy dicts into flat option names (argv stays identical).
+    # *_budget_type keys are update-only; include_budget_types=False ignores them.
+    expansion_error = _expand_strategy_dicts(
+        values,
+        {name: values[name] for name, _ in _STRATEGY_DICT_REGISTRY},
+        include_budget_types=False,
+    )
+    if expansion_error is not None:
+        return expansion_error.__dict__
     for already_appended in (
         "search_strategy",
         "network_strategy",

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -713,11 +713,13 @@ def campaigns_update(
             dict key is the original flat option name, e.g.
             text_search_options={"text_search_average_cpc": 15_000_000,
             "text_search_weekly_spend_limit": 500_000_000}. The micro-unit and
-            plain-integer rules above apply to the dict values. Unknown keys are
-            ignored. The update-only "*_budget_type" key (switch a strategy
-            between WEEKLY_BUDGET and CUSTOM_PERIOD_BUDGET) goes inside the
-            matching dict, e.g. text_search_options={"text_search_budget_type":
-            "WEEKLY_BUDGET"}; it is accepted here but ignored by campaigns_add.
+            plain-integer rules above apply to the dict values. Unknown keys,
+            including typos, are ignored; a dict containing only unknown keys
+            emits no strategy flags. The update-only "*_budget_type" key
+            (switch a strategy between WEEKLY_BUDGET and CUSTOM_PERIOD_BUDGET)
+            goes inside the matching dict, e.g.
+            text_search_options={"text_search_budget_type": "WEEKLY_BUDGET"};
+            it is accepted here but ignored by campaigns_add.
         dry_run: Show the direct request without sending it.
     """
     values = locals()
@@ -960,8 +962,10 @@ def campaigns_add(
             text_search_options={"text_search_average_cpc": 15_000_000}. The
             micro-unit / plain-integer rules above apply to the dict values.
             Smart `*_filter_average_*` keys are per-filter, others per-campaign.
-            Unknown keys are ignored. The update-only "*_budget_type" key is
-            not used by campaigns_add (use campaigns_update).
+            Unknown keys, including typos, are ignored; a dict containing only
+            unknown keys emits no strategy flags. The update-only
+            "*_budget_type" key is not used by campaigns_add (use
+            campaigns_update).
         search_placement_search_results / search_placement_product_gallery /
             search_placement_dynamic_places: TextCampaign / Unified /
             DynamicText Search PlacementTypes (YES/NO).

--- a/server/tools/campaigns.py
+++ b/server/tools/campaigns.py
@@ -713,9 +713,11 @@ def campaigns_update(
             dict key is the original flat option name, e.g.
             text_search_options={"text_search_average_cpc": 15_000_000,
             "text_search_weekly_spend_limit": 500_000_000}. The micro-unit and
-            plain-integer rules above apply to the dict values. Unknown keys,
-            including typos, are ignored; a dict containing only unknown keys
-            emits no strategy flags. The update-only "*_budget_type" key
+            plain-integer rules above apply to the dict values. Key names must
+            exactly match the original flat option names. Unknown keys,
+            including typos, are ignored; if all keys are unknown, no strategy
+            flags are sent and the call may still return success without
+            changing bidding settings. The update-only "*_budget_type" key
             (switch a strategy between WEEKLY_BUDGET and CUSTOM_PERIOD_BUDGET)
             goes inside the matching dict, e.g.
             text_search_options={"text_search_budget_type": "WEEKLY_BUDGET"};
@@ -962,8 +964,10 @@ def campaigns_add(
             text_search_options={"text_search_average_cpc": 15_000_000}. The
             micro-unit / plain-integer rules above apply to the dict values.
             Smart `*_filter_average_*` keys are per-filter, others per-campaign.
-            Unknown keys, including typos, are ignored; a dict containing only
-            unknown keys emits no strategy flags. The update-only
+            Key names must exactly match the original flat option names.
+            Unknown keys, including typos, are ignored; if all keys are
+            unknown, no strategy flags are sent and the call may still return
+            success without changing bidding settings. The update-only
             "*_budget_type" key is not used by campaigns_add (use
             campaigns_update).
         search_placement_search_results / search_placement_product_gallery /

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -559,3 +559,111 @@ class TestCampaignsCrudOperations:
         result = campaigns_resume(ids=ids)
         assert "error" in result
         assert result["error"] == "batch_limit"
+
+
+class TestCampaignsStrategyDictExpansion:
+    """Strategy params are grouped into dicts; expansion must keep argv identical."""
+
+    def test_update_text_search_dict_argv_identical_to_old_flat(self):
+        """Dict keys expand to the same flags the old flat params produced."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_update(
+                id=12345,
+                text_search_options={
+                    "text_search_average_cpc": 15_000_000,
+                    "text_search_weekly_spend_limit": 500_000_000,
+                },
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert argv.count("--text-search-average-cpc") == 1
+        assert argv[argv.index("--text-search-average-cpc") + 1] == "15000000"
+        assert argv[argv.index("--text-search-weekly-spend-limit") + 1] == "500000000"
+        assert "text_search_options" not in argv
+
+    def test_update_search_and_network_dicts_both_expand(self):
+        """Search and network dicts for the same campaign type both expand."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_update(
+                id=12345,
+                text_search_options={"text_search_average_cpc": 10_000_000},
+                text_network_options={"text_network_average_cpc": 8_000_000},
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert argv[argv.index("--text-search-average-cpc") + 1] == "10000000"
+        assert argv[argv.index("--text-network-average-cpc") + 1] == "8000000"
+
+    def test_update_budget_type_via_dict_reaches_cli(self):
+        """The update-only *_budget_type key inside a dict reaches the CLI."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_update(
+                id=12345,
+                text_search_options={"text_search_budget_type": "WEEKLY_BUDGET"},
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert argv[argv.index("--text-search-budget-type") + 1] == "WEEKLY_BUDGET"
+
+    def test_update_empty_strategy_dict_triggers_guard(self):
+        """An empty dict does not satisfy the update guard (bool({}) is False)."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(id=12345, text_search_options={})
+        assert result["error"] == "missing_update_fields"
+        runner.run_json.assert_not_called()
+
+    def test_update_non_dict_strategy_param_rejected(self):
+        """A non-dict strategy value returns invalid_param before any CLI call."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            result = campaigns_update(id=12345, text_search_options="bad")
+        assert result["error"] == "invalid_param"
+        runner.run_json.assert_not_called()
+
+    def test_update_unknown_dict_key_silently_ignored(self):
+        """Unknown keys inside a strategy dict never reach argv."""
+        runner = mock_runner({"Id": 12345})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_update(
+                id=12345,
+                text_search_options={
+                    "text_search_average_cpc": 5_000_000,
+                    "not_a_real_option": "ignored",
+                },
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "not_a_real_option" not in argv
+        assert "--not-a-real-option" not in argv
+        assert "--text-search-average-cpc" in argv
+
+    def test_add_strategy_dict_argv_parity(self):
+        """campaigns_add expands a strategy dict to the correct flags."""
+        runner = mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                campaign_type="TEXT_CAMPAIGN",
+                search_strategy="WB_MAXIMUM_CLICKS",
+                text_search_options={"text_search_weekly_spend_limit": 100_000_000},
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert argv[argv.index("--search-strategy") + 1] == "WB_MAXIMUM_CLICKS"
+        assert argv[argv.index("--text-search-weekly-spend-limit") + 1] == "100000000"
+
+    def test_add_ignores_update_only_budget_type_in_dict(self):
+        """budget_type is update-only; campaigns_add must not emit it."""
+        runner = mock_runner({"Id": 1})
+        with patch("server.tools.campaigns.get_runner", return_value=runner):
+            campaigns_add(
+                name="c",
+                start_date="2026-01-01",
+                text_search_options={
+                    "text_search_budget_type": "WEEKLY_BUDGET",
+                    "text_search_pay_cpa": 3_000_000,
+                },
+            )
+        argv = runner.run_json.call_args[0][0]
+        assert "--text-search-budget-type" not in argv
+        assert "--text-search-pay-cpa" in argv

--- a/tests/test_direct_cli_0312_parity.py
+++ b/tests/test_direct_cli_0312_parity.py
@@ -132,9 +132,28 @@ def test_runtime_and_package_require_direct_cli_0312_or_newer() -> None:
     )
 
 
+def _campaign_strategy_dict_param_names() -> set[str]:
+    """CLI option names exposed via campaigns_* grouped strategy dicts.
+
+    campaigns_add/update collapse the ~138 per-campaign-type bidding-strategy
+    flags (and the 10 update-only *_budget_type flags) into nested dict params
+    to cut tool-spec tokens (#154). They are still 1:1 reachable — just as dict
+    keys, not flat signature params — so the parity guard treats them as exposed.
+    """
+    from server.tools.campaigns import (
+        CAMPAIGN_UPDATE_ONLY_OPTIONS,
+        _STRATEGY_DICT_REGISTRY,
+    )
+
+    names = {opt.name for _, opts in _STRATEGY_DICT_REGISTRY for opt in opts}
+    names |= {opt.name for opt in CAMPAIGN_UPDATE_ONLY_OPTIONS}
+    return names
+
+
 def test_direct_cli_0312_options_are_exposed_by_mcp_signatures() -> None:
     _require_direct_cli_0312()
 
+    strategy_dict_params = _campaign_strategy_dict_param_names()
     missing_by_command: dict[str, list[str]] = {}
     for group, subcommand, module_name, function_name in TARGET_COMMANDS:
         click_command = cli.commands[group].commands[subcommand]
@@ -145,6 +164,10 @@ def test_direct_cli_0312_options_are_exposed_by_mcp_signatures() -> None:
         ]
         fn = getattr(importlib.import_module(module_name), function_name)
         mcp_params = set(inspect.signature(fn).parameters)
+        # Strategy options moved from flat campaigns_* params into grouped dicts;
+        # they remain exposed (as dict keys), so count them as present.
+        if group == "campaigns":
+            mcp_params |= strategy_dict_params
         aliases = ALIASES.get((group, subcommand), {})
         missing = [
             name for name in cli_params if aliases.get(name, name) not in mcp_params


### PR DESCRIPTION
## Проблема (#154, второй блок)

Descriptions-часть #154 закрыта PR #155. Оставался второй блок — тяжёлая **JSON-Schema параметров** `campaigns_add`/`campaigns_update`. Это были два самых тяжёлых тула плагина: вместе **31% всего токенового бюджета спецификации**. Вес давала не docstring, а ~138 плоских `*_search_*`/`*_network_*` полей bidding-стратегии (× 7 типов кампаний) + 10 update-only `*_budget_type`: каждый `int|None`/`str|None` разворачивается FastMCP в `anyOf:[...,{"type":"null"}]`.

## Решение — группировка в dict-параметры

Свернул стратегические поля в **10 вложенных dict-параметров**: `text_search_options`, `text_network_options`, `dyn_search_options`, `dyn_network_options`, `smart_*`, `unified_*`, `mobile_*`.

- Ключи dict = исходные плоские имена опций → агент адресует каждое поле 1:1.
- Входящие dict разворачиваются обратно в эти имена **до** `append_cli_options` → генерируемый argv `direct` **байт-в-байт идентичен**. Parity с direct-cli полностью сохранён.

## Замер (tests.measure_tool_tokens, tiktoken cl100k_base)

| | До | После | Δ |
|---|---:|---:|---:|
| **Tool-spec (всего)** | 40 792 | **32 666** | **−20%** |
| `campaigns_update` | 6 427 | 2 223 | −65% |
| `campaigns_add` | 6 121 | 2 199 | −64% |

## Поведение и безопасность

- Empty-update guard работает: непустой dict удовлетворяет `provided_update_value`, пустой `{}` — нет.
- Не-dict значение → `invalid_param` (до вызова CLI).
- Неизвестные ключи в dict игнорируются (forward-compatible с новыми флагами CLI).
- `campaigns_add` игнорирует update-only `*_budget_type`.
- CLI-option parity guard (`test_direct_cli_0312_parity`) обновлён: распознаёт стратегические опции как доступные через dict-ключи, источник истины — `campaigns.py` (автосинхрон).

## Тесты

8 новых кейсов в `tests/test_campaigns.py` (argv-parity search+network, budget_type через dict, empty-guard, non-dict, unknown-key, add-parity, add игнорирует budget_type). Полный набор: **702 passed**, `ruff`/`mypy` зелёные на 109 файлах.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)